### PR TITLE
Skip empty translations, gate Demucs to speech, peak-match dubbed output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 0.26.8
+
+### Changed
+
+- `TextTranslator.translate_segments` now skips empty and punctuation-only segments (text with fewer than 2 alphanumeric characters) instead of sending them to MarianMT. Whisper routinely emits `" ."`, `"..."`, `"?"`, and single-token segments which the model could hallucinate full sentences from — those hallucinations were then TTS'd into the dubbed track. Skipped segments produce `TranslatedSegment(translated_text="")` so timing/speaker metadata stays parallel to the input list. The pipeline TTS loop also skips empty translated text.
+- `LocalDubbingPipeline` now gates Demucs to the speech-bearing portion of the audio. Speech regions are derived from the transcription, merged, and padded by 0.5s for context. Non-speech gaps pass through as background unchanged. On talk-heavy sources with silence/music gaps this roughly halves separation time. When speech covers ≥90% of the track, falls back to full-track separation (the slicing+stitching overhead would exceed the savings on near-continuous speech).
+- Final dubbed audio is now peak-matched against the source audio so the dub doesn't land quieter than the original. Demucs background normalization and the timing-assembler peak guard each clamp at 1.0 instead of restoring headroom; without this match the dubbed mix consistently came out perceptually thinner. Applied to both `process()` (full dub) and `revoice()`.
+
+### Added
+
+- `AudioSeparator.separate_regions(audio, regions, full_separation_threshold=0.9)` — separates only the given `(start, end)` regions and passes through the rest as background. Used internally by the dubbing pipeline; available for callers that want region-gated source separation directly.
+
 ## 0.26.7
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.26.7"
+version = "0.26.8"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -460,6 +460,64 @@ class TestTextTranslator:
         assert hasattr(translator, "translate_segments")
         assert callable(translator.translate_segments)
 
+    def test_is_translatable_text_filters_punctuation_and_short_text(self):
+        """Filter accepts real text and rejects empty/punctuation/single-char Whisper noise."""
+        from videopython.ai.generation.translation import _is_translatable_text
+
+        assert _is_translatable_text("Hello world") is True
+        assert _is_translatable_text("Hi") is True
+        assert _is_translatable_text("¡Sí!") is True
+
+        assert _is_translatable_text("") is False
+        assert _is_translatable_text(" ") is False
+        assert _is_translatable_text(" .") is False
+        assert _is_translatable_text("...") is False
+        assert _is_translatable_text("?") is False
+        assert _is_translatable_text("♪") is False
+        # Single-letter Whisper segment — too short to be reliable signal.
+        assert _is_translatable_text("a") is False
+        assert _is_translatable_text(" a ") is False
+
+    def test_translate_segments_skips_punctuation_segments(self, monkeypatch):
+        """Punctuation-only segments get translated_text="" without hitting the model."""
+        from videopython.ai.generation.translation import TextTranslator
+
+        translator = TextTranslator()
+
+        translate_calls: list[list[str]] = []
+
+        def fake_translate_batch(self, texts, target_lang, source_lang=None):
+            translate_calls.append(list(texts))
+            return [f"[{t}]" for t in texts]
+
+        monkeypatch.setattr(TextTranslator, "translate_batch", fake_translate_batch)
+
+        words_real = [TranscriptionWord(start=0.0, end=1.0, word="hello")]
+        words_dot = [TranscriptionWord(start=1.0, end=2.0, word=".")]
+        segments = [
+            TranscriptionSegment(start=0.0, end=1.0, text="hello there", words=words_real),
+            TranscriptionSegment(start=1.0, end=2.0, text=" .", words=words_dot),
+            TranscriptionSegment(start=2.0, end=3.0, text="...", words=words_dot),
+            TranscriptionSegment(start=3.0, end=4.0, text="how are you", words=words_real),
+        ]
+
+        result = translator.translate_segments(segments, target_lang="es", source_lang="en")
+
+        # Only the two real segments are sent to the model.
+        assert len(translate_calls) == 1
+        assert translate_calls[0] == ["hello there", "how are you"]
+
+        # Output preserves all four segments, with empty text for the filtered ones.
+        assert len(result) == 4
+        assert result[0].translated_text == "[hello there]"
+        assert result[1].translated_text == ""
+        assert result[2].translated_text == ""
+        assert result[3].translated_text == "[how are you]"
+
+        # Timing/speaker fields preserved on the skipped segments.
+        assert result[1].start == 1.0
+        assert result[1].end == 2.0
+
 
 class TestAudioSeparator:
     """Tests for AudioSeparator class."""
@@ -486,6 +544,227 @@ class TestAudioSeparator:
 
         with pytest.raises(ValueError, match="not supported"):
             AudioSeparator(model_name="invalid_model")
+
+
+class TestMergeRegions:
+    """Tests for the _merge_regions helper that prepares speech regions for Demucs."""
+
+    def test_empty_returns_empty(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        assert _merge_regions([], audio_duration=10.0) == []
+
+    def test_single_region_is_padded_and_clamped(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        out = _merge_regions([(2.0, 4.0)], audio_duration=10.0, pad=0.5)
+        assert out == [(1.5, 4.5)]
+
+    def test_pad_clamps_to_audio_bounds(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        out = _merge_regions([(0.1, 9.8)], audio_duration=10.0, pad=0.5)
+        # left clamped to 0.0; right clamped to 10.0
+        assert out == [(0.0, 10.0)]
+
+    def test_overlapping_regions_merge(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        out = _merge_regions([(0.0, 3.0), (2.0, 5.0)], audio_duration=10.0, pad=0.0)
+        assert out == [(0.0, 5.0)]
+
+    def test_close_regions_merge_within_gap(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        # gaps of 0.8s after padding are merged (default merge_gap=1.0)
+        out = _merge_regions([(0.0, 2.0), (2.8, 5.0)], audio_duration=10.0, pad=0.0, merge_gap=1.0)
+        assert out == [(0.0, 5.0)]
+
+    def test_distant_regions_stay_separate(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        out = _merge_regions([(0.0, 2.0), (8.0, 10.0)], audio_duration=10.0, pad=0.0)
+        assert out == [(0.0, 2.0), (8.0, 10.0)]
+
+    def test_unsorted_input_is_handled(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        out = _merge_regions([(8.0, 9.0), (1.0, 2.0)], audio_duration=10.0, pad=0.0)
+        assert out == [(1.0, 2.0), (8.0, 9.0)]
+
+    def test_zero_length_regions_dropped(self):
+        from videopython.ai.understanding.separation import _merge_regions
+
+        out = _merge_regions([(2.0, 2.0), (3.0, 4.0)], audio_duration=10.0, pad=0.0)
+        assert out == [(3.0, 4.0)]
+
+
+class TestSeparateRegions:
+    """Tests for AudioSeparator.separate_regions."""
+
+    @pytest.fixture
+    def long_stereo_audio(self):
+        """A 10-second, 24 kHz stereo audio. Distinct values per second so we
+        can verify which regions were touched by the fake separator."""
+        sample_rate = 24000
+        duration = 10.0
+        frame_count = int(sample_rate * duration)
+        # Per-second tag in left channel, ramp in right.
+        left = np.repeat(np.arange(10, dtype=np.float32) * 0.05, sample_rate)[:frame_count]
+        right = np.linspace(-0.5, 0.5, frame_count, dtype=np.float32)
+        data = np.column_stack([left, right])
+        metadata = AudioMetadata(
+            sample_rate=sample_rate,
+            channels=2,
+            sample_width=2,
+            duration_seconds=duration,
+            frame_count=frame_count,
+        )
+        return Audio(data, metadata)
+
+    def test_no_regions_returns_passthrough(self, long_stereo_audio, monkeypatch):
+        """No speech regions => silent vocals, original as background. No Demucs call."""
+        from videopython.ai.dubbing.models import SeparatedAudio
+        from videopython.ai.understanding.separation import AudioSeparator
+
+        separator = AudioSeparator()
+
+        def fail_if_called(self, audio):
+            raise AssertionError("Demucs should not run when there are no regions")
+
+        monkeypatch.setattr(AudioSeparator, "_separate_local", fail_if_called)
+
+        result = separator.separate_regions(long_stereo_audio, regions=[])
+
+        assert isinstance(result, SeparatedAudio)
+        assert result.vocals.metadata.duration_seconds == long_stereo_audio.metadata.duration_seconds
+        assert np.allclose(result.vocals.data, 0.0)
+        # Background is the original audio, untouched.
+        assert np.array_equal(result.background.data, long_stereo_audio.data)
+
+    def test_full_coverage_falls_back_to_full_separation(self, long_stereo_audio, monkeypatch):
+        """When regions cover >= threshold of audio, full-track separate() is called."""
+        from videopython.ai.understanding.separation import AudioSeparator
+
+        separator = AudioSeparator()
+        sentinel_calls: list[float] = []
+
+        def fake_separate_local(self, audio):
+            sentinel_calls.append(audio.metadata.duration_seconds)
+            silent = np.zeros_like(audio.data, dtype=np.float32)
+            return SeparatedAudio(
+                vocals=Audio(silent, audio.metadata),
+                background=Audio(audio.data.astype(np.float32), audio.metadata),
+                original=audio,
+                music=None,
+                effects=None,
+            )
+
+        monkeypatch.setattr(AudioSeparator, "_separate_local", fake_separate_local)
+
+        # Regions cover 9.5/10s = 95%, above 0.9 threshold => one full-track call.
+        regions = [(0.0, 9.5)]
+        separator.separate_regions(long_stereo_audio, regions, full_separation_threshold=0.9)
+
+        assert len(sentinel_calls) == 1
+        assert sentinel_calls[0] == long_stereo_audio.metadata.duration_seconds
+
+    def test_partial_coverage_runs_per_region(self, long_stereo_audio, monkeypatch):
+        """Partial speech => Demucs runs once per region; non-speech gaps stay original."""
+        from videopython.ai.understanding.separation import AudioSeparator
+
+        separator = AudioSeparator()
+        chunk_durations: list[float] = []
+
+        def fake_separate_local(self, audio):
+            chunk_durations.append(audio.metadata.duration_seconds)
+            # "Separated" chunk: vocals = constant 0.7, background = -0.3
+            n = len(audio.data)
+            vocals = np.full((n, 2), 0.7, dtype=np.float32)
+            bg = np.full((n, 2), -0.3, dtype=np.float32)
+            return SeparatedAudio(
+                vocals=Audio(vocals, audio.metadata),
+                background=Audio(bg, audio.metadata),
+                original=audio,
+                music=None,
+                effects=None,
+            )
+
+        monkeypatch.setattr(AudioSeparator, "_separate_local", fake_separate_local)
+
+        # Two distant regions, padded inside _merge_regions before this call;
+        # we pass pre-merged regions directly.
+        regions = [(1.0, 2.0), (6.0, 7.0)]
+        result = separator.separate_regions(long_stereo_audio, regions, full_separation_threshold=0.9)
+
+        # Two Demucs calls, one per region.
+        assert len(chunk_durations) == 2
+        for d in chunk_durations:
+            assert abs(d - 1.0) < 0.01
+
+        sr = long_stereo_audio.metadata.sample_rate
+        # Vocals: zero outside regions, 0.7 inside.
+        assert np.allclose(result.vocals.data[: int(1.0 * sr)], 0.0)
+        assert np.allclose(result.vocals.data[int(1.0 * sr) : int(2.0 * sr)], 0.7)
+        assert np.allclose(result.vocals.data[int(2.0 * sr) : int(6.0 * sr)], 0.0)
+        assert np.allclose(result.vocals.data[int(6.0 * sr) : int(7.0 * sr)], 0.7)
+        assert np.allclose(result.vocals.data[int(7.0 * sr) :], 0.0)
+
+        # Background: original audio in gaps, -0.3 inside the regions.
+        assert np.array_equal(
+            result.background.data[: int(1.0 * sr)],
+            long_stereo_audio.data[: int(1.0 * sr)],
+        )
+        assert np.allclose(result.background.data[int(1.0 * sr) : int(2.0 * sr)], -0.3)
+        assert np.array_equal(
+            result.background.data[int(2.0 * sr) : int(6.0 * sr)],
+            long_stereo_audio.data[int(2.0 * sr) : int(6.0 * sr)],
+        )
+        assert np.allclose(result.background.data[int(6.0 * sr) : int(7.0 * sr)], -0.3)
+
+    def test_mono_input_produces_stereo_output(self, monkeypatch):
+        """Mono input is upmixed; output matches full-track contract (always stereo)."""
+        from videopython.ai.understanding.separation import AudioSeparator
+
+        sample_rate = 24000
+        duration = 4.0
+        frame_count = int(sample_rate * duration)
+        data = np.full(frame_count, 0.2, dtype=np.float32)
+        metadata = AudioMetadata(
+            sample_rate=sample_rate,
+            channels=1,
+            sample_width=2,
+            duration_seconds=duration,
+            frame_count=frame_count,
+        )
+        mono = Audio(data, metadata)
+
+        def fake_separate_local(self, audio):
+            # Real _separate_local always returns stereo regardless of input.
+            n = audio.metadata.frame_count
+            zeros = np.zeros((n, 2), dtype=np.float32)
+            stereo_meta = AudioMetadata(
+                sample_rate=audio.metadata.sample_rate,
+                channels=2,
+                sample_width=audio.metadata.sample_width,
+                duration_seconds=audio.metadata.duration_seconds,
+                frame_count=n,
+            )
+            return SeparatedAudio(
+                vocals=Audio(zeros, stereo_meta),
+                background=Audio(zeros.copy(), stereo_meta),
+                original=audio,
+                music=None,
+                effects=None,
+            )
+
+        monkeypatch.setattr(AudioSeparator, "_separate_local", fake_separate_local)
+
+        separator = AudioSeparator()
+        result = separator.separate_regions(mono, regions=[(1.0, 2.0)], full_separation_threshold=0.9)
+
+        assert result.vocals.metadata.channels == 2
+        assert result.background.metadata.channels == 2
 
 
 class TestUnloadMethods:
@@ -1485,3 +1764,249 @@ class TestVideoDubberDubFile:
                 output_path=tmp_path / "out.mp4",
                 target_lang="es",
             )
+
+
+class TestPeakMatch:
+    """Tests for the _peak_match helper used to align dubbed loudness to source."""
+
+    def _make_audio(self, peak: float, duration: float = 1.0, sample_rate: int = 24000) -> Audio:
+        frame_count = int(duration * sample_rate)
+        data = np.full(frame_count, peak, dtype=np.float32)
+        metadata = AudioMetadata(
+            sample_rate=sample_rate,
+            channels=1,
+            sample_width=2,
+            duration_seconds=duration,
+            frame_count=frame_count,
+        )
+        return Audio(data, metadata)
+
+    def test_scales_to_match_reference_peak(self):
+        from videopython.ai.dubbing.pipeline import _peak_match
+
+        target = self._make_audio(0.3)
+        reference = self._make_audio(0.9)
+
+        out = _peak_match(target, reference)
+
+        assert abs(float(np.max(np.abs(out.data))) - 0.9) < 1e-5
+        # Original target buffer must not be mutated.
+        assert abs(float(np.max(np.abs(target.data))) - 0.3) < 1e-5
+
+    def test_silent_target_is_returned_as_is(self):
+        from videopython.ai.dubbing.pipeline import _peak_match
+
+        target = self._make_audio(0.0)
+        reference = self._make_audio(0.5)
+
+        out = _peak_match(target, reference)
+        assert out is target
+
+    def test_silent_reference_is_no_op(self):
+        from videopython.ai.dubbing.pipeline import _peak_match
+
+        target = self._make_audio(0.4)
+        reference = self._make_audio(0.0)
+
+        out = _peak_match(target, reference)
+        assert out is target
+
+    def test_near_unit_scale_is_no_op(self):
+        """Tiny scale factors skip allocation — keeps the common 'already matched' path cheap."""
+        from videopython.ai.dubbing.pipeline import _peak_match
+
+        target = self._make_audio(0.5001)
+        reference = self._make_audio(0.5)
+
+        out = _peak_match(target, reference)
+        assert out is target
+
+
+class TestPipelineSpeechRegionGating:
+    """Pipeline calls separate_regions with merged transcription regions, not separate()."""
+
+    def test_separate_regions_called_with_transcription_segments(self, sample_audio, monkeypatch):
+        """Pipeline derives speech regions from transcription and forwards to separate_regions."""
+        from videopython.ai.dubbing.models import SeparatedAudio
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.understanding.separation import AudioSeparator
+        from videopython.base.text.transcription import Transcription, TranscriptionSegment, TranscriptionWord
+
+        captured: dict = {}
+
+        def fake_separate_regions(self, audio, regions, **kwargs):
+            captured["regions"] = list(regions)
+            silent = np.zeros_like(audio.data, dtype=np.float32)
+            stereo_meta = AudioMetadata(
+                sample_rate=audio.metadata.sample_rate,
+                channels=audio.metadata.channels,
+                sample_width=audio.metadata.sample_width,
+                duration_seconds=audio.metadata.duration_seconds,
+                frame_count=audio.metadata.frame_count,
+            )
+            return SeparatedAudio(
+                vocals=Audio(silent, stereo_meta),
+                background=Audio(audio.data.astype(np.float32), stereo_meta),
+                original=audio,
+                music=None,
+                effects=None,
+            )
+
+        def fail_separate(self, audio):
+            raise AssertionError("separate() should not be called when transcription is available")
+
+        monkeypatch.setattr(AudioSeparator, "separate_regions", fake_separate_regions)
+        monkeypatch.setattr(AudioSeparator, "separate", fail_separate)
+        monkeypatch.setattr(
+            LocalDubbingPipeline,
+            "_init_separator",
+            lambda self: setattr(self, "_separator", AudioSeparator()),
+        )
+
+        # Translator and TTS as fakes so we don't touch real models.
+        def fake_init_translator(self):
+            class FakeTranslator:
+                def translate_segments(self, segments, target_lang, source_lang):
+                    return [
+                        TranslatedSegment(
+                            original_segment=s,
+                            translated_text=s.text,
+                            source_lang=source_lang,
+                            target_lang=target_lang,
+                        )
+                        for s in segments
+                    ]
+
+            self._translator = FakeTranslator()
+
+        def fake_init_tts(self, language="en"):
+            class FakeTTS:
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                    sr = 24000
+                    n = int(sr * 0.2)
+                    data = np.zeros(n, dtype=np.float32)
+                    return Audio(
+                        data,
+                        AudioMetadata(
+                            sample_rate=sr,
+                            channels=1,
+                            sample_width=2,
+                            duration_seconds=0.2,
+                            frame_count=n,
+                        ),
+                    )
+
+            self._tts = FakeTTS()
+
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_translator", fake_init_translator)
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_tts", fake_init_tts)
+
+        # Two distant speech segments inside a 10s source.
+        words = [TranscriptionWord(start=1.0, end=2.0, word="hello there")]
+        words2 = [TranscriptionWord(start=7.0, end=8.0, word="goodbye now")]
+        segs = [
+            TranscriptionSegment(start=1.0, end=2.0, text="hello there", words=words),
+            TranscriptionSegment(start=7.0, end=8.0, text="goodbye now", words=words2),
+        ]
+        transcription = Transcription(segments=segs, language="en")
+
+        # Build a 10-second source audio so segment timings fall inside it.
+        sr = 24000
+        long_data = np.zeros(int(10 * sr), dtype=np.float32)
+        long_audio = Audio(
+            long_data,
+            AudioMetadata(
+                sample_rate=sr,
+                channels=1,
+                sample_width=2,
+                duration_seconds=10.0,
+                frame_count=len(long_data),
+            ),
+        )
+
+        pipeline = LocalDubbingPipeline()
+        pipeline.process(
+            source_audio=long_audio,
+            target_lang="es",
+            preserve_background=True,
+            voice_clone=False,
+            enable_diarization=False,
+            transcription=transcription,
+        )
+
+        # Default _merge_regions: pad=0.5, merge_gap=1.0. The two regions are
+        # 5s apart so they don't merge; each is padded by 0.5 on each side.
+        assert captured["regions"] == [(0.5, 2.5), (6.5, 8.5)]
+
+
+class TestPipelineEmptyTranslationSkipped:
+    """Pipeline skips TTS for empty/punctuation-translated segments."""
+
+    def test_empty_translated_text_is_not_tts_called(self, sample_audio, monkeypatch):
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.base.text.transcription import Transcription, TranscriptionSegment, TranscriptionWord
+
+        tts_calls: list[str] = []
+
+        def fake_init_translator(self):
+            class FakeTranslator:
+                def translate_segments(self, segments, target_lang, source_lang):
+                    # Mimic the real filter: punctuation-only -> "".
+                    out = []
+                    for s in segments:
+                        text = s.text
+                        translated = "[X]" if any(c.isalnum() for c in text) and len(text.strip()) >= 2 else ""
+                        out.append(
+                            TranslatedSegment(
+                                original_segment=s,
+                                translated_text=translated,
+                                source_lang=source_lang,
+                                target_lang=target_lang,
+                            )
+                        )
+                    return out
+
+            self._translator = FakeTranslator()
+
+        def fake_init_tts(self, language="en"):
+            class FakeTTS:
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                    tts_calls.append(text)
+                    sr = 24000
+                    n = int(sr * 0.2)
+                    return Audio(
+                        np.zeros(n, dtype=np.float32),
+                        AudioMetadata(
+                            sample_rate=sr,
+                            channels=1,
+                            sample_width=2,
+                            duration_seconds=0.2,
+                            frame_count=n,
+                        ),
+                    )
+
+            self._tts = FakeTTS()
+
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_translator", fake_init_translator)
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_tts", fake_init_tts)
+
+        words = [TranscriptionWord(start=0.0, end=1.0, word="hello")]
+        segs = [
+            TranscriptionSegment(start=0.0, end=1.0, text="hello there", words=words),
+            TranscriptionSegment(start=1.0, end=2.0, text=" .", words=words),
+            TranscriptionSegment(start=2.0, end=3.0, text="how are you", words=words),
+        ]
+        transcription = Transcription(segments=segs, language="en")
+
+        pipeline = LocalDubbingPipeline()
+        pipeline.process(
+            source_audio=sample_audio,
+            target_lang="es",
+            preserve_background=False,
+            voice_clone=False,
+            enable_diarization=False,
+            transcription=transcription,
+        )
+
+        # Only two TTS calls; the punctuation-only segment was skipped.
+        assert tts_calls == ["[X]", "[X]"]

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -7,11 +7,40 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
+import numpy as np
+
 from videopython.ai.dubbing.models import DubbingResult, RevoiceResult, SeparatedAudio
 from videopython.ai.dubbing.timing import TimingSynchronizer
 
 if TYPE_CHECKING:
     from videopython.base.audio import Audio
+
+
+def _peak_match(target: Audio, reference: Audio) -> Audio:
+    """Scale ``target`` so its peak amplitude matches ``reference``.
+
+    Demucs background normalization and the timing-assembler peak guard
+    each clamp at 1.0 instead of restoring headroom, so a dubbed mix
+    typically lands quieter than the source — perceptually "thinner."
+    A single peak match recovers most of that drift without LUFS deps.
+
+    No-op when either side has zero peak (silent input or all-silent dub).
+    The new ``Audio`` shares no buffer with ``target``.
+    """
+    from videopython.base.audio import Audio as _Audio
+
+    target_peak = float(np.max(np.abs(target.data))) if target.data.size else 0.0
+    reference_peak = float(np.max(np.abs(reference.data))) if reference.data.size else 0.0
+
+    if target_peak <= 0.0 or reference_peak <= 0.0:
+        return target
+
+    scale = reference_peak / target_peak
+    if abs(scale - 1.0) < 1e-3:
+        return target
+
+    return _Audio(target.data * scale, target.metadata)
+
 
 WhisperModel = Literal["tiny", "base", "small", "medium", "large", "turbo"]
 
@@ -239,7 +268,19 @@ class LocalDubbingPipeline:
             if self._separator is None:
                 self._init_separator()
 
-            separated_audio = self._separator.separate(source_audio)
+            # Limit Demucs to the speech-bearing portion of the audio. The
+            # transcription has already located every speech region; running
+            # source separation outside those is pure overhead (no vocals to
+            # isolate). On talk-heavy sources with silence/music gaps this
+            # roughly halves separation time. When speech covers most of the
+            # track separate_regions falls back to a full-track separate().
+            from videopython.ai.understanding.separation import _merge_regions
+
+            speech_regions = _merge_regions(
+                [(s.start, s.end) for s in transcription.segments],
+                audio_duration=source_audio.metadata.duration_seconds,
+            )
+            separated_audio = self._separator.separate_regions(source_audio, speech_regions)
             self._maybe_unload("_separator")
             vocal_audio = separated_audio.vocals
             background_audio = separated_audio.background
@@ -296,6 +337,12 @@ class LocalDubbingPipeline:
             for i, segment in enumerate(translated_segments):
                 if segment.duration < 0.1:
                     continue
+                # Translation filter (translation.py:_is_translatable_text)
+                # leaves translated_text="" for punctuation-only or empty
+                # segments. Don't TTS those — saves a model call and avoids
+                # injecting hallucinated speech into the dubbed track.
+                if not segment.translated_text.strip():
+                    continue
 
                 progress = 0.50 + (0.30 * (i / len(translated_segments)))
                 report_progress(f"Generating speech ({i + 1}/{len(translated_segments)})", progress)
@@ -342,6 +389,11 @@ class LocalDubbingPipeline:
             del background_audio
         else:
             final_audio = dubbed_speech
+
+        # Peak-match against the source so the dub doesn't land quieter
+        # than the original. Done last so it captures both vocals+background
+        # mixes and speech-only outputs uniformly.
+        final_audio = _peak_match(final_audio, source_audio)
 
         report_progress("Complete", 1.0)
 
@@ -393,7 +445,13 @@ class LocalDubbingPipeline:
             if self._separator is None:
                 self._init_separator()
 
-            separated_audio = self._separator.separate(source_audio)
+            from videopython.ai.understanding.separation import _merge_regions
+
+            speech_regions = _merge_regions(
+                [(s.start, s.end) for s in transcription.segments],
+                audio_duration=source_audio.metadata.duration_seconds,
+            )
+            separated_audio = self._separator.separate_regions(source_audio, speech_regions)
             self._maybe_unload("_separator")
             vocal_audio = separated_audio.vocals
             background_audio = separated_audio.background
@@ -447,6 +505,8 @@ class LocalDubbingPipeline:
             del background_audio
         else:
             final_audio = generated_speech
+
+        final_audio = _peak_match(final_audio, source_audio)
 
         report_progress("Complete", 1.0)
 

--- a/src/videopython/ai/generation/translation.py
+++ b/src/videopython/ai/generation/translation.py
@@ -8,6 +8,17 @@ from videopython.ai._device import log_device_initialization, release_device_mem
 from videopython.ai.dubbing.models import TranslatedSegment
 from videopython.base.text.transcription import TranscriptionSegment
 
+
+def _is_translatable_text(text: str) -> bool:
+    """Return True if text has enough content to be worth translating.
+
+    Whisper routinely emits punctuation-only or single-character segments
+    (" .", "...", "?", "♪") that MarianMT can hallucinate full sentences
+    from. Require at least 2 alphanumeric characters to filter these out.
+    """
+    return sum(1 for c in text if c.isalnum()) >= 2
+
+
 LANGUAGE_NAMES = {
     "en": "English",
     "es": "Spanish",
@@ -159,17 +170,28 @@ class TextTranslator:
         target_lang: str,
         source_lang: str | None = None,
     ) -> list[TranslatedSegment]:
-        """Translate transcription segments while preserving timing/speaker info."""
+        """Translate transcription segments while preserving timing/speaker info.
+
+        Segments whose text is empty or contains fewer than 2 alphanumeric
+        characters are not sent to the model — they receive
+        ``translated_text=""`` instead. This avoids MarianMT hallucinating
+        full sentences from " .", "...", or single-token Whisper segments,
+        which would otherwise be TTS'd into the dubbed track.
+        """
         effective_source = source_lang or "en"
-        texts = [segment.text for segment in segments]
-        translated_texts = self.translate_batch(texts, target_lang, source_lang)
+
+        translatable_indices = [i for i, segment in enumerate(segments) if _is_translatable_text(segment.text)]
+        translatable_texts = [segments[i].text for i in translatable_indices]
+        translated_texts = self.translate_batch(translatable_texts, target_lang, source_lang)
+
+        translation_map: dict[int, str] = dict(zip(translatable_indices, translated_texts))
 
         translated_segments = []
-        for segment, translated_text in zip(segments, translated_texts):
+        for i, segment in enumerate(segments):
             translated_segments.append(
                 TranslatedSegment(
                     original_segment=segment,
-                    translated_text=translated_text,
+                    translated_text=translation_map.get(i, ""),
                     source_lang=effective_source,
                     target_lang=target_lang,
                     speaker=segment.speaker,

--- a/src/videopython/ai/understanding/separation.py
+++ b/src/videopython/ai/understanding/separation.py
@@ -2,11 +2,57 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.ai.dubbing.models import SeparatedAudio
 from videopython.base.audio import Audio, AudioMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def _merge_regions(
+    regions: list[tuple[float, float]],
+    audio_duration: float,
+    pad: float = 0.5,
+    merge_gap: float = 1.0,
+) -> list[tuple[float, float]]:
+    """Merge overlapping/adjacent (start, end) ranges and pad each side.
+
+    Args:
+        regions: Speech regions in seconds. Order does not matter.
+        audio_duration: Total audio duration; output is clamped to ``[0, audio_duration]``.
+        pad: Seconds added to each side. Demucs needs context to separate
+            cleanly at boundaries; 0.5s avoids clipped onsets/decays.
+        merge_gap: Adjacent regions whose padded edges are within this
+            many seconds are merged. Avoids running Demucs on very short
+            slices (where its temporal context isn't there).
+
+    Returns:
+        Sorted list of non-overlapping (start, end) regions covering the
+        speech-bearing portion of the audio.
+    """
+    if not regions:
+        return []
+
+    sorted_regions = sorted(regions)
+
+    merged: list[tuple[float, float]] = []
+    for start, end in sorted_regions:
+        if end <= start:
+            continue
+        padded_start = max(0.0, start - pad)
+        padded_end = min(audio_duration, end + pad)
+        if padded_start >= audio_duration or padded_end <= 0.0:
+            continue
+
+        if merged and padded_start - merged[-1][1] <= merge_gap:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], padded_end))
+        else:
+            merged.append((padded_start, padded_end))
+
+    return merged
 
 
 class AudioSeparator:
@@ -113,6 +159,133 @@ class AudioSeparator:
     def separate(self, audio: Audio) -> SeparatedAudio:
         """Separate audio into vocals and background components."""
         return self._separate_local(audio)
+
+    def separate_regions(
+        self,
+        audio: Audio,
+        regions: list[tuple[float, float]],
+        full_separation_threshold: float = 0.9,
+    ) -> SeparatedAudio:
+        """Separate only the given (start, end) regions; pass the rest through.
+
+        Demucs is the slowest stage of the dubbing pipeline. On talk-heavy
+        sources (podcasts, interviews) most of the track is speech, but
+        long pauses, silence, or music-only stretches don't need vocal
+        isolation — there's nothing to isolate. We run Demucs only on the
+        speech-bearing regions and treat the rest as pure background.
+
+        Output is full-length: vocals are silent outside the given
+        regions; background is the original audio outside the given
+        regions and the Demucs-separated background inside.
+
+        Args:
+            audio: Source audio (typically the full track).
+            regions: List of ``(start, end)`` second pairs marking
+                speech-bearing portions. Caller is responsible for
+                merging/padding (use ``_merge_regions``).
+            full_separation_threshold: If the regions cover more than
+                this fraction of the audio, fall back to full-track
+                ``separate()`` since per-region slicing+stitching
+                overhead would exceed the savings. Default 0.9.
+
+        Returns:
+            ``SeparatedAudio`` with full-length vocals and background.
+        """
+        import numpy as np
+
+        if not regions:
+            logger.info("separate_regions: no regions, returning silent vocals over original audio")
+            return self._passthrough_separation(audio)
+
+        total_duration = audio.metadata.duration_seconds
+        speech_duration = sum(end - start for start, end in regions)
+        if total_duration > 0 and speech_duration / total_duration >= full_separation_threshold:
+            logger.info(
+                "separate_regions: speech covers %.0f%% of audio (>=%.0f%%), using full-track separation",
+                speech_duration / total_duration * 100,
+                full_separation_threshold * 100,
+            )
+            return self._separate_local(audio)
+
+        logger.info(
+            "separate_regions: separating %.1fs of speech across %d region(s) (full duration: %.1fs)",
+            speech_duration,
+            len(regions),
+            total_duration,
+        )
+
+        # Build full-length output buffers. Background defaults to the
+        # original audio (so non-speech gaps pass through unchanged); vocals
+        # default to silence (no speech to isolate outside the regions).
+        # Both are stereo to match the full-track separation contract.
+        sr = audio.metadata.sample_rate
+        stereo_audio = audio if audio.metadata.channels == 2 else audio._to_stereo()
+
+        total_samples = len(stereo_audio.data)
+        vocals_full = np.zeros((total_samples, 2), dtype=np.float32)
+        background_full = stereo_audio.data.astype(np.float32, copy=True)
+
+        for start, end in regions:
+            chunk = audio.slice(start, end)
+            separated_chunk = self._separate_local(chunk)
+            chunk_vocals = separated_chunk.vocals.data
+            chunk_background = separated_chunk.background.data
+
+            # Demucs operates at its model sample rate (typically 44.1 kHz)
+            # and returns stereo. The slice of `audio` we passed in may have
+            # been resampled inside _separate_local, so resample the chunk
+            # outputs back to the source sample rate before splicing.
+            chunk_sr = separated_chunk.vocals.metadata.sample_rate
+            if chunk_sr != sr:
+                chunk_vocals = separated_chunk.vocals.resample(sr).data
+                chunk_background = separated_chunk.background.resample(sr).data
+
+            start_sample = int(start * sr)
+            end_sample = min(start_sample + len(chunk_vocals), total_samples)
+            length = end_sample - start_sample
+            if length <= 0:
+                continue
+
+            vocals_full[start_sample:end_sample] = chunk_vocals[:length]
+            background_full[start_sample:end_sample] = chunk_background[:length]
+
+        metadata = AudioMetadata(
+            sample_rate=sr,
+            channels=2,
+            sample_width=audio.metadata.sample_width,
+            duration_seconds=total_samples / sr,
+            frame_count=total_samples,
+        )
+        vocals = Audio(np.ascontiguousarray(vocals_full, dtype=np.float32), metadata)
+        background = Audio(np.ascontiguousarray(background_full, dtype=np.float32), metadata)
+
+        return SeparatedAudio(
+            vocals=vocals,
+            background=background,
+            original=stereo_audio,
+            music=None,
+            effects=None,
+        )
+
+    def _passthrough_separation(self, audio: Audio) -> SeparatedAudio:
+        """Return the original audio as background with silent vocals.
+
+        Used when no speech regions are present — there's nothing to
+        separate, so the entire signal is background by definition.
+        """
+        import numpy as np
+
+        stereo_audio = audio if audio.metadata.channels == 2 else audio._to_stereo()
+        silent_vocals_data = np.zeros_like(stereo_audio.data, dtype=np.float32)
+        vocals = Audio(silent_vocals_data, stereo_audio.metadata)
+
+        return SeparatedAudio(
+            vocals=vocals,
+            background=stereo_audio,
+            original=stereo_audio,
+            music=None,
+            effects=None,
+        )
 
     def extract_vocals(self, audio: Audio) -> Audio:
         """Convenience method to extract only vocals from audio."""

--- a/uv.lock
+++ b/uv.lock
@@ -5604,7 +5604,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.26.7"
+version = "0.26.8"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
- Filter empty and punctuation-only segments before translation (text with <2 alphanumeric chars). Avoids MarianMT hallucinating full sentences from " .", "...", and single-token Whisper noise, which were getting TTS'd into the dubbed track.
- Gate Demucs to speech-bearing regions derived from the transcription (merged + 0.5s padded for context). Non-speech gaps pass through as background unchanged. Falls back to full-track separation when speech covers >=90% of the audio. Roughly halves separation time on talk-heavy sources with silence gaps.
- Peak-match the final dubbed audio against the source so the dub doesn't land quieter than the original. Demucs background normalization and the timing-assembler peak guard each clamp at 1.0 instead of restoring headroom.