### PR TITLE
Add low_memory mode to VideoDubber

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.26.2
+
+### Added
+
+- `VideoDubber(low_memory=True)` unloads each pipeline stage's model (Whisper, Demucs, MarianMT, Chatterbox) after it runs, so only one model is resident at a time. Trades per-run latency for a lower memory ceiling. Recommended for GPUs with <=12GB VRAM or hosts with <32GB RAM. Each model class (`AudioToText`, `AudioSeparator`, `TextTranslator`, `TextToSpeech`) now exposes an `unload()` method that clears cached weights and releases CUDA/MPS allocator cache.
+
 ## 0.26.1
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.26.1"
+version = "0.26.2"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -452,3 +452,143 @@ class TestAudioSeparator:
 
         with pytest.raises(ValueError, match="not supported"):
             AudioSeparator(model_name="invalid_model")
+
+
+class TestUnloadMethods:
+    """Tests for unload() on each model class used in dubbing.
+
+    Each class must clear its cached model attributes so that the next call
+    re-initializes lazily. Used by low-memory dubbing to free VRAM between
+    pipeline stages.
+    """
+
+    def test_audio_separator_unload(self):
+        from videopython.ai.understanding.separation import AudioSeparator
+
+        separator = AudioSeparator()
+        separator._model = object()  # stand-in for a loaded model
+        separator.unload()
+        assert separator._model is None
+
+    def test_audio_separator_unload_is_idempotent(self):
+        from videopython.ai.understanding.separation import AudioSeparator
+
+        separator = AudioSeparator()
+        separator.unload()
+        separator.unload()
+        assert separator._model is None
+
+    def test_text_translator_unload(self):
+        from videopython.ai.generation.translation import TextTranslator
+
+        translator = TextTranslator()
+        translator._model = object()
+        translator._tokenizer = object()
+        translator._current_lang_pair = ("en", "es")
+        translator.unload()
+        assert translator._model is None
+        assert translator._tokenizer is None
+        assert translator._current_lang_pair is None
+
+    def test_text_to_speech_unload(self):
+        from videopython.ai.generation.audio import TextToSpeech
+
+        tts = TextToSpeech()
+        tts._model = object()
+        tts._processor = object()
+        tts._chatterbox_model = object()
+        tts.unload()
+        assert tts._model is None
+        assert tts._processor is None
+        assert tts._chatterbox_model is None
+
+    def test_audio_to_text_unload(self, monkeypatch):
+        import videopython.ai.understanding.audio as audio_mod
+
+        monkeypatch.setattr(audio_mod, "select_device", lambda _requested, mps_allowed=False: "cpu")
+
+        transcriber = audio_mod.AudioToText()
+        transcriber._model = object()
+        transcriber._diarization_pipeline = object()
+        transcriber.unload()
+        assert transcriber._model is None
+        assert transcriber._diarization_pipeline is None
+
+
+class TestLocalDubbingPipelineLowMemory:
+    """Tests for low_memory mode plumbing in LocalDubbingPipeline."""
+
+    def test_default_is_not_low_memory(self):
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+
+        pipeline = LocalDubbingPipeline()
+        assert pipeline.low_memory is False
+
+    def test_low_memory_flag_stored(self):
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+
+        pipeline = LocalDubbingPipeline(low_memory=True)
+        assert pipeline.low_memory is True
+
+    def test_maybe_unload_noop_when_low_memory_disabled(self):
+        """With low_memory=False, _maybe_unload must not call unload()."""
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+
+        pipeline = LocalDubbingPipeline(low_memory=False)
+
+        class FakeModel:
+            def __init__(self):
+                self.unload_calls = 0
+
+            def unload(self):
+                self.unload_calls += 1
+
+        fake = FakeModel()
+        pipeline._transcriber = fake
+        pipeline._maybe_unload("_transcriber")
+        assert fake.unload_calls == 0
+
+    def test_maybe_unload_calls_unload_when_enabled(self):
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+
+        pipeline = LocalDubbingPipeline(low_memory=True)
+
+        class FakeModel:
+            def __init__(self):
+                self.unload_calls = 0
+
+            def unload(self):
+                self.unload_calls += 1
+
+        fake = FakeModel()
+        pipeline._translator = fake
+        pipeline._maybe_unload("_translator")
+        assert fake.unload_calls == 1
+
+    def test_maybe_unload_noop_when_component_is_none(self):
+        """If a stage was never initialized (e.g. caller provided transcription),
+        _maybe_unload must not raise."""
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+
+        pipeline = LocalDubbingPipeline(low_memory=True)
+        assert pipeline._transcriber is None
+        pipeline._maybe_unload("_transcriber")  # should not raise
+
+
+class TestVideoDubberLowMemory:
+    """Tests for low_memory plumbing from VideoDubber to LocalDubbingPipeline."""
+
+    def test_default_low_memory_false(self):
+        from videopython.ai.dubbing import VideoDubber
+
+        dubber = VideoDubber()
+        assert dubber.low_memory is False
+
+    def test_low_memory_propagated_to_pipeline(self):
+        from videopython.ai.dubbing import VideoDubber
+
+        dubber = VideoDubber(low_memory=True)
+        assert dubber.low_memory is True
+
+        dubber._init_local_pipeline()
+        assert dubber._local_pipeline.low_memory is True

--- a/src/videopython/ai/_device.py
+++ b/src/videopython/ai/_device.py
@@ -25,6 +25,33 @@ def log_device_initialization(
     )
 
 
+def release_device_memory(device: str | None) -> None:
+    """Release cached allocator memory for the given device.
+
+    Safe to call when torch is not importable or the device is CPU/None.
+    """
+    try:
+        import torch
+    except ImportError:
+        return
+
+    import gc
+
+    gc.collect()
+
+    if device == "cuda" and torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        return
+
+    if device == "mps":
+        mps_backend = getattr(torch.backends, "mps", None)
+        if mps_backend is not None and mps_backend.is_available():
+            mps_mod = getattr(torch, "mps", None)
+            empty_cache = getattr(mps_mod, "empty_cache", None) if mps_mod is not None else None
+            if callable(empty_cache):
+                empty_cache()
+
+
 def select_device(
     device: str | None,
     *,

--- a/src/videopython/ai/dubbing/dubber.py
+++ b/src/videopython/ai/dubbing/dubber.py
@@ -14,18 +14,28 @@ logger = logging.getLogger(__name__)
 
 
 class VideoDubber:
-    """Dubs videos into different languages using the local pipeline."""
+    """Dubs videos into different languages using the local pipeline.
 
-    def __init__(self, device: str | None = None):
+    Args:
+        device: Execution device (``cpu``, ``cuda``, ``mps``, or ``None`` for auto).
+        low_memory: When True, each pipeline stage (Whisper, Demucs, MarianMT,
+            Chatterbox TTS) is unloaded from memory after it runs, so only one
+            model is resident at a time. Trades per-run latency (~10-30s of
+            extra model loads) for a much lower memory ceiling. Recommended for
+            GPUs with <=12GB VRAM or hosts with <32GB RAM. Default False.
+    """
+
+    def __init__(self, device: str | None = None, low_memory: bool = False):
         self.device = device
+        self.low_memory = low_memory
         self._local_pipeline: Any = None
         requested = device.lower() if isinstance(device, str) else "auto"
-        logger.info("VideoDubber initialized with device=%s", requested)
+        logger.info("VideoDubber initialized with device=%s low_memory=%s", requested, low_memory)
 
     def _init_local_pipeline(self) -> None:
         from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
 
-        self._local_pipeline = LocalDubbingPipeline(device=self.device)
+        self._local_pipeline = LocalDubbingPipeline(device=self.device, low_memory=self.low_memory)
 
     def dub(
         self,

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -15,12 +15,23 @@ logger = logging.getLogger(__name__)
 
 
 class LocalDubbingPipeline:
-    """Local pipeline for video dubbing."""
+    """Local pipeline for video dubbing.
 
-    def __init__(self, device: str | None = None):
+    When ``low_memory=True``, each stage's model is unloaded after it runs, so
+    only one model is resident at a time. This trades per-run latency (models
+    re-load from disk between stages) for peak memory. Recommended for GPUs
+    with <=12GB VRAM or hosts with <32GB RAM.
+    """
+
+    def __init__(self, device: str | None = None, low_memory: bool = False):
         self.device = device
+        self.low_memory = low_memory
         requested = device.lower() if isinstance(device, str) else "auto"
-        logger.info("LocalDubbingPipeline initialized with device=%s", requested)
+        logger.info(
+            "LocalDubbingPipeline initialized with device=%s low_memory=%s",
+            requested,
+            low_memory,
+        )
 
         self._transcriber: Any = None
         self._transcriber_diarization: bool | None = None
@@ -30,6 +41,23 @@ class LocalDubbingPipeline:
         self._tts_language: str | None = None
         self._separator: Any = None
         self._synchronizer: TimingSynchronizer | None = None
+
+    def _maybe_unload(self, component_name: str) -> None:
+        """Unload a stage's model when low_memory mode is enabled.
+
+        No-op when low_memory=False or the component was never initialized
+        (e.g. caller supplied a pre-computed transcription so the transcriber
+        was skipped).
+        """
+        if not self.low_memory:
+            return
+        component = getattr(self, component_name, None)
+        if component is None:
+            return
+        unload = getattr(component, "unload", None)
+        if callable(unload):
+            logger.info("low_memory: unloading %s", component_name.lstrip("_"))
+            unload()
 
     def _init_transcriber(self, enable_diarization: bool = False) -> None:
         """Initialize the transcription model."""
@@ -141,6 +169,7 @@ class LocalDubbingPipeline:
                 self._transcriber_diarization = enable_diarization
 
             transcription = self._transcriber.transcribe(source_audio)
+            self._maybe_unload("_transcriber")
 
         if not transcription.segments:
             return DubbingResult(
@@ -162,6 +191,7 @@ class LocalDubbingPipeline:
                 self._init_separator()
 
             separated_audio = self._separator.separate(source_audio)
+            self._maybe_unload("_separator")
             vocal_audio = separated_audio.vocals
 
         voice_samples: dict[str, Audio] = {}
@@ -178,6 +208,7 @@ class LocalDubbingPipeline:
             target_lang=target_lang,
             source_lang=detected_lang,
         )
+        self._maybe_unload("_translator")
 
         report_progress("Generating dubbed speech", 0.50)
         if self._tts is None or self._tts_voice_clone != voice_clone or self._tts_language != target_lang:
@@ -207,6 +238,8 @@ class LocalDubbingPipeline:
             dubbed_segments.append(dubbed_audio)
             target_durations.append(segment.duration)
             start_times.append(segment.start)
+
+        self._maybe_unload("_tts")
 
         report_progress("Synchronizing timing", 0.85)
         if self._synchronizer is None:
@@ -263,6 +296,7 @@ class LocalDubbingPipeline:
             self._transcriber_diarization = False
 
         transcription = self._transcriber.transcribe(source_audio)
+        self._maybe_unload("_transcriber")
 
         separated_audio: SeparatedAudio | None = None
         vocal_audio = source_audio
@@ -273,6 +307,7 @@ class LocalDubbingPipeline:
                 self._init_separator()
 
             separated_audio = self._separator.separate(source_audio)
+            self._maybe_unload("_separator")
             vocal_audio = separated_audio.vocals
 
         report_progress("Extracting voice sample", 0.40)
@@ -295,6 +330,7 @@ class LocalDubbingPipeline:
 
         generated_speech = self._tts.generate_audio(text, voice_sample=voice_sample)
         speech_duration = generated_speech.metadata.duration_seconds
+        self._maybe_unload("_tts")
 
         report_progress("Assembling audio", 0.85)
 

--- a/src/videopython/ai/generation/audio.py
+++ b/src/videopython/ai/generation/audio.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.base.audio import Audio, AudioMetadata
 
 
@@ -150,6 +150,16 @@ class TextToSpeech:
             return self._generate_chatterbox(text, voice_sample)
 
         return self._generate_local(text, effective_voice)
+
+    def unload(self) -> None:
+        """Release the TTS model(s) so the next generate_audio() re-initializes.
+
+        Used by low-memory dubbing to free VRAM between pipeline stages.
+        """
+        self._model = None
+        self._processor = None
+        self._chatterbox_model = None
+        release_device_memory(self.device)
 
 
 class TextToMusic:

--- a/src/videopython/ai/generation/translation.py
+++ b/src/videopython/ai/generation/translation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.ai.dubbing.models import TranslatedSegment
 from videopython.base.text.transcription import TranscriptionSegment
 
@@ -179,6 +179,16 @@ class TextTranslator:
             )
 
         return translated_segments
+
+    def unload(self) -> None:
+        """Release the translation model so the next translate() re-initializes.
+
+        Used by low-memory dubbing to free VRAM between pipeline stages.
+        """
+        self._model = None
+        self._tokenizer = None
+        self._current_lang_pair = None
+        release_device_memory(self.device)
 
     @staticmethod
     def get_supported_languages() -> dict[str, str]:

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.base.audio import Audio
 from videopython.base.description import AudioClassification, AudioEvent
 from videopython.base.text.transcription import Transcription, TranscriptionSegment, TranscriptionWord
@@ -50,6 +50,15 @@ class AudioToText:
 
         self._diarization_pipeline = Pipeline.from_pretrained(self.PYANNOTE_DIARIZATION_MODEL)
         self._diarization_pipeline.to(torch.device(self.device))
+
+    def unload(self) -> None:
+        """Release the Whisper and diarization models so the next call re-initializes.
+
+        Used by low-memory dubbing to free VRAM between pipeline stages.
+        """
+        self._model = None
+        self._diarization_pipeline = None
+        release_device_memory(self.device)
 
     def _process_transcription_result(self, transcription_result: dict) -> Transcription:
         """Process raw transcription result into a Transcription object."""

--- a/src/videopython/ai/understanding/separation.py
+++ b/src/videopython/ai/understanding/separation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.ai.dubbing.models import SeparatedAudio
 from videopython.base.audio import Audio, AudioMetadata
 
@@ -134,3 +134,11 @@ class AudioSeparator:
     def extract_background(self, audio: Audio) -> Audio:
         """Convenience method to extract only background from audio."""
         return self.separate(audio).background
+
+    def unload(self) -> None:
+        """Release the Demucs model so the next separate() re-initializes.
+
+        Used by low-memory dubbing to free VRAM between pipeline stages.
+        """
+        self._model = None
+        release_device_memory(self.device)

--- a/uv.lock
+++ b/uv.lock
@@ -5604,7 +5604,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.26.1"
+version = "0.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Unload each pipeline stage's model (Whisper, Demucs, MarianMT, Chatterbox) after it runs so only one model is resident at a time. Trades per-run latency for a lower memory ceiling. Addresses #223 for users running dubbing on 32GB RAM / 8GB VRAM hardware.

Each model class exposes unload(); the pipeline dispatches via _maybe_unload() between stages when low_memory=True.