### PR TITLE
Mention VAD-gated language detection in AudioToText docs

### DIFF
--- a/docs/examples/auto-subtitles.md
+++ b/docs/examples/auto-subtitles.md
@@ -62,6 +62,7 @@ Model options:
 
 - `tiny`, `base`, `small`, `medium`, `large`, `turbo`
 - Enable diarization with `AudioToText(enable_diarization=True)` when needed.
+- VAD-gated language detection runs by default (`enable_vad=True`); pass `enable_vad=False` to skip it.
 
 ### 2. Configure Subtitle Style
 

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -15,7 +15,11 @@ class AudioToText:
     """Transcription service for audio and video using local Whisper models.
 
     Uses openai-whisper for transcription (with word-level timestamps) and
-    pyannote-audio for optional speaker diarization.
+    pyannote-audio for optional speaker diarization. By default, Silero VAD
+    runs before Whisper to gate language detection on a 30s window built from
+    voiced regions only — fixes Whisper's tendency to lock onto the wrong
+    language when the file opens with silence, music, or non-vocal credits.
+    Disable with ``enable_vad=False`` to reproduce pre-0.27 behaviour.
     """
 
     PYANNOTE_DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"


### PR DESCRIPTION
Class docstring (rendered into docs/api/ai/understanding.md via mkdocstrings) and the auto-subtitles example didn't reflect the 0.27.0 default. Add a brief note in both about Silero VAD running before Whisper to gate language detection, and the enable_vad=False opt-out.