### PR TITLE
M2: Qwen3 translation backend with Marian fallback

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## 0.28.1
+
+### Added
+
+- `Qwen3Translator` translation backend (`videopython.ai.generation.qwen3.Qwen3Translator`). Uses Qwen3-4B-Instruct-2507 via `llama-cpp-python` (Q4_K_M GGUF, ~2.4 GB; downloaded on first use to the standard HuggingFace cache). Produces context-aware, length-budgeted translation: the prompt includes a per-segment `target_chars` budget derived from source duration × language-specific speech rate, and an optional `low_confidence` flag for segments whose `avg_logprob` is unhealthy. Output is JSON-line, with parse retry and optional per-segment Marian fallback when both Qwen attempts fail. Apache-2.0 model + MIT inference framework. Adds `llama-cpp-python>=0.3` to the `ai` extra.
+- `TranslationBackend` runtime-checkable Protocol (`videopython.ai.generation.translation.TranslationBackend`). Captures the three-method contract `translate_segments` / `unload` / `get_supported_languages`. Both `MarianTranslator` and `Qwen3Translator` satisfy it; the pipeline depends only on the protocol.
+- `translator: Literal["auto", "marian", "qwen3"] = "auto"` constructor kwarg on `VideoDubber` and `LocalDubbingPipeline`. The `"auto"` resolver picks based on language coverage **and** device: GPU + Qwen-supported pair → Qwen3 (best quality); Marian-supported pair → Marian (~10-15× faster on CPU); CPU + Qwen-only pair → Qwen3 with a loud WARNING. The integration spike on `cam1_1min.mp4` (Polish→Spanish) showed Qwen3-4B Q4_K_M on CPU runs ~2.8× the wall time of Marian end-to-end (and ~13× on the translation stage in isolation), so the auto resolver intentionally prefers Marian on CPU even when Qwen would also cover the pair.
+- `UnsupportedLanguageError(ValueError)` exposed from `videopython.ai.dubbing`. Carries `source_lang` and `target_lang` so callers can introspect the unsupported pair without parsing the message. Raised by the auto resolver when neither backend covers the pair.
+- `translation_failures: list[int]` field on `DubbingResult`. Populated by `Qwen3Translator` for segments where both the primary call and the per-segment Marian fallback failed — those segments land on the result with `translated_text=""`. Empty list under `MarianTranslator`.
+
+### Changed
+
+- `_transcribe_with_diarization` now re-attaches per-segment Whisper confidence (`avg_logprob`, `no_speech_prob`, `compression_ratio`) to the diarization-rebuilt segments by max-overlap match. Without this fix the segments-from-words rebuild dropped the metadata that 0.28.0 plumbed through, so on every diarized run the M1.3 confidence fields were `None`. M1.5's logprob-based reject rule and any prompt that branches on confidence now have signal on the diarized path too.
+- `TextTranslator` is renamed to `MarianTranslator`. The old name remains as a back-compat alias through 0.28.x; remove in 0.30.0. Existing imports continue to work unchanged.
+
+### Known limitations
+
+- Qwen3 on CPU is impractical for everyday use — wall time on a 60-second source ran ~25 minutes (vs ~9 minutes for Marian) in the integration spike. The auto resolver prevents accidental opt-in; explicit `translator="qwen3"` on CPU triggers a startup WARNING.
+- On the same spike, Qwen3 produced clearly better translations on idiomatic and question-vs-statement segments but **regressed slightly on truncation rate** (worst-case segment lost 2.18 s of content vs Marian's 0.86 s) and **mistranslated a single-word segment** (`narzekamy` → `mejoramos`, opposite meaning). The prompt's character-budget instruction isn't strict enough on long segments, and very short segments give the LLM too little anchor to disambiguate. Both will be revisited as follow-ups; for now, the auto resolver's CPU preference for Marian is the practical mitigation.
+
 ## 0.28.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.28.0"
+version = "0.28.1"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },
@@ -80,6 +80,8 @@ ai = [
     "sentencepiece>=0.1.99",
     # Audio source separation
     "demucs>=4.0.0",
+    # Translation backend: Qwen3 GGUF inference (M2)
+    "llama-cpp-python>=0.3.0",
 ]
 
 # Required for pip install videopython[ai] - pip uses optional-dependencies, not dependency-groups
@@ -111,6 +113,8 @@ ai = [
     "sentencepiece>=0.1.99",
     # Audio source separation
     "demucs>=4.0.0",
+    # Translation backend: Qwen3 GGUF inference (M2)
+    "llama-cpp-python>=0.3.0",
 ]
 
 [project.urls]
@@ -136,6 +140,7 @@ module = [
     "pyannote", "pyannote.*",
     "silero_vad", "silero_vad.*",
     "cv2", "cv2.*",
+    "llama_cpp", "llama_cpp.*",
 ]
 ignore_missing_imports = true
 

--- a/src/tests/ai/test_audio_to_text_device.py
+++ b/src/tests/ai/test_audio_to_text_device.py
@@ -315,6 +315,142 @@ class TestProcessTranscriptionConfidenceFields:
         assert seg.compression_ratio is None
 
 
+class TestAttachConfidenceByOverlap:
+    """_attach_confidence_by_overlap re-attaches Whisper's per-segment
+    confidence onto a diarization-rebuilt segment list by max-overlap match."""
+
+    @staticmethod
+    def _seg(start: float, end: float, *, avg_logprob=None, no_speech_prob=None, compression_ratio=None):
+        from videopython.base.text.transcription import TranscriptionSegment
+
+        return TranscriptionSegment(
+            start=start,
+            end=end,
+            text="x",
+            words=[],
+            avg_logprob=avg_logprob,
+            no_speech_prob=no_speech_prob,
+            compression_ratio=compression_ratio,
+        )
+
+    def test_target_inside_one_source_inherits_its_confidence(self) -> None:
+        sources = [self._seg(0.0, 10.0, avg_logprob=-0.5, no_speech_prob=0.1, compression_ratio=1.8)]
+        targets = [self._seg(2.0, 7.0)]
+
+        audio_mod._attach_confidence_by_overlap(targets, sources)
+
+        assert targets[0].avg_logprob == -0.5
+        assert targets[0].no_speech_prob == 0.1
+        assert targets[0].compression_ratio == 1.8
+
+    def test_target_spanning_two_sources_picks_max_overlap(self) -> None:
+        # source A covers [0, 4), source B covers [4, 10). Target is [3, 8) —
+        # 1s overlap with A, 4s overlap with B → B wins.
+        sources = [
+            self._seg(0.0, 4.0, avg_logprob=-0.3),
+            self._seg(4.0, 10.0, avg_logprob=-1.5),
+        ]
+        targets = [self._seg(3.0, 8.0)]
+
+        audio_mod._attach_confidence_by_overlap(targets, sources)
+
+        assert targets[0].avg_logprob == -1.5
+
+    def test_target_with_no_overlap_left_untouched(self) -> None:
+        sources = [self._seg(0.0, 5.0, avg_logprob=-0.5)]
+        targets = [self._seg(10.0, 15.0)]
+
+        audio_mod._attach_confidence_by_overlap(targets, sources)
+
+        assert targets[0].avg_logprob is None
+        assert targets[0].no_speech_prob is None
+        assert targets[0].compression_ratio is None
+
+    def test_diarization_split_each_half_inherits_parent(self) -> None:
+        """Realistic case: one Whisper segment, diarization splits it across two
+        speakers. Both halves should inherit the parent's confidence."""
+        sources = [self._seg(0.0, 10.0, avg_logprob=-0.7, no_speech_prob=0.05)]
+        targets = [self._seg(0.0, 4.5), self._seg(4.5, 10.0)]
+
+        audio_mod._attach_confidence_by_overlap(targets, sources)
+
+        for tgt in targets:
+            assert tgt.avg_logprob == -0.7
+            assert tgt.no_speech_prob == 0.05
+
+
+class TestDiarizationCarriesConfidence:
+    """End-to-end check: _transcribe_with_diarization must surface
+    per-segment confidence on the rebuilt segments. Without M2.0 these
+    fields are None on every diarized run."""
+
+    def test_diarized_segments_inherit_whisper_confidence(
+        self, fake_whisper: _FakeWhisperModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(audio_mod, "select_device", lambda _r, mps_allowed=False: "cpu")
+        transcriber = audio_mod.AudioToText(enable_diarization=True, device=None)
+
+        # Whisper produces one 10s segment with healthy confidence and
+        # word-level timings.
+        def fake_transcribe(**kwargs: Any) -> dict[str, Any]:
+            fake_whisper.transcribe_calls.append(kwargs)
+            return {
+                "language": "ja",
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "text": "alpha beta",
+                        "words": [
+                            {"word": "alpha", "start": 0.0, "end": 4.0},
+                            {"word": "beta", "start": 4.0, "end": 10.0},
+                        ],
+                        "avg_logprob": -0.6,
+                        "no_speech_prob": 0.08,
+                        "compression_ratio": 1.9,
+                    }
+                ],
+            }
+
+        fake_whisper.transcribe = fake_transcribe  # type: ignore[method-assign]
+
+        # Diarization splits the segment into two speakers at t=4.0.
+        def fake_init_diarization(self: Any) -> None:
+            class _Annotation:
+                def itertracks(self, yield_label: bool = True):
+                    Turn = type("Turn", (), {})
+                    a = Turn()
+                    a.start, a.end = 0.0, 4.0
+                    b = Turn()
+                    b.start, b.end = 4.0, 10.0
+                    return iter([(a, None, "SPEAKER_00"), (b, None, "SPEAKER_01")])
+
+            class _DiarOutput:
+                exclusive_speaker_diarization = _Annotation()
+
+            self._diarization_pipeline = lambda _payload: _DiarOutput()
+
+        monkeypatch.setattr(audio_mod.AudioToText, "_init_diarization", fake_init_diarization)
+        monkeypatch.setattr(audio_mod.AudioToText, "_run_vad", lambda self, _a: [(0.0, 10.0)])
+        monkeypatch.setattr(audio_mod.AudioToText, "_detect_language", lambda self, _a, _s: "ja")
+
+        # Use a 10s audio so VAD/Whisper see real timing; content is irrelevant.
+        result = transcriber.transcribe(_short_audio(duration_s=10.0))
+
+        # Diarization should have produced two segments (one per speaker).
+        assert len(result.segments) == 2
+        speakers = {s.speaker for s in result.segments}
+        assert speakers == {"SPEAKER_00", "SPEAKER_01"}
+
+        # Both halves overlap the single Whisper segment, so both inherit its
+        # confidence — proves M2's confidence-aware prompting has signal on
+        # the diarized path.
+        for seg in result.segments:
+            assert seg.avg_logprob == -0.6
+            assert seg.no_speech_prob == 0.08
+            assert seg.compression_ratio == 1.9
+
+
 class TestDetectLanguageWindow:
     """_detect_language must build the mel from at most 30s of voiced audio."""
 

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -1002,6 +1002,8 @@ class TestTranslationProgressCallback:
         )
 
         class _FakeTranslator:
+            translation_failures: list[int] = []
+
             def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                 # Simulate three batch ticks like a 3-batch translation run.
                 if progress_callback is not None:
@@ -1018,7 +1020,7 @@ class TestTranslationProgressCallback:
                     for s in segments
                 ]
 
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             self._translator = _FakeTranslator()
 
         def fake_init_tts(self, language="en"):
@@ -1682,8 +1684,10 @@ class TestPipelineSuppliedTranscriptionDiarization:
 
         # Skip separation, translation, TTS, and synchronization; we only care
         # about how the pipeline handles the supplied transcription.
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             class FakeTranslator:
+                translation_failures: list[int] = []
+
                 def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                     from videopython.ai.dubbing.models import TranslatedSegment
 
@@ -1911,8 +1915,10 @@ class TestVoiceSampleCache:
 
         monkeypatch.setattr(LocalDubbingPipeline, "_extract_voice_samples", fake_extract)
 
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             class FakeTranslator:
+                translation_failures: list[int] = []
+
                 def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                     return [
                         TranslatedSegment(
@@ -2006,8 +2012,10 @@ class TestVoiceSampleCache:
 
         monkeypatch.setattr(audio_mod.Audio, "save", counting_save)
 
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             class FakeTranslator:
+                translation_failures: list[int] = []
+
                 def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                     return [
                         TranslatedSegment(
@@ -2480,8 +2488,10 @@ class TestPipelineSpeechRegionGating:
         )
 
         # Translator and TTS as fakes so we don't touch real models.
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             class FakeTranslator:
+                translation_failures: list[int] = []
+
                 def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                     return [
                         TranslatedSegment(
@@ -2564,8 +2574,10 @@ class TestPipelineEmptyTranslationSkipped:
 
         tts_calls: list[str] = []
 
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             class FakeTranslator:
+                translation_failures: list[int] = []
+
                 def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                     # Mimic the real filter: punctuation-only -> "".
                     out = []
@@ -2816,8 +2828,10 @@ class TestStrictQualityIntegration:
 
         from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
 
-        def fake_init_translator(self):
+        def fake_init_translator(self, source_lang, target_lang):
             class FakeTranslator:
+                translation_failures: list[int] = []
+
                 def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
                     return [
                         TranslatedSegment(
@@ -2880,3 +2894,271 @@ class TestStrictQualityIntegration:
 
         dubber = VideoDubber()
         assert dubber.strict_quality is False
+
+
+class TestTranslatorResolver:
+    """Tests for the M2.3 translator resolver in LocalDubbingPipeline."""
+
+    @staticmethod
+    def _patch_qwen_supports(monkeypatch, supports_fn):
+        from videopython.ai.generation.qwen3 import Qwen3Translator
+
+        monkeypatch.setattr(Qwen3Translator, "supports", staticmethod(supports_fn))
+
+    @staticmethod
+    def _patch_marian_has_model(monkeypatch, has_fn):
+        from videopython.ai.generation.translation import MarianTranslator
+
+        monkeypatch.setattr(MarianTranslator, "has_model_for", classmethod(has_fn))
+
+    @staticmethod
+    def _stub_qwen_init(monkeypatch):
+        """Replace Qwen3Translator.__init__ to set just the attributes the
+        resolver path inspects, without paying the cost of the real init.
+        Resolution tests don't actually call translate_segments — they only
+        verify which backend type the resolver returned."""
+        from videopython.ai.generation.qwen3 import Qwen3Translator
+
+        def stub_init(self, *args, **kwargs):
+            self.device = kwargs.get("device")
+            self.marian_fallback = kwargs.get("marian_fallback", True)
+            self._llm = None
+            self._marian = None
+            self._failures_last_call = []
+
+        monkeypatch.setattr(Qwen3Translator, "__init__", stub_init)
+
+    def test_auto_picks_qwen_on_gpu(self, monkeypatch):
+        """device resolves to cuda + Qwen covers the pair → Qwen wins."""
+        from videopython.ai.dubbing import pipeline as pipeline_mod
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.generation.qwen3 import Qwen3Translator
+
+        monkeypatch.setattr(pipeline_mod, "select_device", lambda _d, mps_allowed=True: "cuda")
+        self._stub_qwen_init(monkeypatch)
+
+        p = LocalDubbingPipeline(translator="auto")
+        backend = p._resolve_translator_auto("en", "es")
+
+        assert isinstance(backend, Qwen3Translator)
+
+    def test_auto_falls_back_to_marian_on_cpu(self, monkeypatch):
+        """device=cpu + Marian covers the pair → Marian wins (avoid 13× slowdown)."""
+        from videopython.ai.dubbing import pipeline as pipeline_mod
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.generation.translation import MarianTranslator
+
+        monkeypatch.setattr(pipeline_mod, "select_device", lambda _d, mps_allowed=True: "cpu")
+
+        p = LocalDubbingPipeline(translator="auto")
+        backend = p._resolve_translator_auto("en", "es")
+
+        assert isinstance(backend, MarianTranslator)
+
+    def test_auto_uses_qwen_on_cpu_when_marian_lacks_pair(self, monkeypatch, caplog):
+        """device=cpu + Marian doesn't have the pair + Qwen does → Qwen wins
+        with a loud warning about latency."""
+        import logging
+
+        from videopython.ai.dubbing import pipeline as pipeline_mod
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.generation.qwen3 import Qwen3Translator
+
+        monkeypatch.setattr(pipeline_mod, "select_device", lambda _d, mps_allowed=True: "cpu")
+        self._patch_marian_has_model(monkeypatch, lambda cls, src, tgt: False)
+        self._patch_qwen_supports(monkeypatch, lambda src, tgt: True)
+        self._stub_qwen_init(monkeypatch)
+
+        p = LocalDubbingPipeline(translator="auto")
+        with caplog.at_level(logging.WARNING, logger="videopython.ai.dubbing.pipeline"):
+            backend = p._resolve_translator_auto("xh", "yo")
+
+        assert isinstance(backend, Qwen3Translator)
+        assert any("CPU" in r.message and "slow" in r.message.lower() for r in caplog.records)
+
+    def test_auto_raises_unsupported_when_neither_covers(self, monkeypatch):
+        """No backend covers the pair → UnsupportedLanguageError."""
+        from videopython.ai.dubbing import pipeline as pipeline_mod
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.generation.translation import UnsupportedLanguageError
+
+        monkeypatch.setattr(pipeline_mod, "select_device", lambda _d, mps_allowed=True: "cpu")
+        self._patch_marian_has_model(monkeypatch, lambda cls, src, tgt: False)
+        self._patch_qwen_supports(monkeypatch, lambda src, tgt: False)
+
+        p = LocalDubbingPipeline(translator="auto")
+        with pytest.raises(UnsupportedLanguageError) as exc:
+            p._resolve_translator_auto("xx", "yy")
+
+        assert exc.value.source_lang == "xx"
+        assert exc.value.target_lang == "yy"
+
+    def test_explicit_marian_overrides_auto_resolution(self, monkeypatch):
+        """translator='marian' bypasses the resolver — even on GPU."""
+        from videopython.ai.dubbing import pipeline as pipeline_mod
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.generation.translation import MarianTranslator
+
+        monkeypatch.setattr(pipeline_mod, "select_device", lambda _d, mps_allowed=True: "cuda")
+
+        p = LocalDubbingPipeline(translator="marian")
+        p._init_translator(source_lang="en", target_lang="es")
+
+        assert isinstance(p._translator, MarianTranslator)
+
+    def test_explicit_qwen3_overrides_auto_resolution(self, monkeypatch):
+        """translator='qwen3' bypasses the resolver — even on CPU."""
+        from videopython.ai.dubbing import pipeline as pipeline_mod
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.ai.generation.qwen3 import Qwen3Translator
+
+        monkeypatch.setattr(pipeline_mod, "select_device", lambda _d, mps_allowed=True: "cpu")
+        self._stub_qwen_init(monkeypatch)
+
+        p = LocalDubbingPipeline(translator="qwen3")
+        p._init_translator(source_lang="en", target_lang="es")
+
+        assert isinstance(p._translator, Qwen3Translator)
+
+    def test_dubber_propagates_translator_kwarg(self):
+        """VideoDubber.translator forwards into LocalDubbingPipeline.translator."""
+        from videopython.ai.dubbing import VideoDubber
+
+        dubber = VideoDubber(translator="qwen3")
+        dubber._init_local_pipeline()
+
+        assert dubber._local_pipeline.translator == "qwen3"
+
+    def test_dubber_default_translator_is_auto(self):
+        from videopython.ai.dubbing import VideoDubber
+
+        assert VideoDubber().translator == "auto"
+
+
+class TestTranslationFailuresOnResult:
+    """Qwen3Translator.translation_failures must surface onto DubbingResult."""
+
+    def test_translation_failures_propagated(self, sample_audio, monkeypatch):
+        """When Qwen marks an index as failed, the pipeline copies it to
+        DubbingResult.translation_failures."""
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.base.text.transcription import Transcription, TranscriptionSegment, TranscriptionWord
+
+        # Fake translator that marks segment 1 as a hard failure.
+        class FakeTranslator:
+            translation_failures = [1]
+
+            def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
+                return [
+                    TranslatedSegment(
+                        original_segment=s,
+                        translated_text=s.text if i != 1 else "",
+                        source_lang=source_lang,
+                        target_lang=target_lang,
+                    )
+                    for i, s in enumerate(segments)
+                ]
+
+        def fake_init_translator(self, source_lang, target_lang):
+            self._translator = FakeTranslator()
+
+        def fake_init_tts(self, language="en"):
+            class FakeTTS:
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                    sr = 24000
+                    n = int(sr * 0.2)
+                    return Audio(
+                        np.zeros(n, dtype=np.float32),
+                        AudioMetadata(
+                            sample_rate=sr,
+                            channels=1,
+                            sample_width=2,
+                            duration_seconds=0.2,
+                            frame_count=n,
+                        ),
+                    )
+
+            self._tts = FakeTTS()
+
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_translator", fake_init_translator)
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_tts", fake_init_tts)
+
+        words = [TranscriptionWord(start=0.0, end=1.0, word="hi")]
+        segs = [
+            TranscriptionSegment(start=0.0, end=1.0, text="hello", words=words),
+            TranscriptionSegment(start=1.0, end=2.0, text="bad", words=words),
+            TranscriptionSegment(start=2.0, end=3.0, text="bye", words=words),
+        ]
+        transcription = Transcription(segments=segs, language="en")
+
+        pipeline = LocalDubbingPipeline()
+        result = pipeline.process(
+            source_audio=sample_audio,
+            target_lang="es",
+            preserve_background=False,
+            voice_clone=False,
+            enable_diarization=False,
+            transcription=transcription,
+        )
+
+        assert result.translation_failures == [1]
+
+    def test_translation_failures_default_empty_for_marian(self, sample_audio, monkeypatch):
+        """A backend that returns no translation_failures (e.g. Marian)
+        leaves DubbingResult.translation_failures as an empty list."""
+        from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
+        from videopython.base.text.transcription import Transcription, TranscriptionSegment, TranscriptionWord
+
+        class FakeMarianlikeTranslator:
+            translation_failures: list[int] = []
+
+            def translate_segments(self, segments, target_lang, source_lang, progress_callback=None):
+                return [
+                    TranslatedSegment(
+                        original_segment=s,
+                        translated_text=s.text,
+                        source_lang=source_lang,
+                        target_lang=target_lang,
+                    )
+                    for s in segments
+                ]
+
+        def fake_init_translator(self, source_lang, target_lang):
+            self._translator = FakeMarianlikeTranslator()
+
+        def fake_init_tts(self, language="en"):
+            class FakeTTS:
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                    sr = 24000
+                    n = int(sr * 0.2)
+                    return Audio(
+                        np.zeros(n, dtype=np.float32),
+                        AudioMetadata(
+                            sample_rate=sr,
+                            channels=1,
+                            sample_width=2,
+                            duration_seconds=0.2,
+                            frame_count=n,
+                        ),
+                    )
+
+            self._tts = FakeTTS()
+
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_translator", fake_init_translator)
+        monkeypatch.setattr(LocalDubbingPipeline, "_init_tts", fake_init_tts)
+
+        words = [TranscriptionWord(start=0.0, end=1.0, word="hi")]
+        segs = [TranscriptionSegment(start=0.0, end=1.0, text="hello", words=words)]
+        transcription = Transcription(segments=segs, language="en")
+
+        pipeline = LocalDubbingPipeline()
+        result = pipeline.process(
+            source_audio=sample_audio,
+            target_lang="es",
+            preserve_background=False,
+            voice_clone=False,
+            enable_diarization=False,
+            transcription=transcription,
+        )
+
+        assert result.translation_failures == []

--- a/src/tests/ai/test_qwen3_translator.py
+++ b/src/tests/ai/test_qwen3_translator.py
@@ -1,0 +1,335 @@
+"""Unit tests for Qwen3Translator. No real model weights load — the
+``llama_cpp.Llama`` constructor is patched to return a fake LLM that
+returns canned JSON-line output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from videopython.ai.generation.qwen3 import (
+    Qwen3Translator,
+    _build_system_prompt,
+    _build_user_prompt,
+    _parse_jsonl_response,
+    _target_chars_for,
+)
+from videopython.base.text.transcription import TranscriptionSegment, TranscriptionWord
+
+
+def _seg(
+    start: float,
+    end: float,
+    text: str,
+    *,
+    speaker: str | None = None,
+    avg_logprob: float | None = None,
+) -> TranscriptionSegment:
+    return TranscriptionSegment(
+        start=start,
+        end=end,
+        text=text,
+        words=[TranscriptionWord(start=start, end=end, word=text)],
+        speaker=speaker,
+        avg_logprob=avg_logprob,
+    )
+
+
+class _FakeLlama:
+    """Stand-in for ``llama_cpp.Llama`` that yields scripted responses.
+
+    Constructed with a list of raw text outputs; each ``__call__`` pops
+    the next one. Records the prompt argument for inspection.
+    """
+
+    def __init__(self, scripted_outputs: list[str]) -> None:
+        self._outputs = list(scripted_outputs)
+        self.prompts_seen: list[str] = []
+
+    def __call__(self, prompt: str, **kwargs: Any) -> dict[str, Any]:
+        self.prompts_seen.append(prompt)
+        if not self._outputs:
+            raise AssertionError("FakeLlama got an unexpected extra call")
+        text = self._outputs.pop(0)
+        return {"choices": [{"text": text}]}
+
+
+def _patch_qwen_with_fake(monkeypatch: pytest.MonkeyPatch, fake: _FakeLlama) -> None:
+    """Replace _init_local so it installs the fake LLM without downloads."""
+
+    def fake_init_local(self: Qwen3Translator) -> None:
+        self._llm = fake
+
+    monkeypatch.setattr(Qwen3Translator, "_init_local", fake_init_local)
+
+
+class TestPromptBuilders:
+    """Pure builders, no model. Cheap to test exhaustively."""
+
+    def test_system_prompt_names_languages(self) -> None:
+        prompt = _build_system_prompt("ja", "es")
+        assert "Japanese" in prompt
+        assert "Spanish" in prompt
+        assert "JSON" in prompt
+
+    def test_system_prompt_unknown_language_falls_back_to_code(self) -> None:
+        prompt = _build_system_prompt("xx", "yy")
+        # Unknown codes show up verbatim — not ideal but doesn't crash.
+        assert "xx" in prompt and "yy" in prompt
+
+    def test_user_prompt_includes_target_chars(self) -> None:
+        seg = _seg(0.0, 10.0, "hello world")
+        prompt = _build_user_prompt([seg], "es")
+        assert '"target_chars"' in prompt
+        # 10s * 14 chars/sec * 1.15 ≈ 161
+        assert '"target_chars": 161' in prompt
+
+    def test_user_prompt_marks_low_confidence(self) -> None:
+        # Below the -1.0 hint threshold.
+        seg = _seg(0.0, 10.0, "questionable", avg_logprob=-2.0)
+        prompt = _build_user_prompt([seg], "es")
+        assert '"low_confidence": true' in prompt
+
+    def test_user_prompt_omits_low_confidence_when_healthy(self) -> None:
+        seg = _seg(0.0, 10.0, "clean", avg_logprob=-0.3)
+        prompt = _build_user_prompt([seg], "es")
+        assert "low_confidence" not in prompt
+
+    def test_user_prompt_omits_low_confidence_when_none(self) -> None:
+        seg = _seg(0.0, 10.0, "no logprob")
+        prompt = _build_user_prompt([seg], "es")
+        assert "low_confidence" not in prompt
+
+    def test_user_prompt_announces_segment_count(self) -> None:
+        segs = [_seg(0, 1, "a"), _seg(1, 2, "b"), _seg(2, 3, "c")]
+        prompt = _build_user_prompt(segs, "es")
+        assert "exactly 3 lines" in prompt
+
+    def test_target_chars_uses_language_rate(self) -> None:
+        # Spanish ~14 c/s, Japanese ~8 c/s, default ~12 c/s.
+        assert _target_chars_for(10.0, "es") == int(10.0 * 14.0 * 1.15)
+        assert _target_chars_for(10.0, "ja") == int(10.0 * 8.0 * 1.15)
+        assert _target_chars_for(10.0, "xx") == int(10.0 * 12.0 * 1.15)
+
+    def test_target_chars_minimum_one(self) -> None:
+        # Zero-duration shouldn't yield zero.
+        assert _target_chars_for(0.0, "es") == 1
+
+
+class TestJsonlParser:
+    """``_parse_jsonl_response`` is permissive — must tolerate fences and
+    preamble Qwen sometimes adds."""
+
+    def test_parses_clean_lines(self) -> None:
+        raw = '{"i": 0, "translated": "Hola"}\n{"i": 1, "translated": "Mundo"}'
+        assert _parse_jsonl_response(raw) == {0: "Hola", 1: "Mundo"}
+
+    def test_skips_markdown_fences(self) -> None:
+        raw = '```json\n{"i": 0, "translated": "Hola"}\n```'
+        assert _parse_jsonl_response(raw) == {0: "Hola"}
+
+    def test_skips_garbage_lines(self) -> None:
+        raw = 'Aquí están las traducciones:\n{"i": 0, "translated": "Hola"}\nEsa fue la última.\n'
+        assert _parse_jsonl_response(raw) == {0: "Hola"}
+
+    def test_returns_empty_on_pure_garbage(self) -> None:
+        raw = "I cannot translate this content."
+        assert _parse_jsonl_response(raw) == {}
+
+    def test_skips_objects_missing_required_keys(self) -> None:
+        raw = '{"i": 0}\n{"translated": "x"}\n{"i": 1, "translated": "OK"}'
+        assert _parse_jsonl_response(raw) == {1: "OK"}
+
+
+class TestQwenTranslateSegments:
+    """Integration of prompt → fake LLM → parse → output. No real model."""
+
+    def test_happy_path_one_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha"), _seg(5, 10, "beta")]
+        fake = _FakeLlama(['{"i": 0, "translated": "uno"}\n{"i": 1, "translated": "dos"}'])
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        assert [r.translated_text for r in result] == ["uno", "dos"]
+        assert translator.translation_failures == []
+        # Only one Qwen call (no retry needed).
+        assert len(fake.prompts_seen) == 1
+
+    def test_progress_callback_fires_three_times(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha")]
+        fake = _FakeLlama(['{"i": 0, "translated": "a"}'])
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        ticks: list[float] = []
+        translator.translate_segments(segs, target_lang="es", source_lang="en", progress_callback=ticks.append)
+
+        assert ticks == [0.5, 0.9, 1.0]
+
+    def test_punctuation_only_segments_not_sent_to_qwen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [
+            _seg(0, 5, "real text"),
+            _seg(5, 6, "..."),
+            _seg(6, 10, "more text"),
+        ]
+        fake = _FakeLlama(['{"i": 0, "translated": "uno"}\n{"i": 1, "translated": "dos"}'])
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        # The "..." segment gets translated_text="" without hitting Qwen.
+        assert result[0].translated_text == "uno"
+        assert result[1].translated_text == ""
+        assert result[2].translated_text == "dos"
+        # The prompt only included two real segments.
+        prompt = fake.prompts_seen[0]
+        assert "real text" in prompt
+        assert "more text" in prompt
+        assert "..." not in prompt
+
+
+class TestRetryAndFallback:
+    """Parse retry → Marian fallback → translation_failures."""
+
+    def test_retry_recovers_missing_segments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha"), _seg(5, 10, "beta")]
+        # First call: only segment 0 came back. Second call (retry) covers
+        # the missing one. Note retry uses local index 0 for the missing seg.
+        fake = _FakeLlama(
+            [
+                '{"i": 0, "translated": "uno"}',
+                '{"i": 0, "translated": "dos-retry"}',
+            ]
+        )
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        assert [r.translated_text for r in result] == ["uno", "dos-retry"]
+        assert translator.translation_failures == []
+        assert len(fake.prompts_seen) == 2
+
+    def test_marian_fallback_recovers_segments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha"), _seg(5, 10, "beta")]
+        # Both Qwen calls fail to return segment 1.
+        fake = _FakeLlama(
+            [
+                '{"i": 0, "translated": "uno"}',
+                "garbage",
+            ]
+        )
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        # Stub Marian so it returns translated text without loading models.
+        from videopython.ai.dubbing.models import TranslatedSegment
+        from videopython.ai.generation.translation import MarianTranslator
+
+        marian_calls: list[list[str]] = []
+
+        def fake_marian_translate(
+            self: MarianTranslator,
+            segments: list[TranscriptionSegment],
+            target_lang: str,
+            source_lang: str | None = None,
+            progress_callback: Any = None,
+        ) -> list[TranslatedSegment]:
+            marian_calls.append([s.text for s in segments])
+            return [
+                TranslatedSegment(
+                    original_segment=s,
+                    translated_text=f"marian-{s.text}",
+                    source_lang=source_lang or "en",
+                    target_lang=target_lang,
+                    speaker=s.speaker,
+                    start=s.start,
+                    end=s.end,
+                )
+                for s in segments
+            ]
+
+        monkeypatch.setattr(MarianTranslator, "translate_segments", fake_marian_translate)
+
+        translator = Qwen3Translator(device="cpu")
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        assert [r.translated_text for r in result] == ["uno", "marian-beta"]
+        assert translator.translation_failures == []
+        # Marian was called once with just the missing segment.
+        assert marian_calls == [["beta"]]
+
+    def test_failures_recorded_when_marian_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha"), _seg(5, 10, "beta")]
+        fake = _FakeLlama(
+            [
+                '{"i": 0, "translated": "uno"}',
+                "garbage",
+            ]
+        )
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu", marian_fallback=False)
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        # Failed segment gets empty translation; index recorded.
+        assert result[0].translated_text == "uno"
+        assert result[1].translated_text == ""
+        assert translator.translation_failures == [1]
+
+    def test_failures_recorded_when_marian_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha"), _seg(5, 10, "beta")]
+        fake = _FakeLlama(
+            [
+                '{"i": 0, "translated": "uno"}',
+                "garbage",
+            ]
+        )
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        from videopython.ai.generation.translation import MarianTranslator
+
+        def fake_marian_raises(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("marian model unavailable")
+
+        monkeypatch.setattr(MarianTranslator, "translate_segments", fake_marian_raises)
+
+        translator = Qwen3Translator(device="cpu", marian_fallback=True)
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        assert result[1].translated_text == ""
+        assert translator.translation_failures == [1]
+
+
+class TestUnloadAndProtocol:
+    def test_unload_clears_models(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        segs = [_seg(0, 5, "alpha")]
+        fake = _FakeLlama(['{"i": 0, "translated": "a"}'])
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        translator.translate_segments(segs, target_lang="es", source_lang="en")
+        assert translator._llm is fake
+
+        translator.unload()
+        assert translator._llm is None
+        assert translator._marian is None
+
+    def test_satisfies_translation_backend_protocol(self) -> None:
+        from videopython.ai.generation.translation import TranslationBackend
+
+        translator = Qwen3Translator(device="cpu")
+        assert isinstance(translator, TranslationBackend)
+
+    def test_supports_static_check(self) -> None:
+        assert Qwen3Translator.supports("en", "es") is True
+        assert Qwen3Translator.supports("en", "en") is True
+        assert Qwen3Translator.supports("en", "xx") is False
+
+    def test_get_supported_languages_returns_dict(self) -> None:
+        langs = Qwen3Translator.get_supported_languages()
+        assert isinstance(langs, dict)
+        assert "en" in langs and "es" in langs

--- a/src/videopython/ai/dubbing/__init__.py
+++ b/src/videopython/ai/dubbing/__init__.py
@@ -5,6 +5,7 @@ from videopython.ai.dubbing.models import DubbingResult, RevoiceResult, Separate
 from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
 from videopython.ai.dubbing.quality import GarbageTranscriptError, TranscriptQuality, assess_transcript
 from videopython.ai.dubbing.timing import TimingSynchronizer
+from videopython.ai.generation.translation import UnsupportedLanguageError
 
 __all__ = [
     "VideoDubber",
@@ -17,4 +18,5 @@ __all__ = [
     "GarbageTranscriptError",
     "TranscriptQuality",
     "assess_transcript",
+    "UnsupportedLanguageError",
 ]

--- a/src/videopython/ai/dubbing/dubber.py
+++ b/src/videopython/ai/dubbing/dubber.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from videopython.ai.dubbing.models import DubbingResult, RevoiceResult
-from videopython.ai.dubbing.pipeline import WhisperModel
+from videopython.ai.dubbing.pipeline import TranslatorChoice, WhisperModel
 
 if TYPE_CHECKING:
     from videopython.base.video import Video
@@ -44,6 +44,12 @@ class VideoDubber:
             but processing continues. Either way the
             :class:`TranscriptQuality` is exposed on ``DubbingResult`` for
             inspection.
+        translator: Translation backend to use. ``"auto"`` (default)
+            picks Qwen3 on GPU, MarianMT on CPU; ``"marian"`` and
+            ``"qwen3"`` force the named backend regardless of device.
+            See :class:`videopython.ai.generation.qwen3.Qwen3Translator`
+            for tradeoffs (Qwen3 is slower on CPU but produces
+            context-aware, length-budgeted output).
     """
 
     def __init__(
@@ -55,6 +61,7 @@ class VideoDubber:
         no_speech_threshold: float = 0.6,
         logprob_threshold: float | None = -1.0,
         strict_quality: bool = False,
+        translator: TranslatorChoice = "auto",
     ):
         self.device = device
         self.low_memory = low_memory
@@ -63,13 +70,15 @@ class VideoDubber:
         self.no_speech_threshold = no_speech_threshold
         self.logprob_threshold = logprob_threshold
         self.strict_quality = strict_quality
+        self.translator = translator
         self._local_pipeline: Any = None
         requested = device.lower() if isinstance(device, str) else "auto"
         logger.info(
-            "VideoDubber initialized with device=%s low_memory=%s whisper_model=%s",
+            "VideoDubber initialized with device=%s low_memory=%s whisper_model=%s translator=%s",
             requested,
             low_memory,
             whisper_model,
+            translator,
         )
 
     def _init_local_pipeline(self) -> None:
@@ -83,6 +92,7 @@ class VideoDubber:
             no_speech_threshold=self.no_speech_threshold,
             logprob_threshold=self.logprob_threshold,
             strict_quality=self.strict_quality,
+            translator=self.translator,
         )
 
     def dub(

--- a/src/videopython/ai/dubbing/models.py
+++ b/src/videopython/ai/dubbing/models.py
@@ -180,6 +180,11 @@ class DubbingResult:
         timing_summary: Aggregate stats over per-segment timing adjustments.
         transcript_quality: Heuristic quality assessment of the transcription
             (None when the pipeline returned early on an empty transcription).
+        translation_failures: Indices of segments where translation failed
+            entirely. Used by Qwen3Translator when both the primary call and
+            the per-segment Marian fallback fail; those segments are dubbed
+            with empty text. Empty list under MarianTranslator (Marian has
+            no failure mode that drops segments).
     """
 
     dubbed_audio: Audio
@@ -191,6 +196,7 @@ class DubbingResult:
     voice_samples: dict[str, Audio] = field(default_factory=dict)
     timing_summary: TimingSummary | None = None
     transcript_quality: TranscriptQuality | None = None
+    translation_failures: list[int] = field(default_factory=list)
 
     @property
     def num_segments(self) -> int:

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -9,12 +9,22 @@ from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import numpy as np
 
+from videopython.ai._device import select_device
 from videopython.ai.dubbing.models import DubbingResult, RevoiceResult, SeparatedAudio, TimingSummary
 from videopython.ai.dubbing.quality import GarbageTranscriptError, assess_transcript
 from videopython.ai.dubbing.timing import TimingSynchronizer
+from videopython.ai.generation.qwen3 import Qwen3Translator
+from videopython.ai.generation.translation import (
+    MarianTranslator,
+    TranslationBackend,
+    UnsupportedLanguageError,
+)
 
 if TYPE_CHECKING:
     from videopython.base.audio import Audio
+
+
+TranslatorChoice = Literal["auto", "marian", "qwen3"]
 
 
 def _peak_match(target: Audio, reference: Audio) -> Audio:
@@ -74,6 +84,7 @@ class LocalDubbingPipeline:
         no_speech_threshold: float = 0.6,
         logprob_threshold: float | None = -1.0,
         strict_quality: bool = False,
+        translator: TranslatorChoice = "auto",
     ):
         self.device = device
         self.low_memory = low_memory
@@ -82,12 +93,14 @@ class LocalDubbingPipeline:
         self.no_speech_threshold = no_speech_threshold
         self.logprob_threshold = logprob_threshold
         self.strict_quality = strict_quality
+        self.translator = translator
         requested = device.lower() if isinstance(device, str) else "auto"
         logger.info(
-            "LocalDubbingPipeline initialized with device=%s low_memory=%s whisper_model=%s",
+            "LocalDubbingPipeline initialized with device=%s low_memory=%s whisper_model=%s translator=%s",
             requested,
             low_memory,
             whisper_model,
+            translator,
         )
 
         self._transcriber: Any = None
@@ -128,11 +141,64 @@ class LocalDubbingPipeline:
             logprob_threshold=self.logprob_threshold,
         )
 
-    def _init_translator(self) -> None:
-        """Initialize the translation model."""
-        from videopython.ai.generation.translation import TextTranslator
+    def _init_translator(self, source_lang: str, target_lang: str) -> None:
+        """Initialize the translation backend.
 
-        self._translator = TextTranslator(device=self.device)
+        Resolves the configured ``self.translator`` choice into a concrete
+        backend. ``"auto"`` uses :meth:`_resolve_translator_auto`; explicit
+        choices instantiate the named backend directly. Re-initialization
+        is a no-op when ``self._translator`` is already a matching instance
+        for the same language pair (handled at call sites via the existing
+        ``self._translator is None`` gate).
+        """
+        if self.translator == "marian":
+            self._translator = MarianTranslator(device=self.device)
+        elif self.translator == "qwen3":
+            self._translator = Qwen3Translator(device=self.device)
+        else:  # "auto"
+            self._translator = self._resolve_translator_auto(source_lang, target_lang)
+
+    def _resolve_translator_auto(self, source_lang: str, target_lang: str) -> TranslationBackend:
+        """Pick a backend based on language coverage AND device.
+
+        Qwen3-4B Q4_K_M on CPU is roughly 10-15x slower than MarianMT (M2.1
+        spike on dreams_15min.mp4). The resolver picks Marian on CPU
+        whenever it covers the language pair and only escalates to Qwen
+        when a GPU is available or Marian doesn't cover the pair.
+        """
+        device = select_device(self.device, mps_allowed=True)
+        has_gpu = device in ("cuda", "mps")
+
+        # 1. GPU + Qwen covers the pair → Qwen wins (best quality).
+        if has_gpu and Qwen3Translator.supports(source_lang, target_lang):
+            logger.info(
+                "translator: auto-selected qwen3 (device=%s, supports %s->%s)",
+                device,
+                source_lang,
+                target_lang,
+            )
+            return Qwen3Translator(device=self.device)
+
+        # 2. Marian covers the pair → Marian (fast).
+        if MarianTranslator.has_model_for(source_lang, target_lang):
+            if has_gpu:
+                reason = f"Qwen does not cover {source_lang}->{target_lang}"
+            else:
+                reason = f"device={device} (Qwen would be ~10-15x slower; pass translator='qwen3' to override)"
+            logger.info("translator: auto-selected marian (%s)", reason)
+            return MarianTranslator(device=self.device)
+
+        # 3. CPU + only Qwen covers it: warn loudly and use Qwen anyway.
+        if Qwen3Translator.supports(source_lang, target_lang):
+            logger.warning(
+                "translator: auto-selected qwen3 on CPU (%s->%s not in Marian); "
+                "translation will be slow (~10-15x MarianMT). Consider GPU.",
+                source_lang,
+                target_lang,
+            )
+            return Qwen3Translator(device=self.device)
+
+        raise UnsupportedLanguageError(source_lang, target_lang)
 
     def _init_tts(self, language: str = "en") -> None:
         """Initialize the text-to-speech model."""
@@ -430,7 +496,7 @@ class LocalDubbingPipeline:
 
         report_progress("Translating text", 0.35)
         if self._translator is None:
-            self._init_translator()
+            self._init_translator(source_lang=detected_lang, target_lang=target_lang)
 
         # Translation stage spans 0.35 → 0.50 of overall pipeline progress.
         # MarianMT runs sequentially over 8-segment batches; on a 15-min
@@ -446,6 +512,9 @@ class LocalDubbingPipeline:
             source_lang=detected_lang,
             progress_callback=_on_translation_progress,
         )
+        # Capture per-segment failures (always empty for Marian) before
+        # _maybe_unload nukes the backend in low_memory mode.
+        translation_failures = list(self._translator.translation_failures)
         self._maybe_unload("_translator")
 
         report_progress("Generating dubbed speech", 0.50)
@@ -559,6 +628,7 @@ class LocalDubbingPipeline:
             voice_samples=voice_samples,
             timing_summary=timing_summary,
             transcript_quality=transcript_quality,
+            translation_failures=translation_failures,
         )
 
     def revoice(

--- a/src/videopython/ai/generation/qwen3.py
+++ b/src/videopython/ai/generation/qwen3.py
@@ -1,0 +1,394 @@
+"""Qwen3-Instruct translation backend (M2).
+
+GGUF inference via ``llama-cpp-python``. One model for now —
+``Qwen3-4B-Instruct-2507`` (Apache-2.0, ~2.4 GB Q4_K_M). The original M2
+plan called for low/medium/high tiers (4B / 8B / 30B-A3B); we deferred
+that complexity until M2.4 eval data shows the larger models actually
+deliver a quality lift worth the VRAM cost.
+
+Latency note: on CPU the 4B model is roughly 10-15× slower than
+:class:`MarianTranslator` per the M2.1 spike. On GPU it lands within ~2×
+of Marian. Translation quality is decisively higher than Marian on
+context-dependent and idiomatic content. The pipeline's
+:class:`LocalDubbingPipeline` chooses based on ``device`` + the
+``translator`` kwarg.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+from videopython.ai._device import release_device_memory, select_device
+from videopython.ai.generation.translation import (
+    LANGUAGE_NAMES,
+    MarianTranslator,
+    _is_translatable_text,
+)
+from videopython.base.text.transcription import TranscriptionSegment
+
+# Imported under TYPE_CHECKING only — qwen3 sits below videopython.ai.dubbing
+# in the import order (pipeline.py imports Qwen3Translator), so a top-level
+# import would create a cycle. The runtime constructor reaches for it via a
+# lazy local import inside translate_segments.
+if TYPE_CHECKING:
+    from videopython.ai.dubbing.models import TranslatedSegment
+
+logger = logging.getLogger(__name__)
+
+
+# Default model. Constants are module-level so an eval harness or future
+# tier pick can override at the call site without forking the class.
+DEFAULT_REPO_ID = "unsloth/Qwen3-4B-Instruct-2507-GGUF"
+DEFAULT_FILENAME = "Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+
+
+# Average characters per second of natural speech, used to derive the
+# per-segment ``target_chars`` budget. Rough field measurements; the prompt
+# tells Qwen this is a target ±15%, not a hard cap.
+_SPEECH_CHARS_PER_SEC: dict[str, float] = {
+    "en": 14.0,
+    "es": 14.0,
+    "pt": 13.5,
+    "it": 13.5,
+    "fr": 13.0,
+    "de": 12.0,
+    "pl": 12.5,
+    "nl": 12.5,
+    "ru": 12.0,
+    "uk": 12.0,
+    "cs": 12.0,
+    "sk": 12.0,
+    "ro": 13.0,
+    "hu": 12.0,
+    "fi": 11.0,
+    "sv": 12.5,
+    "da": 13.0,
+    "nb": 13.0,
+    "no": 13.0,
+    "ja": 8.0,
+    "ko": 9.0,
+    "zh": 7.0,
+    "zh-CN": 7.0,
+    "zh-TW": 7.0,
+    "th": 9.0,
+    "vi": 11.0,
+    "ar": 10.0,
+    "he": 10.0,
+    "hi": 11.0,
+    "ta": 10.0,
+    "id": 12.0,
+    "ms": 12.0,
+    "tr": 12.0,
+    "el": 12.0,
+}
+_SPEECH_CHARS_DEFAULT = 12.0
+
+
+# Qwen's avg_logprob is in [-inf, 0]. Values below this threshold mark a
+# transcription window we don't trust — Qwen gets a hint not to over-anchor.
+_LOW_LOGPROB_HINT_THRESHOLD = -1.0
+
+
+def _target_chars_for(duration_seconds: float, target_lang: str) -> int:
+    """Character-count budget for a segment of ``duration_seconds`` in ``target_lang``."""
+    rate = _SPEECH_CHARS_PER_SEC.get(target_lang, _SPEECH_CHARS_DEFAULT)
+    return max(1, int(duration_seconds * rate * 1.15))
+
+
+def _build_system_prompt(source_lang: str, target_lang: str) -> str:
+    """Stable system + format spec. The few-shot example uses generic
+    phrases (no fixture-specific content) so the prompt generalizes.
+    """
+    src_name = LANGUAGE_NAMES.get(source_lang, source_lang)
+    tgt_name = LANGUAGE_NAMES.get(target_lang, target_lang)
+    return (
+        f"You are a professional dub translator. Translate from {src_name} to {tgt_name}.\n"
+        "Preserve register and proper nouns. Match each segment's syllable count so the\n"
+        "dub fits the original timing — translation is for spoken audio, not subtitles.\n"
+        "Aim for ``target_chars`` characters per segment (±15%).\n"
+        "If a segment is non-speech filler (grunts, laughter, music cues) keep it as filler in\n"
+        "the target language; do not invent content.\n"
+        "If a segment carries ``low_confidence``, the source transcription may be wrong;\n"
+        "translate conservatively rather than committing to a specific phrase.\n"
+        "\n"
+        "Output one JSON object per line, no preamble, no commentary, no markdown:\n"
+        '{"i": <segment_index>, "translated": "<text>"}\n'
+    )
+
+
+def _build_user_prompt(segments: list[TranscriptionSegment], target_lang: str) -> str:
+    """Per-call body — the segments to translate."""
+    lines: list[str] = []
+    for idx, seg in enumerate(segments):
+        budget = _target_chars_for(seg.end - seg.start, target_lang)
+        entry: dict[str, Any] = {
+            "i": idx,
+            "text": seg.text,
+            "target_chars": budget,
+        }
+        if seg.avg_logprob is not None and seg.avg_logprob < _LOW_LOGPROB_HINT_THRESHOLD:
+            entry["low_confidence"] = True
+        lines.append(json.dumps(entry, ensure_ascii=False))
+    request_block = "\n".join(lines)
+    return (
+        f"Input segments:\n{request_block}\nTranslations (one JSON object per line, exactly {len(segments)} lines):\n"
+    )
+
+
+def _parse_jsonl_response(raw: str) -> dict[int, str]:
+    """Extract ``{i: translated_text}`` from Qwen output. Permissive — tolerates
+    markdown fences and preamble lines that the model occasionally adds."""
+    parsed: dict[int, str] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("```"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "i" in obj and "translated" in obj:
+            try:
+                parsed[int(obj["i"])] = str(obj["translated"])
+            except (TypeError, ValueError):
+                continue
+    return parsed
+
+
+class Qwen3Translator:
+    """Qwen3-Instruct translation via llama-cpp-python (GGUF).
+
+    Args:
+        device: ``"cuda"``, ``"mps"``, ``"cpu"``, or ``None`` for auto.
+        marian_fallback: If True (default), fall back to Marian for any
+            segment that fails Qwen's parse retry. Set False to disable
+            (failures land in ``translation_failures`` instead).
+        repo_id: HuggingFace repo for the GGUF weights. Defaults to
+            ``DEFAULT_REPO_ID``; override for eval harnesses.
+        filename: GGUF filename within ``repo_id``. Defaults to
+            ``DEFAULT_FILENAME``.
+        n_ctx: llama.cpp context window. 8192 is plenty for a 15-min source;
+            raise for very long sources. Hard cap is the model's training
+            context (262K for Qwen3-4B-Instruct-2507).
+        max_tokens: Generation cap per call. 4× the input character count
+            is a safe upper bound for translation output.
+        temperature: Decoding temperature. 0.1 keeps output structurally
+            consistent (high JSON parse rate) without being deterministic.
+    """
+
+    def __init__(
+        self,
+        device: str | None = None,
+        marian_fallback: bool = True,
+        repo_id: str = DEFAULT_REPO_ID,
+        filename: str = DEFAULT_FILENAME,
+        n_ctx: int = 8192,
+        max_tokens: int = 4096,
+        temperature: float = 0.1,
+    ):
+        self.device = device
+        self.marian_fallback = marian_fallback
+        self.repo_id = repo_id
+        self.filename = filename
+        self.n_ctx = n_ctx
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+        # Lazily initialized.
+        self._llm: Any = None
+        self._marian: MarianTranslator | None = None
+        # Tracks which segment indices both Qwen and Marian failed on. The
+        # pipeline reads this to populate DubbingResult.translation_failures.
+        self._failures_last_call: list[int] = []
+
+    def _init_local(self) -> None:
+        """Download (if needed) and load the GGUF weights."""
+        from huggingface_hub import hf_hub_download
+        from llama_cpp import Llama
+
+        # Warn about CPU latency at load time (not __init__) — the warning is
+        # about runtime cost, which only applies once the model is actually
+        # loaded. Construction is cheap; tests instantiate Qwen3Translator
+        # without intending to run inference, so __init__ shouldn't shout.
+        resolved = select_device(self.device, mps_allowed=True)
+        if resolved == "cpu":
+            logger.warning(
+                "Qwen3Translator on CPU is ~10-15x slower than MarianTranslator. "
+                "Consider translator='marian' for development or pass device='cuda'/'mps'.",
+            )
+
+        logger.info("Qwen3Translator: loading %s", self.filename)
+        model_path = Path(hf_hub_download(repo_id=self.repo_id, filename=self.filename))
+
+        # n_gpu_layers=-1 offloads everything to GPU when one is available;
+        # 0 forces CPU. llama-cpp-python's Metal/CUDA support detects and
+        # uses whatever the build was compiled against.
+        n_gpu_layers = 0 if resolved == "cpu" else -1
+        # n_threads omitted on purpose — llama-cpp-python defaults to a
+        # sensible per-host value (min(physical cores, 4)). Hardcoding 8
+        # under-utilizes a 16-core box and over-subscribes a 4-core CI.
+        self._llm = Llama(
+            model_path=str(model_path),
+            n_ctx=self.n_ctx,
+            n_gpu_layers=n_gpu_layers,
+            verbose=False,
+        )
+
+    def _qwen_translate(
+        self, segments: list[TranscriptionSegment], target_lang: str, source_lang: str
+    ) -> dict[int, str]:
+        """One Qwen call to translate all segments. Empty result on parse failure."""
+        if self._llm is None:
+            self._init_local()
+
+        system = _build_system_prompt(source_lang, target_lang)
+        user = _build_user_prompt(segments, target_lang)
+        prompt = system + user
+
+        response = self._llm(
+            prompt,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            stop=None,
+        )
+        raw = response["choices"][0]["text"]
+        return _parse_jsonl_response(raw)
+
+    def translate_segments(
+        self,
+        segments: list[TranscriptionSegment],
+        target_lang: str,
+        source_lang: str | None = None,
+        progress_callback: Callable[[float], None] | None = None,
+    ) -> list[TranslatedSegment]:
+        """Translate segments via Qwen with parse-retry + optional Marian fallback.
+
+        The progress_callback fires three times: 0.5 after the first
+        Qwen call, 0.9 after the optional retry/fallback, 1.0 at the
+        end. M2.1 phase 2 confirmed smaller batches don't help on CPU,
+        so finer-grained progress isn't possible without fake ticks.
+        """
+        effective_source = source_lang or "en"
+        self._failures_last_call = []
+
+        translatable_indices = [i for i, seg in enumerate(segments) if _is_translatable_text(seg.text)]
+        translatable_segments = [segments[i] for i in translatable_indices]
+
+        # First attempt.
+        if translatable_segments:
+            qwen_results = self._qwen_translate(translatable_segments, target_lang, effective_source)
+        else:
+            qwen_results = {}
+        if progress_callback is not None:
+            progress_callback(0.5)
+
+        # Identify segments Qwen failed (unparseable or missing index).
+        # Indices in qwen_results / translatable_segments are 0-based positions
+        # within translatable_segments, NOT positions in the full ``segments``
+        # list. Map back at the end.
+        missing_local_indices = [li for li in range(len(translatable_segments)) if li not in qwen_results]
+
+        # Retry once on the missing subset with stricter instructions.
+        if missing_local_indices:
+            retry_segments = [translatable_segments[li] for li in missing_local_indices]
+            logger.info(
+                "Qwen3Translator: retrying %d/%d segments after first parse",
+                len(retry_segments),
+                len(translatable_segments),
+            )
+            retry_results = self._qwen_translate(retry_segments, target_lang, effective_source)
+            # retry_results uses 0..len(retry_segments)-1 as keys; map back.
+            for retry_local, original_local in enumerate(missing_local_indices):
+                if retry_local in retry_results:
+                    qwen_results[original_local] = retry_results[retry_local]
+        if progress_callback is not None:
+            progress_callback(0.9)
+
+        # Anything still missing → Marian fallback (or surface as failure).
+        still_missing_local = [li for li in range(len(translatable_segments)) if li not in qwen_results]
+        if still_missing_local and self.marian_fallback:
+            fallback_segments = [translatable_segments[li] for li in still_missing_local]
+            logger.warning(
+                "Qwen3Translator: falling back to Marian for %d segments after retry",
+                len(fallback_segments),
+            )
+            if self._marian is None:
+                self._marian = MarianTranslator(device=self.device)
+            try:
+                fallback_translated = self._marian.translate_segments(
+                    fallback_segments, target_lang=target_lang, source_lang=effective_source
+                )
+                for li, ts in zip(still_missing_local, fallback_translated):
+                    qwen_results[li] = ts.translated_text
+            except Exception as exc:
+                logger.warning("Qwen3Translator: Marian fallback failed (%s)", exc)
+                # Leave them missing; they'll be recorded as failures below.
+
+        # Whatever's still missing is a hard failure. Record original-segment
+        # indices (positions in the full ``segments`` list) so the caller
+        # can reconcile against translated_segments.
+        for li in range(len(translatable_segments)):
+            if li not in qwen_results:
+                self._failures_last_call.append(translatable_indices[li])
+
+        # Lazy import to avoid a circular dep through videopython.ai.dubbing
+        # (see TYPE_CHECKING import at the top of the module).
+        from videopython.ai.dubbing.models import TranslatedSegment
+
+        # Materialize TranslatedSegments parallel to the input list.
+        translated_segments: list[TranslatedSegment] = []
+        local_translation_for_orig: dict[int, str] = {}
+        for li, original_idx in enumerate(translatable_indices):
+            if li in qwen_results:
+                local_translation_for_orig[original_idx] = qwen_results[li]
+
+        for i, segment in enumerate(segments):
+            translated_text = local_translation_for_orig.get(i, "")
+            translated_segments.append(
+                TranslatedSegment(
+                    original_segment=segment,
+                    translated_text=translated_text,
+                    source_lang=effective_source,
+                    target_lang=target_lang,
+                    speaker=segment.speaker,
+                    start=segment.start,
+                    end=segment.end,
+                )
+            )
+
+        if progress_callback is not None:
+            progress_callback(1.0)
+        return translated_segments
+
+    @property
+    def translation_failures(self) -> list[int]:
+        """Indices (in the most recent ``segments`` input) where translation
+        failed entirely. Empty if all segments translated.
+        """
+        return list(self._failures_last_call)
+
+    def unload(self) -> None:
+        """Release the model so the next call re-initializes. Used by
+        :class:`LocalDubbingPipeline` in ``low_memory`` mode."""
+        self._llm = None
+        if self._marian is not None:
+            self._marian.unload()
+            self._marian = None
+        release_device_memory(self.device)
+
+    @staticmethod
+    def get_supported_languages() -> dict[str, str]:
+        """Qwen handles all of Marian's language set plus more; we expose the
+        Marian set for now and let M2.4 eval add anything Qwen-only.
+        """
+        return LANGUAGE_NAMES.copy()
+
+    @classmethod
+    def supports(cls, source_lang: str, target_lang: str) -> bool:
+        """Coverage hint for the M2.3 ``auto`` resolver."""
+        if source_lang == target_lang:
+            return True
+        return source_lang in LANGUAGE_NAMES and target_lang in LANGUAGE_NAMES

--- a/src/videopython/ai/generation/translation.py
+++ b/src/videopython/ai/generation/translation.py
@@ -1,12 +1,49 @@
-"""Text translation using local Helsinki-NLP models."""
+"""Text translation backends.
+
+Two backends share the :class:`TranslationBackend` protocol:
+
+- :class:`MarianTranslator` (HuggingFace Helsinki-NLP MarianMT) — fast,
+  segment-isolated, available for ~30 language pairs. Default on CPU.
+- :class:`Qwen3Translator` (Qwen3-4B/8B/14B-Instruct via llama-cpp-python) —
+  slower but produces context-aware, length-budgeted translations. Default
+  on GPU.
+
+The pipeline picks via :class:`videopython.ai.dubbing.pipeline` based on a
+``translator`` kwarg (``"auto"`` resolves at runtime).
+"""
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
 
 from videopython.ai._device import log_device_initialization, release_device_memory, select_device
-from videopython.ai.dubbing.models import TranslatedSegment
 from videopython.base.text.transcription import TranscriptionSegment
+
+# Imported under TYPE_CHECKING to avoid a circular dep through
+# videopython.ai.dubbing (the dubbing pipeline imports both
+# MarianTranslator and Qwen3Translator, which both import
+# TranslatedSegment from dubbing.models). Runtime users do a lazy
+# local import inside translate_segments.
+if TYPE_CHECKING:
+    from videopython.ai.dubbing.models import TranslatedSegment
+
+
+class UnsupportedLanguageError(ValueError):
+    """Raised when no available translation backend supports a given
+    ``(source, target)`` language pair.
+
+    Carries the requested pair so callers can introspect:
+
+        try:
+            dubber.dub(video, target_lang="xh")
+        except UnsupportedLanguageError as e:
+            print(f"No backend covers {e.source_lang}->{e.target_lang}")
+    """
+
+    def __init__(self, source_lang: str, target_lang: str, message: str | None = None):
+        self.source_lang = source_lang
+        self.target_lang = target_lang
+        super().__init__(message or f"No translation backend supports {source_lang}->{target_lang}")
 
 
 def _is_translatable_text(text: str) -> bool:
@@ -17,6 +54,36 @@ def _is_translatable_text(text: str) -> bool:
     from. Require at least 2 alphanumeric characters to filter these out.
     """
     return sum(1 for c in text if c.isalnum()) >= 2
+
+
+@runtime_checkable
+class TranslationBackend(Protocol):
+    """Pipeline-facing translation interface.
+
+    Both :class:`MarianTranslator` and :class:`Qwen3Translator` satisfy
+    this. The pipeline only depends on these methods.
+    """
+
+    def translate_segments(
+        self,
+        segments: list[TranscriptionSegment],
+        target_lang: str,
+        source_lang: str | None = None,
+        progress_callback: Callable[[float], None] | None = None,
+    ) -> list[TranslatedSegment]: ...
+
+    def unload(self) -> None: ...
+
+    @property
+    def translation_failures(self) -> list[int]:
+        """Indices into the most recent ``segments`` input where the backend
+        could not produce a translation. Empty for backends that never fail
+        per-segment (e.g. MarianTranslator). The dubbing pipeline copies
+        this onto :class:`DubbingResult.translation_failures`."""
+        ...
+
+    @staticmethod
+    def get_supported_languages() -> dict[str, str]: ...
 
 
 LANGUAGE_NAMES = {
@@ -56,8 +123,8 @@ LANGUAGE_NAMES = {
 }
 
 
-class TextTranslator:
-    """Translates text between languages using local seq2seq models."""
+class MarianTranslator:
+    """Translates text between languages using local Helsinki-NLP MarianMT models."""
 
     # Languages without a direct opus-mt-{src}-{tgt} model. Maps (source, target)
     # to an alternative HuggingFace model identifier.
@@ -67,6 +134,25 @@ class TextTranslator:
         ("en", "ja"): "Helsinki-NLP/opus-mt-en-jap",
         ("en", "pl"): "Helsinki-NLP/opus-mt-en-zlw",
     }
+
+    @classmethod
+    def has_model_for(cls, source_lang: str, target_lang: str) -> bool:
+        """Return True if Marian has (or is likely to have) a model for ``(source, target)``.
+
+        Same-language pairs return True (translation is the identity).
+        Otherwise: True if either an entry in ``_MODEL_OVERRIDES`` exists or
+        both languages are in :data:`LANGUAGE_NAMES`. The latter is a
+        permissive proxy — Marian publishes ``opus-mt-{src}-{tgt}`` for
+        most ISO-639-1 pairs we expose, but not all (e.g. some Asian-to-
+        Asian pairs route through English). Used by the M2.3 ``auto``
+        resolver as a *coverage hint*; the actual existence check happens
+        at first-use download time.
+        """
+        if source_lang == target_lang:
+            return True
+        if (source_lang, target_lang) in cls._MODEL_OVERRIDES:
+            return True
+        return source_lang in LANGUAGE_NAMES and target_lang in LANGUAGE_NAMES
 
     def __init__(self, model_name: str | None = None, device: str | None = None):
         self.model_name = model_name
@@ -194,6 +280,10 @@ class TextTranslator:
         callers can render translation-stage progress without knowing the
         batch size.
         """
+        # Lazy import to avoid a circular dep through videopython.ai.dubbing
+        # (see TYPE_CHECKING import at the top of the module).
+        from videopython.ai.dubbing.models import TranslatedSegment
+
         effective_source = source_lang or "en"
 
         translatable_indices = [i for i, segment in enumerate(segments) if _is_translatable_text(segment.text)]
@@ -230,6 +320,20 @@ class TextTranslator:
         self._current_lang_pair = None
         release_device_memory(self.device)
 
+    @property
+    def translation_failures(self) -> list[int]:
+        """Marian never fails per-segment (worst case it produces poor
+        output, not no output). Always empty; satisfies the
+        :class:`TranslationBackend` protocol."""
+        return []
+
     @staticmethod
     def get_supported_languages() -> dict[str, str]:
         return LANGUAGE_NAMES.copy()
+
+
+# Back-compat alias. ``TextTranslator`` was the class name through 0.28.x;
+# 0.29.0 renames to ``MarianTranslator`` to make room for ``Qwen3Translator``
+# behind a shared :class:`TranslationBackend` protocol. The alias will be
+# removed in 0.30.0.
+TextTranslator = MarianTranslator

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -11,6 +11,36 @@ from videopython.base.text.transcription import Transcription, TranscriptionSegm
 from videopython.base.video import Video
 
 
+def _attach_confidence_by_overlap(
+    target_segments: list[TranscriptionSegment],
+    source_segments: list[TranscriptionSegment],
+) -> None:
+    """Stamp Whisper confidence (avg_logprob, no_speech_prob, compression_ratio)
+    onto ``target_segments`` from the ``source_segments`` they overlap most with.
+
+    Used to re-attach per-segment confidence after diarization rebuilds segments
+    from words and drops the original Whisper-segment metadata. Whisper's
+    confidence is window-level, not phoneme-level, so overlap-by-time is the
+    right granularity — re-deriving per-word and re-aggregating wouldn't be
+    more accurate.
+
+    Mutates ``target_segments`` in place. Segments with no overlap to any
+    source segment are left untouched (their confidence stays None).
+    """
+    for tgt in target_segments:
+        best_overlap = 0.0
+        best_src: TranscriptionSegment | None = None
+        for src in source_segments:
+            overlap = max(0.0, min(tgt.end, src.end) - max(tgt.start, src.start))
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_src = src
+        if best_src is not None:
+            tgt.avg_logprob = best_src.avg_logprob
+            tgt.no_speech_prob = best_src.no_speech_prob
+            tgt.compression_ratio = best_src.compression_ratio
+
+
 class AudioToText:
     """Transcription service for audio and video using local Whisper models.
 
@@ -295,6 +325,13 @@ class AudioToText:
 
         transcription = self._process_transcription_result(transcription_result)
 
+        # Capture original Whisper segments before flattening to words. The
+        # diarization rebuild via Transcription(words=...) regroups by speaker,
+        # which loses the per-segment confidence M1.3 plumbed through. We
+        # re-attach by max-overlap match below so M2's confidence-aware
+        # translation prompts have signal on the diarized path too.
+        whisper_segments = transcription.segments
+
         all_words: list[TranscriptionWord] = []
         for seg in transcription.segments:
             all_words.extend(seg.words)
@@ -302,7 +339,9 @@ class AudioToText:
         if all_words:
             all_words = self._assign_speakers_to_words(all_words, diarization_result)
 
-        return Transcription(words=all_words, language=transcription.language)
+        rebuilt = Transcription(words=all_words, language=transcription.language)
+        _attach_confidence_by_overlap(rebuilt.segments, whisper_segments)
+        return rebuilt
 
     def _transcribe_local(self, audio: Audio) -> Transcription:
         """Transcribe using local Whisper model.

--- a/uv.lock
+++ b/uv.lock
@@ -938,6 +938,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1850,6 +1859,19 @@ sdist = { url = "https://files.pythonhosted.org/packages/b8/39/6fc58ca81492db047
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/73/3d757cb3fc16f0f9794dd289bcd0c4a031d9cf54d8137d6b984b2d02edf3/lightning_utilities-0.15.2-py3-none-any.whl", hash = "sha256:ad3ab1703775044bbf880dbf7ddaaac899396c96315f3aa1779cec9d618a9841", size = 29431, upload-time = "2025-08-06T13:57:38.046Z" },
 ]
+
+[[package]]
+name = "llama-cpp-python"
+version = "0.3.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "diskcache" },
+    { name = "jinja2" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/ee/206c17c34ce1ba4cb5518c846e27b1f71f42a971fcfa008d24c871729e12/llama_cpp_python-0.3.22.tar.gz", hash = "sha256:93c54af95d917fe6d6d70039efe16ca9240634d11010f5aaf795261b9f43042f", size = 67970237, upload-time = "2026-05-02T22:40:56.385Z" }
 
 [[package]]
 name = "llvmlite"
@@ -5618,7 +5640,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5637,6 +5659,7 @@ ai = [
     { name = "diffusers" },
     { name = "easyocr" },
     { name = "hf-transfer" },
+    { name = "llama-cpp-python" },
     { name = "numba" },
     { name = "ollama" },
     { name = "openai-whisper" },
@@ -5662,6 +5685,7 @@ ai = [
     { name = "diffusers" },
     { name = "easyocr" },
     { name = "hf-transfer" },
+    { name = "llama-cpp-python" },
     { name = "numba" },
     { name = "ollama" },
     { name = "openai-whisper" },
@@ -5700,6 +5724,7 @@ requires-dist = [
     { name = "diffusers", marker = "extra == 'ai'", specifier = ">=0.30.0" },
     { name = "easyocr", marker = "extra == 'ai'", specifier = ">=1.7.0" },
     { name = "hf-transfer", marker = "extra == 'ai'", specifier = ">=0.1.9" },
+    { name = "llama-cpp-python", marker = "extra == 'ai'", specifier = ">=0.3.0" },
     { name = "numba", marker = "extra == 'ai'", specifier = ">=0.61.0" },
     { name = "numpy", specifier = ">=1.25.2" },
     { name = "ollama", marker = "extra == 'ai'", specifier = ">=0.4.5" },
@@ -5729,6 +5754,7 @@ ai = [
     { name = "diffusers", specifier = ">=0.30.0" },
     { name = "easyocr", specifier = ">=1.7.0" },
     { name = "hf-transfer", specifier = ">=0.1.9" },
+    { name = "llama-cpp-python", specifier = ">=0.3.0" },
     { name = "numba", specifier = ">=0.61.0" },
     { name = "ollama", specifier = ">=0.4.5" },
     { name = "openai-whisper", specifier = ">=20240930" },


### PR DESCRIPTION
Adds Qwen3-4B-Instruct (GGUF via llama-cpp-python) as a context-aware translation backend behind a shared TranslationBackend protocol with MarianTranslator. LocalDubbingPipeline gains a `translator` kwarg ("auto"|"marian"|"qwen3"); auto picks Qwen on GPU and Marian on CPU based on the M2.1 spike showing Qwen3-4B Q4_K_M is ~10-15x slower than Marian on CPU and within ~2x on GPU.

Qwen3Translator builds a JSONL prompt with per-segment target_chars budgets (lang-specific speech-rate table) and low_confidence hints sourced from Whisper's avg_logprob. Failures retry once, then fall back to Marian per-segment; hard failures surface on DubbingResult.translation_failures.

Whisper segment confidence (avg_logprob, no_speech_prob, compression_ratio) is now re-attached after the diarization rebuild via _attach_confidence_by_overlap so the confidence-aware translation prompts have signal on the diarized path.

TextTranslator is kept as an alias for MarianTranslator through 0.29.x.

Bumps to 0.28.1.