### PR TITLE
Add dub_file audio-only path to VideoDubber

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 0.26.3
+
+### Added
+
+- `VideoDubber.dub_file(input_path, output_path, target_lang, ...)` dubs a video file on disk without loading any video frames into Python memory. Extracts audio via ffmpeg, runs the dubbing pipeline on the audio only, then muxes the dubbed audio back into the source video using ffmpeg stream-copy (no video re-encode). Peak memory is bounded by model weights and the audio track, independent of video length and resolution. Use instead of `dub_and_replace` for long or high-resolution sources.
+- `videopython.ai.dubbing.remux.replace_audio_stream(video_path, audio_path, output_path)` helper that stream-copies a video track while replacing its audio.
+
+### Changed
+
+- `LocalDubbingPipeline.process()` and `LocalDubbingPipeline.revoice()` now take a `source_audio: Audio` argument instead of `video: Video`. `VideoDubber.dub()`/`revoice()` public signatures are unchanged — they pass `video.audio` at the boundary.
+
 ## 0.26.2
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.26.2"
+version = "0.26.3"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -592,3 +592,258 @@ class TestVideoDubberLowMemory:
 
         dubber._init_local_pipeline()
         assert dubber._local_pipeline.low_memory is True
+
+
+class TestReplaceAudioStream:
+    """Tests for the ffmpeg audio-stream replacement helper."""
+
+    def test_missing_video_raises(self, tmp_path):
+        from videopython.ai.dubbing.remux import replace_audio_stream
+
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"")
+
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
+            replace_audio_stream(tmp_path / "missing.mp4", audio, tmp_path / "out.mp4")
+
+    def test_missing_audio_raises(self, tmp_path):
+        from videopython.ai.dubbing.remux import replace_audio_stream
+
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"")
+
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
+            replace_audio_stream(video, tmp_path / "missing.wav", tmp_path / "out.mp4")
+
+    def test_ffmpeg_failure_raises_remux_error(self, tmp_path, monkeypatch):
+        """Non-zero ffmpeg exit code is wrapped in RemuxError with stderr."""
+        import subprocess as sp
+
+        import videopython.ai.dubbing.remux as remux_mod
+
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"not a real video")
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"not a real wav")
+
+        class FakeResult:
+            returncode = 1
+            stderr = b"simulated ffmpeg error"
+
+        def fake_run(cmd, capture_output):
+            return FakeResult()
+
+        monkeypatch.setattr(sp, "run", fake_run)
+        monkeypatch.setattr(remux_mod.subprocess, "run", fake_run)
+
+        with pytest.raises(remux_mod.RemuxError, match="simulated ffmpeg error"):
+            remux_mod.replace_audio_stream(video, audio, tmp_path / "out.mp4")
+
+    def test_ffmpeg_command_structure(self, tmp_path, monkeypatch):
+        """ffmpeg is invoked with stream-copy video and mapped audio."""
+        import videopython.ai.dubbing.remux as remux_mod
+
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"fake")
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"fake")
+        out = tmp_path / "out.mp4"
+
+        captured: dict = {}
+
+        class FakeResult:
+            returncode = 0
+            stderr = b""
+
+        def fake_run(cmd, capture_output):
+            captured["cmd"] = cmd
+            return FakeResult()
+
+        monkeypatch.setattr(remux_mod.subprocess, "run", fake_run)
+
+        remux_mod.replace_audio_stream(video, audio, out)
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "ffmpeg"
+        assert "-c:v" in cmd and cmd[cmd.index("-c:v") + 1] == "copy"
+        assert "-map" in cmd
+        # Two -map args: video from input 0, audio from input 1
+        map_indices = [i for i, v in enumerate(cmd) if v == "-map"]
+        assert len(map_indices) == 2
+        assert cmd[map_indices[0] + 1] == "0:v:0"
+        assert cmd[map_indices[1] + 1] == "1:a:0"
+        assert "-shortest" in cmd
+        assert cmd[-1] == str(out)
+
+
+class TestVideoDubberDubFile:
+    """Tests for VideoDubber.dub_file path-based entry point."""
+
+    def test_missing_input_raises(self, tmp_path):
+        from videopython.ai.dubbing import VideoDubber
+
+        dubber = VideoDubber()
+
+        with pytest.raises(FileNotFoundError, match="Input video not found"):
+            dubber.dub_file(
+                input_path=tmp_path / "missing.mp4",
+                output_path=tmp_path / "out.mp4",
+                target_lang="es",
+            )
+
+    def test_dub_file_orchestration(self, tmp_path, sample_audio, sample_segment, monkeypatch):
+        """dub_file extracts audio, runs pipeline, saves dubbed audio, and remuxes.
+
+        Mocks Audio.from_path (to avoid ffmpeg), the pipeline (to avoid models),
+        Audio.save (to avoid encoding), and replace_audio_stream (to avoid ffmpeg).
+        Verifies the call sequence and argument wiring.
+        """
+        from pathlib import Path
+
+        import videopython.ai.dubbing.dubber as dubber_mod
+        import videopython.ai.dubbing.remux as remux_mod
+        from videopython.ai.dubbing import VideoDubber
+        from videopython.ai.dubbing.models import DubbingResult, TranslatedSegment
+        from videopython.base.audio import audio as audio_mod
+        from videopython.base.text.transcription import Transcription
+
+        input_path = tmp_path / "in.mp4"
+        input_path.write_bytes(b"fake mp4 bytes")
+        output_path = tmp_path / "out.mp4"
+
+        calls: list[tuple[str, dict]] = []
+
+        def fake_from_path(cls, file_path):
+            calls.append(("from_path", {"file_path": str(file_path)}))
+            return sample_audio
+
+        monkeypatch.setattr(audio_mod.Audio, "from_path", classmethod(fake_from_path))
+
+        translated = TranslatedSegment(
+            original_segment=sample_segment,
+            translated_text="Hola",
+            source_lang="en",
+            target_lang="es",
+        )
+        fake_result = DubbingResult(
+            dubbed_audio=sample_audio,
+            translated_segments=[translated],
+            source_transcription=Transcription(segments=[sample_segment]),
+            source_lang="en",
+            target_lang="es",
+        )
+
+        class FakePipeline:
+            low_memory = False
+
+            def process(self, **kwargs):
+                calls.append(("process", kwargs))
+                return fake_result
+
+        def fake_init(self):
+            self._local_pipeline = FakePipeline()
+
+        monkeypatch.setattr(VideoDubber, "_init_local_pipeline", fake_init)
+
+        def fake_save(self, file_path, format=None):
+            calls.append(("save", {"file_path": str(file_path)}))
+            Path(file_path).write_bytes(b"fake wav")
+
+        monkeypatch.setattr(audio_mod.Audio, "save", fake_save)
+
+        def fake_replace(video_path, audio_path, output_path, **kwargs):
+            calls.append(
+                (
+                    "replace",
+                    {
+                        "video_path": str(video_path),
+                        "audio_path": str(audio_path),
+                        "output_path": str(output_path),
+                    },
+                )
+            )
+
+        monkeypatch.setattr(remux_mod, "replace_audio_stream", fake_replace)
+        monkeypatch.setattr(dubber_mod, "tempfile", __import__("tempfile"))
+
+        dubber = VideoDubber()
+        result = dubber.dub_file(
+            input_path=input_path,
+            output_path=output_path,
+            target_lang="es",
+        )
+
+        names = [c[0] for c in calls]
+        assert names == ["from_path", "process", "save", "replace"]
+        assert calls[0][1]["file_path"] == str(input_path)
+        assert calls[1][1]["source_audio"] is sample_audio
+        assert calls[1][1]["target_lang"] == "es"
+        assert calls[3][1]["video_path"] == str(input_path)
+        assert calls[3][1]["output_path"] == str(output_path)
+        assert calls[2][1]["file_path"] == calls[3][1]["audio_path"]
+        assert result is fake_result
+
+    def test_dub_file_cleans_up_temp_audio_on_failure(self, tmp_path, sample_audio, sample_segment, monkeypatch):
+        """Temp wav is deleted even if replace_audio_stream raises."""
+        from pathlib import Path as _Path
+
+        import videopython.ai.dubbing.remux as remux_mod
+        from videopython.ai.dubbing import VideoDubber
+        from videopython.ai.dubbing.models import DubbingResult, TranslatedSegment
+        from videopython.base.audio import audio as audio_mod
+        from videopython.base.text.transcription import Transcription
+
+        input_path = tmp_path / "in.mp4"
+        input_path.write_bytes(b"fake")
+
+        temp_paths: list[_Path] = []
+
+        monkeypatch.setattr(audio_mod.Audio, "from_path", classmethod(lambda cls, p: sample_audio))
+
+        translated = TranslatedSegment(
+            original_segment=sample_segment,
+            translated_text="Hola",
+            source_lang="en",
+            target_lang="es",
+        )
+        fake_result = DubbingResult(
+            dubbed_audio=sample_audio,
+            translated_segments=[translated],
+            source_transcription=Transcription(segments=[sample_segment]),
+            source_lang="en",
+            target_lang="es",
+        )
+
+        class FakePipeline:
+            low_memory = False
+
+            def process(self, **kwargs):
+                return fake_result
+
+        def fake_init(self):
+            self._local_pipeline = FakePipeline()
+
+        monkeypatch.setattr(VideoDubber, "_init_local_pipeline", fake_init)
+
+        def fake_save(self, file_path, format=None):
+            p = _Path(file_path)
+            temp_paths.append(p)
+            p.write_bytes(b"fake wav")
+
+        monkeypatch.setattr(audio_mod.Audio, "save", fake_save)
+
+        def failing_replace(**kwargs):
+            raise remux_mod.RemuxError("boom")
+
+        monkeypatch.setattr(remux_mod, "replace_audio_stream", failing_replace)
+
+        dubber = VideoDubber()
+        with pytest.raises(remux_mod.RemuxError, match="boom"):
+            dubber.dub_file(
+                input_path=input_path,
+                output_path=tmp_path / "out.mp4",
+                target_lang="es",
+            )
+
+        assert len(temp_paths) == 1
+        assert not temp_paths[0].exists()

--- a/src/videopython/ai/dubbing/dubber.py
+++ b/src/videopython/ai/dubbing/dubber.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from videopython.ai.dubbing.models import DubbingResult, RevoiceResult
@@ -60,7 +62,7 @@ class VideoDubber:
             self._init_local_pipeline()
 
         return self._local_pipeline.process(
-            video=video,
+            source_audio=video.audio,
             target_lang=target_lang,
             source_lang=source_lang,
             preserve_background=preserve_background,
@@ -99,6 +101,84 @@ class VideoDubber:
         )
         return video.add_audio(result.dubbed_audio, overlay=False)
 
+    def dub_file(
+        self,
+        input_path: str | Path,
+        output_path: str | Path,
+        target_lang: str,
+        source_lang: str | None = None,
+        preserve_background: bool = True,
+        voice_clone: bool = True,
+        enable_diarization: bool = False,
+        progress_callback: Callable[[str, float], None] | None = None,
+        transcription: Any = None,
+    ) -> DubbingResult:
+        """Dub a video file in place on disk without loading video frames into memory.
+
+        Extracts the audio track via ffmpeg, runs the dubbing pipeline on the
+        audio only, then muxes the dubbed audio back into the source video
+        using ffmpeg stream-copy (no video re-encode). Peak memory is bounded
+        by model weights and the audio track — independent of video length and
+        resolution.
+
+        Use this instead of ``dub_and_replace`` when the source video is long
+        or high-resolution and you don't need frame-level access in Python.
+
+        Args:
+            input_path: Path to the source video file.
+            output_path: Path to write the dubbed video. Overwritten if it exists.
+            target_lang: Target language code (e.g. ``"es"``, ``"fr"``).
+            source_lang: Source language code, or ``None`` to auto-detect.
+            preserve_background: Preserve background music/effects via source separation.
+            voice_clone: Clone the source speaker's voice for the dubbed track.
+            enable_diarization: Enable speaker diarization for per-speaker voice cloning.
+            progress_callback: Optional callback ``(stage: str, progress: float) -> None``.
+            transcription: Optional pre-computed ``Transcription`` to skip the Whisper step.
+
+        Returns:
+            ``DubbingResult`` with the dubbed audio, translated segments, and
+            source transcription. The output video is written to ``output_path``.
+        """
+        from videopython.ai.dubbing.remux import replace_audio_stream
+        from videopython.base.audio import Audio
+
+        input_path = Path(input_path)
+        output_path = Path(output_path)
+
+        if not input_path.exists():
+            raise FileNotFoundError(f"Input video not found: {input_path}")
+
+        logger.info("dub_file: loading audio from %s", input_path)
+        source_audio = Audio.from_path(input_path)
+
+        if self._local_pipeline is None:
+            self._init_local_pipeline()
+
+        result = self._local_pipeline.process(
+            source_audio=source_audio,
+            target_lang=target_lang,
+            source_lang=source_lang,
+            preserve_background=preserve_background,
+            voice_clone=voice_clone,
+            enable_diarization=enable_diarization,
+            progress_callback=progress_callback,
+            transcription=transcription,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            dubbed_audio_path = Path(tmp.name)
+        try:
+            result.dubbed_audio.save(dubbed_audio_path)
+            replace_audio_stream(
+                video_path=input_path,
+                audio_path=dubbed_audio_path,
+                output_path=output_path,
+            )
+        finally:
+            dubbed_audio_path.unlink(missing_ok=True)
+
+        return result
+
     def revoice(
         self,
         video: Video,
@@ -111,7 +191,7 @@ class VideoDubber:
             self._init_local_pipeline()
 
         return self._local_pipeline.revoice(
-            video=video,
+            source_audio=video.audio,
             text=text,
             preserve_background=preserve_background,
             progress_callback=progress_callback,

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -9,7 +9,7 @@ from videopython.ai.dubbing.models import DubbingResult, RevoiceResult, Separate
 from videopython.ai.dubbing.timing import TimingSynchronizer
 
 if TYPE_CHECKING:
-    from videopython.base.video import Video
+    from videopython.base.audio import Audio
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,6 @@ class LocalDubbingPipeline:
         max_duration: float = 10.0,
     ) -> dict[str, Any]:
         """Extract voice samples for each speaker from the audio."""
-        from videopython.base.audio import Audio
 
         voice_samples: dict[str, Audio] = {}
 
@@ -135,7 +134,7 @@ class LocalDubbingPipeline:
 
     def process(
         self,
-        video: Video,
+        source_audio: Audio,
         target_lang: str,
         source_lang: str | None = None,
         preserve_background: bool = True,
@@ -144,21 +143,21 @@ class LocalDubbingPipeline:
         progress_callback: Callable[[str, float], None] | None = None,
         transcription: Any | None = None,
     ) -> DubbingResult:
-        """Process a video through the local dubbing pipeline.
+        """Run the dubbing pipeline against the given source audio.
 
         Args:
+            source_audio: Source audio track to dub. Callers with a ``Video``
+                object should pass ``video.audio``; callers with only a file path
+                can use ``Audio.from_path(path)`` to avoid loading video frames.
             transcription: Optional pre-computed Transcription object. When provided,
                 the internal Whisper transcription step is skipped (saving time and VRAM).
                 Must be a ``videopython.base.text.transcription.Transcription`` instance
                 with populated ``segments``.
         """
-        from videopython.base.audio import Audio
 
         def report_progress(stage: str, progress: float) -> None:
             if progress_callback:
                 progress_callback(stage, progress)
-
-        source_audio = video.audio
 
         if transcription is not None:
             report_progress("Using provided transcription", 0.05)
@@ -275,19 +274,23 @@ class LocalDubbingPipeline:
 
     def revoice(
         self,
-        video: Video,
+        source_audio: Audio,
         text: str,
         preserve_background: bool = True,
         progress_callback: Callable[[str, float], None] | None = None,
     ) -> RevoiceResult:
-        """Replace speech in a video with new text using voice cloning."""
+        """Replace speech in audio with new text using voice cloning.
+
+        Args:
+            source_audio: Source audio track to revoice. Callers with a ``Video``
+                object should pass ``video.audio``.
+        """
         from videopython.base.audio import Audio
 
         def report_progress(stage: str, progress: float) -> None:
             if progress_callback:
                 progress_callback(stage, progress)
 
-        source_audio = video.audio
         original_duration = source_audio.metadata.duration_seconds
 
         report_progress("Analyzing audio", 0.05)

--- a/src/videopython/ai/dubbing/remux.py
+++ b/src/videopython/ai/dubbing/remux.py
@@ -1,0 +1,73 @@
+"""ffmpeg helper for replacing a video file's audio track without re-encoding video."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class RemuxError(RuntimeError):
+    """ffmpeg failed while replacing an audio stream."""
+
+
+def replace_audio_stream(
+    video_path: str | Path,
+    audio_path: str | Path,
+    output_path: str | Path,
+    audio_codec: str = "aac",
+    audio_bitrate: str = "192k",
+) -> None:
+    """Copy ``video_path``'s video stream and mux in ``audio_path`` as the audio track.
+
+    Uses ffmpeg stream-copy for video (no re-encode) and encodes audio to AAC.
+    ``-shortest`` trims to the shorter of the two streams so the output duration
+    matches the source video when the dubbed audio is slightly longer.
+
+    Args:
+        video_path: Source video file (video stream is copied unchanged).
+        audio_path: Audio file to use as the new audio track.
+        output_path: Destination file. Overwritten if it exists.
+        audio_codec: ffmpeg audio codec name. Defaults to ``aac`` (MP4-compatible).
+        audio_bitrate: Audio bitrate passed to ffmpeg (``-b:a``).
+
+    Raises:
+        FileNotFoundError: If ``video_path`` or ``audio_path`` does not exist.
+        RemuxError: If ffmpeg returns a non-zero exit code.
+    """
+    video_path = Path(video_path)
+    audio_path = Path(audio_path)
+    output_path = Path(output_path)
+
+    if not video_path.exists():
+        raise FileNotFoundError(f"Video file not found: {video_path}")
+    if not audio_path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video_path),
+        "-i",
+        str(audio_path),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "copy",
+        "-c:a",
+        audio_codec,
+        "-b:a",
+        audio_bitrate,
+        "-shortest",
+        str(output_path),
+    ]
+
+    logger.info("replace_audio_stream: %s + %s -> %s", video_path, audio_path, output_path)
+    result = subprocess.run(cmd, capture_output=True)
+    if result.returncode != 0:
+        raise RemuxError(f"ffmpeg failed (exit {result.returncode}): {result.stderr.decode(errors='replace')}")

--- a/uv.lock
+++ b/uv.lock
@@ -5604,7 +5604,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
VideoDubber.dub_file(input_path, output_path, target_lang, ...) dubs a video file on disk without loading video frames into memory. Extracts audio via ffmpeg, runs the existing dubbing pipeline on the audio, and muxes the dubbed audio back into the source video using ffmpeg stream-copy (no video re-encode). Peak memory is bounded by model weights and the audio track, independent of video length and resolution. Addresses #223 for long/high-res sources.

Refactored LocalDubbingPipeline.process/revoice to take source_audio: Audio directly; VideoDubber.dub/revoice pass video.audio at the boundary (public API unchanged).

Added src/videopython/ai/dubbing/remux.py with replace_audio_stream() ffmpeg helper.