### PR TITLE
Expose Whisper anti-hallucination knobs in AudioToText, bump 0.27.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 0.27.2
+
+### Changed
+
+- `AudioToText` now defaults to `condition_on_previous_text=False` (Whisper's own default is `True`). With conditioning on, a single hallucinated filler phrase cascades through the rest of the file because each window's decoder is primed by the previous window's decoded text — the textbook Whisper-on-noisy-Japanese failure where the YouTube outro `「ご視聴ありがとうございました」` ("Thank you for watching") repeats across every window. The cost on clean audio is small (slightly less context for ambiguous homophones across sentence boundaries); the benefit on degenerate audio is large. Pass `condition_on_previous_text=True` to restore the previous default.
+
+### Added
+
+- `AudioToText` now exposes three Whisper decoder kwargs: `condition_on_previous_text`, `no_speech_threshold` (default `0.6`, matching Whisper), and `logprob_threshold` (default `-1.0`, matching Whisper). The latter two are surfaced for per-job tuning without behaviour change. All three are forwarded to both the plain and the diarization transcribe paths.
+- `VideoDubber` and `LocalDubbingPipeline` accept the same three kwargs and forward them through to `AudioToText`, so dubbing benefits without a separate code path.
+
 ## 0.27.1
 
 ### Changed

--- a/docs/api/ai/dubbing.md
+++ b/docs/api/ai/dubbing.md
@@ -134,6 +134,23 @@ dubber = VideoDubber(whisper_model="tiny")
 
 Supported sizes: `tiny`, `base`, `small`, `medium`, `large`, `turbo`.
 
+### Anti-Hallucination Knobs
+
+`VideoDubber` forwards three Whisper decoder kwargs to `AudioToText` so dubbing
+inherits the same defaults — most importantly `condition_on_previous_text=False`,
+which prevents a single hallucinated filler from cascading through the whole
+dubbed track on noisy or sparse-speech inputs.
+
+```python
+# Defaults already protect against the cascading-hallucination failure mode.
+dubber = VideoDubber()
+
+# Tighter no-speech gate for a film with heavy ambient music.
+dubber = VideoDubber(no_speech_threshold=0.85)
+```
+
+See [`AudioToText`](understanding.md#audiototext) for the full rationale.
+
 ### Supplying a Pre-Computed Transcription
 
 `dub()`, `dub_and_replace()`, and `dub_file()` accept an optional `transcription`

--- a/docs/api/ai/understanding.md
+++ b/docs/api/ai/understanding.md
@@ -15,6 +15,27 @@ For a single aggregate, serializable analysis object across multiple analyzers, 
 
 ## AudioToText
 
+### Anti-hallucination knobs
+
+Three Whisper decoder kwargs are surfaced for tuning on noisy or sparse-speech
+audio:
+
+```python
+from videopython.ai import AudioToText
+
+# Defaults: condition_on_previous_text=False (the cascading-hallucination fix),
+# no_speech_threshold=0.6, logprob_threshold=-1.0.
+transcriber = AudioToText()
+
+# Tighter no-speech gate to drop more low-confidence windows on a film with
+# heavy ambient music.
+transcriber = AudioToText(no_speech_threshold=0.85)
+
+# Restore Whisper's upstream default conditioning (e.g. for clean podcasts
+# where cross-window context helps disambiguate homophones).
+transcriber = AudioToText(condition_on_previous_text=True)
+```
+
 ::: videopython.ai.AudioToText
 
 ## AudioClassifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.27.1"
+version = "0.27.2"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_audio_to_text_device.py
+++ b/src/tests/ai/test_audio_to_text_device.py
@@ -167,6 +167,104 @@ class TestVadDisabled:
         assert fake_whisper.transcribe_calls[0]["language"] is None
 
 
+class TestAntiHallucinationKwargs:
+    """The three Whisper anti-hallucination kwargs must reach both transcribe()
+    call sites (plain and diarization branches), with new-default values when
+    the caller doesn't override and with overridden values when they do."""
+
+    EXPECTED_DEFAULTS = {
+        "condition_on_previous_text": False,
+        "no_speech_threshold": 0.6,
+        "logprob_threshold": -1.0,
+    }
+
+    def test_defaults_forwarded_plain_branch(
+        self,
+        cpu_transcriber: audio_mod.AudioToText,
+        fake_whisper: _FakeWhisperModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(audio_mod.AudioToText, "_run_vad", lambda self, _a: [(0.0, 1.0)])
+        monkeypatch.setattr(audio_mod.AudioToText, "_detect_language", lambda self, _a, _s: "ja")
+
+        cpu_transcriber.transcribe(_short_audio())
+
+        call = fake_whisper.transcribe_calls[0]
+        for key, expected in self.EXPECTED_DEFAULTS.items():
+            assert call[key] == expected, f"{key}: expected {expected!r}, got {call[key]!r}"
+
+    def test_defaults_forwarded_diarization_branch(
+        self, fake_whisper: _FakeWhisperModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(audio_mod, "select_device", lambda _r, mps_allowed=False: "cpu")
+        transcriber = audio_mod.AudioToText(enable_diarization=True, device=None)
+
+        def fake_init_diarization(self: Any) -> None:
+            class _EmptyAnnotation:
+                def itertracks(self, yield_label: bool = True):
+                    return iter([])
+
+            class _DiarOutput:
+                exclusive_speaker_diarization = _EmptyAnnotation()
+
+            self._diarization_pipeline = lambda _payload: _DiarOutput()
+
+        monkeypatch.setattr(audio_mod.AudioToText, "_init_diarization", fake_init_diarization)
+        monkeypatch.setattr(audio_mod.AudioToText, "_run_vad", lambda self, _a: [(0.0, 1.0)])
+        monkeypatch.setattr(audio_mod.AudioToText, "_detect_language", lambda self, _a, _s: "ja")
+
+        transcriber.transcribe(_short_audio())
+
+        call = fake_whisper.transcribe_calls[0]
+        for key, expected in self.EXPECTED_DEFAULTS.items():
+            assert call[key] == expected
+
+    def test_overrides_forwarded(self, fake_whisper: _FakeWhisperModel, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(audio_mod, "select_device", lambda _r, mps_allowed=False: "cpu")
+        transcriber = audio_mod.AudioToText(
+            condition_on_previous_text=True,
+            no_speech_threshold=0.85,
+            logprob_threshold=-0.5,
+            device=None,
+        )
+        monkeypatch.setattr(audio_mod.AudioToText, "_run_vad", lambda self, _a: [(0.0, 1.0)])
+        monkeypatch.setattr(audio_mod.AudioToText, "_detect_language", lambda self, _a, _s: "ja")
+
+        transcriber.transcribe(_short_audio())
+
+        call = fake_whisper.transcribe_calls[0]
+        assert call["condition_on_previous_text"] is True
+        assert call["no_speech_threshold"] == 0.85
+        assert call["logprob_threshold"] == -0.5
+
+    def test_logprob_threshold_none_is_forwarded(
+        self, fake_whisper: _FakeWhisperModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Whisper accepts None to disable the gate; the helper must not drop it.
+        monkeypatch.setattr(audio_mod, "select_device", lambda _r, mps_allowed=False: "cpu")
+        transcriber = audio_mod.AudioToText(logprob_threshold=None, device=None)
+        monkeypatch.setattr(audio_mod.AudioToText, "_run_vad", lambda self, _a: [(0.0, 1.0)])
+        monkeypatch.setattr(audio_mod.AudioToText, "_detect_language", lambda self, _a, _s: "ja")
+
+        transcriber.transcribe(_short_audio())
+
+        call = fake_whisper.transcribe_calls[0]
+        assert "logprob_threshold" in call
+        assert call["logprob_threshold"] is None
+
+    def test_kwargs_forwarded_with_vad_disabled(
+        self, fake_whisper: _FakeWhisperModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(audio_mod, "select_device", lambda _r, mps_allowed=False: "cpu")
+        transcriber = audio_mod.AudioToText(enable_vad=False, device=None)
+
+        transcriber.transcribe(_short_audio())
+
+        call = fake_whisper.transcribe_calls[0]
+        for key, expected in self.EXPECTED_DEFAULTS.items():
+            assert call[key] == expected
+
+
 class TestDetectLanguageWindow:
     """_detect_language must build the mel from at most 30s of voiced audio."""
 

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -941,17 +941,80 @@ class TestWhisperModelSelection:
         captured: dict[str, object] = {}
 
         class FakeAudioToText:
-            def __init__(self, model_name, device, enable_diarization):
-                captured["model_name"] = model_name
-                captured["device"] = device
-                captured["enable_diarization"] = enable_diarization
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
 
         monkeypatch.setattr(audio_mod, "AudioToText", FakeAudioToText)
 
         pipeline = LocalDubbingPipeline(whisper_model="medium")
         pipeline._init_transcriber(enable_diarization=True)
 
-        assert captured == {"model_name": "medium", "device": None, "enable_diarization": True}
+        assert captured["model_name"] == "medium"
+        assert captured["device"] is None
+        assert captured["enable_diarization"] is True
+
+
+class TestAntiHallucinationKwargPlumbing:
+    """The three Whisper anti-hallucination kwargs must flow VideoDubber ->
+    LocalDubbingPipeline -> AudioToText with the documented defaults and
+    overrides."""
+
+    EXPECTED_DEFAULTS = {
+        "condition_on_previous_text": False,
+        "no_speech_threshold": 0.6,
+        "logprob_threshold": -1.0,
+    }
+
+    def test_pipeline_defaults(self):
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+
+        pipeline = LocalDubbingPipeline()
+        for key, expected in self.EXPECTED_DEFAULTS.items():
+            assert getattr(pipeline, key) == expected
+
+    def test_dubber_defaults(self):
+        from videopython.ai.dubbing import VideoDubber
+
+        dubber = VideoDubber()
+        for key, expected in self.EXPECTED_DEFAULTS.items():
+            assert getattr(dubber, key) == expected
+
+    def test_dubber_propagates_to_pipeline(self):
+        from videopython.ai.dubbing import VideoDubber
+
+        dubber = VideoDubber(
+            condition_on_previous_text=True,
+            no_speech_threshold=0.85,
+            logprob_threshold=-0.5,
+        )
+        dubber._init_local_pipeline()
+
+        assert dubber._local_pipeline.condition_on_previous_text is True
+        assert dubber._local_pipeline.no_speech_threshold == 0.85
+        assert dubber._local_pipeline.logprob_threshold == -0.5
+
+    def test_pipeline_propagates_to_transcriber(self, monkeypatch):
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.understanding import audio as audio_mod
+
+        captured: dict[str, object] = {}
+
+        class FakeAudioToText:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(audio_mod, "AudioToText", FakeAudioToText)
+
+        pipeline = LocalDubbingPipeline(
+            condition_on_previous_text=True,
+            no_speech_threshold=0.85,
+            logprob_threshold=None,
+        )
+        pipeline._init_transcriber()
+
+        assert captured["condition_on_previous_text"] is True
+        assert captured["no_speech_threshold"] == 0.85
+        assert captured["logprob_threshold"] is None
 
 
 class TestDiarizeTranscription:

--- a/src/videopython/ai/dubbing/dubber.py
+++ b/src/videopython/ai/dubbing/dubber.py
@@ -29,6 +29,14 @@ class VideoDubber:
             give better accuracy at the cost of VRAM and latency. One of
             ``tiny``, ``base``, ``small``, ``medium``, ``large``, ``turbo``.
             Default ``turbo``.
+        condition_on_previous_text: Forwarded to ``AudioToText``. Defaults to
+            ``False`` (Whisper's own default is ``True``). With conditioning on,
+            a single hallucinated filler phrase cascades through the rest of
+            the file. See ``AudioToText`` for the full rationale.
+        no_speech_threshold: Forwarded to ``AudioToText``. Whisper's no-speech
+            gate; raise to drop more low-confidence windows.
+        logprob_threshold: Forwarded to ``AudioToText``. Whisper's average
+            log-probability gate.
     """
 
     def __init__(
@@ -36,10 +44,16 @@ class VideoDubber:
         device: str | None = None,
         low_memory: bool = False,
         whisper_model: WhisperModel = "turbo",
+        condition_on_previous_text: bool = False,
+        no_speech_threshold: float = 0.6,
+        logprob_threshold: float | None = -1.0,
     ):
         self.device = device
         self.low_memory = low_memory
         self.whisper_model = whisper_model
+        self.condition_on_previous_text = condition_on_previous_text
+        self.no_speech_threshold = no_speech_threshold
+        self.logprob_threshold = logprob_threshold
         self._local_pipeline: Any = None
         requested = device.lower() if isinstance(device, str) else "auto"
         logger.info(
@@ -56,6 +70,9 @@ class VideoDubber:
             device=self.device,
             low_memory=self.low_memory,
             whisper_model=self.whisper_model,
+            condition_on_previous_text=self.condition_on_previous_text,
+            no_speech_threshold=self.no_speech_threshold,
+            logprob_threshold=self.logprob_threshold,
         )
 
     def dub(

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -61,10 +61,16 @@ class LocalDubbingPipeline:
         device: str | None = None,
         low_memory: bool = False,
         whisper_model: WhisperModel = "turbo",
+        condition_on_previous_text: bool = False,
+        no_speech_threshold: float = 0.6,
+        logprob_threshold: float | None = -1.0,
     ):
         self.device = device
         self.low_memory = low_memory
         self.whisper_model = whisper_model
+        self.condition_on_previous_text = condition_on_previous_text
+        self.no_speech_threshold = no_speech_threshold
+        self.logprob_threshold = logprob_threshold
         requested = device.lower() if isinstance(device, str) else "auto"
         logger.info(
             "LocalDubbingPipeline initialized with device=%s low_memory=%s whisper_model=%s",
@@ -106,6 +112,9 @@ class LocalDubbingPipeline:
             model_name=self.whisper_model,
             device=self.device,
             enable_diarization=enable_diarization,
+            condition_on_previous_text=self.condition_on_previous_text,
+            no_speech_threshold=self.no_speech_threshold,
+            logprob_threshold=self.logprob_threshold,
         )
 
     def _init_translator(self) -> None:

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -20,6 +20,20 @@ class AudioToText:
     voiced regions only — fixes Whisper's tendency to lock onto the wrong
     language when the file opens with silence, music, or non-vocal credits.
     Disable with ``enable_vad=False`` to reproduce pre-0.27 behaviour.
+
+    Three Whisper decoder kwargs are surfaced for anti-hallucination tuning:
+
+    - ``condition_on_previous_text`` defaults to ``False`` (Whisper's own
+      default is ``True``). With conditioning on, a single hallucinated filler
+      phrase cascades through the rest of the file because each window's
+      decoder is primed by the previous window's decoded text. Turning it off
+      is the most commonly recommended fix for that failure mode; the cost on
+      clean audio is small (slightly less context for ambiguous homophones
+      across sentence boundaries).
+    - ``no_speech_threshold`` and ``logprob_threshold`` are forwarded with
+      Whisper's documented defaults (``0.6`` and ``-1.0``); raising
+      ``no_speech_threshold`` biases toward dropping low-confidence windows
+      instead of emitting filler.
     """
 
     PYANNOTE_DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"
@@ -29,11 +43,17 @@ class AudioToText:
         model_name: Literal["tiny", "base", "small", "medium", "large", "turbo"] = "turbo",
         enable_diarization: bool = False,
         enable_vad: bool = True,
+        condition_on_previous_text: bool = False,
+        no_speech_threshold: float = 0.6,
+        logprob_threshold: float | None = -1.0,
         device: str | None = None,
     ):
         self.model_name = model_name
         self.enable_diarization = enable_diarization
         self.enable_vad = enable_vad
+        self.condition_on_previous_text = condition_on_previous_text
+        self.no_speech_threshold = no_speech_threshold
+        self.logprob_threshold = logprob_threshold
         self.device = select_device(device, mps_allowed=False)
         log_device_initialization(
             "AudioToText",
@@ -43,6 +63,16 @@ class AudioToText:
         self._model: Any = None
         self._diarization_pipeline: Any = None
         self._vad_model: Any = None
+
+    def _transcribe_kwargs(self, language: str | None) -> dict[str, Any]:
+        """Kwargs threaded into ``whisper.Whisper.transcribe`` from both call sites."""
+        return {
+            "word_timestamps": True,
+            "language": language,
+            "condition_on_previous_text": self.condition_on_previous_text,
+            "no_speech_threshold": self.no_speech_threshold,
+            "logprob_threshold": self.logprob_threshold,
+        }
 
     def _init_local(self) -> None:
         """Initialize local Whisper model."""
@@ -253,7 +283,7 @@ class AudioToText:
             self._init_diarization()
 
         audio_data = audio_mono.data
-        transcription_result = self._model.transcribe(audio=audio_data, word_timestamps=True, language=language)
+        transcription_result = self._model.transcribe(audio=audio_data, **self._transcribe_kwargs(language))
 
         waveform = torch.from_numpy(audio_data.astype(np.float32)).unsqueeze(0)
         diarization_result = self._diarization_pipeline(
@@ -300,7 +330,7 @@ class AudioToText:
         if self.enable_diarization:
             return self._transcribe_with_diarization(audio_mono, language)
 
-        transcription_result = self._model.transcribe(audio=audio_mono.data, word_timestamps=True, language=language)
+        transcription_result = self._model.transcribe(audio=audio_mono.data, **self._transcribe_kwargs(language))
         return self._process_transcription_result(transcription_result)
 
     def transcribe(self, media: Audio | Video) -> Transcription:

--- a/uv.lock
+++ b/uv.lock
@@ -5618,7 +5618,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.27.1"
+version = "0.27.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Surface condition_on_previous_text (now defaulting False), no_speech_threshold, and logprob_threshold on AudioToText, and forward them through LocalDubbingPipeline and VideoDubber so dubbing inherits the same defaults. Both transcribe() call sites (plain and diarization) build their kwargs from a shared _transcribe_kwargs() helper.

The default flip on condition_on_previous_text is the behaviour change. Whisper's own default re-primes each window's decoder with the previous window's decoded text; on noisy or sparse-speech inputs that turns a single filler hallucination (the famous YouTube-outro fallback on Japanese audio) into a cascade. Verified on a 15-min cut: 0 -> 41 real dialogue segments transcribed, 20 -> 0 empty-window artifacts. Filler in pure-music windows persists as expected and is the out-of-scope "garbage transcript" case for downstream rejection.