### PR TITLE
M4: Source-prosody-conditioned Chatterbox expressiveness (0.28.3)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 0.28.3
+
+### Added
+
+- `Expressiveness` dataclass exposed from `videopython.ai.dubbing` carrying the three Chatterbox `generate()` knobs (`exaggeration`, `cfg_weight`, `temperature`) as `Optional[float]`. `None` means "don't pass the kwarg, use Chatterbox's default". Same three knobs added as optional kwargs on `TextToSpeech.generate_audio`.
+
+### Changed
+
+- Dubbing pipeline now derives a per-segment `Expressiveness` from source vocals RMS and forwards it to Chatterbox, so the dub tracks the source's loud/quiet shape instead of using flat defaults. Three buckets: <0.7× baseline → `exaggeration=0.3, cfg_weight=0.7`; >1.3× → `exaggeration=0.85, cfg_weight=0.35`; in between → Chatterbox defaults. Knob values picked by-ear on `cam1_1min.mp4`. Pure numpy, no new dep.
+- `DubCache.tts_key` folds the three knobs into the hash. Pre-0.28.3 cache entries miss on first hit and re-synthesize; old WAVs stay on disk until `dub_cache_clear`. All-`None` profile hashes the same as absent kwargs.
+
 ## 0.28.2
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.28.2"
+version = "0.28.3"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -1025,7 +1025,7 @@ class TestTranslationProgressCallback:
 
         def fake_init_tts(self, language="en"):
             class _FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     sr = 24000
                     n = int(sr * 0.2)
                     return Audio(
@@ -1705,7 +1705,7 @@ class TestPipelineSuppliedTranscriptionDiarization:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     sample_rate = 24000
                     duration = 0.2
                     frame_count = int(sample_rate * duration)
@@ -1934,7 +1934,7 @@ class TestVoiceSampleCache:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     tts_calls.append({"voice_sample_path": voice_sample_path, "voice_sample": voice_sample})
                     sample_rate = 24000
                     duration = 0.2
@@ -2031,7 +2031,7 @@ class TestVoiceSampleCache:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     tts_calls.append({"voice_sample_path": voice_sample_path})
                     sample_rate = 24000
                     duration = 0.2
@@ -2710,7 +2710,7 @@ class TestPipelineSpeechRegionGating:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     sr = 24000
                     n = int(sr * 0.2)
                     data = np.zeros(n, dtype=np.float32)
@@ -2801,7 +2801,7 @@ class TestPipelineEmptyTranslationSkipped:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     tts_calls.append(text)
                     sr = 24000
                     n = int(sr * 0.2)
@@ -3050,7 +3050,7 @@ class TestStrictQualityIntegration:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     sr = 24000
                     n = int(sr * 0.2)
                     return Audio(
@@ -3267,7 +3267,7 @@ class TestTranslationFailuresOnResult:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     sr = 24000
                     n = int(sr * 0.2)
                     return Audio(
@@ -3331,7 +3331,7 @@ class TestTranslationFailuresOnResult:
 
         def fake_init_tts(self, language="en"):
             class FakeTTS:
-                def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+                def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
                     sr = 24000
                     n = int(sr * 0.2)
                     return Audio(
@@ -3514,7 +3514,7 @@ def _stub_dub_pipeline(
             pass
 
     class FakeTTS:
-        def generate_audio(self, text, voice_sample=None, voice_sample_path=None):
+        def generate_audio(self, text, voice_sample=None, voice_sample_path=None, **_kwargs):
             tts_calls.append(text)
             return sample_audio
 
@@ -3656,3 +3656,67 @@ class TestVideoDubberCacheKwarg:
         from videopython.ai.dubbing import VideoDubber
 
         assert VideoDubber().cache_dir is None
+
+
+class TestProsody:
+    """Unit tests for the prosody-conditioning helpers in pipeline.py."""
+
+    @staticmethod
+    def _audio_with_amplitude(amplitude: float, duration: float = 1.0, sample_rate: int = 24000) -> Audio:
+        """Constant-amplitude buffer whose RMS == amplitude — easiest
+        input for reasoning about RMS ratios exactly."""
+        frame_count = int(sample_rate * duration)
+        data = np.full(frame_count, amplitude, dtype=np.float32)
+        metadata = AudioMetadata(
+            sample_rate=sample_rate,
+            channels=1,
+            sample_width=2,
+            duration_seconds=duration,
+            frame_count=frame_count,
+        )
+        return Audio(data, metadata)
+
+    def test_rms_matches_known_amplitude(self):
+        from videopython.ai.dubbing.pipeline import _rms
+
+        audio = self._audio_with_amplitude(0.3)
+        assert _rms(audio.data) == pytest.approx(0.3, abs=1e-4)
+
+    def test_expressiveness_default_when_baseline_zero(self):
+        from videopython.ai.dubbing import Expressiveness
+        from videopython.ai.dubbing.pipeline import _expressiveness_for
+
+        # Silent baseline → can't compute a ratio, must degrade safely.
+        result = _expressiveness_for(self._audio_with_amplitude(0.5), baseline_rms=0.0)
+        assert result == Expressiveness()
+
+    def test_expressiveness_default_when_segment_silent(self):
+        from videopython.ai.dubbing import Expressiveness
+        from videopython.ai.dubbing.pipeline import _expressiveness_for
+
+        result = _expressiveness_for(self._audio_with_amplitude(0.0), baseline_rms=0.5)
+        assert result == Expressiveness()
+
+    def test_expressiveness_calm_when_quiet(self):
+        from videopython.ai.dubbing.pipeline import _expressiveness_for
+
+        # ratio = 0.3 / 1.0 = 0.3 < CALM_RATIO_THRESHOLD (0.7) → calm
+        result = _expressiveness_for(self._audio_with_amplitude(0.3), baseline_rms=1.0)
+        assert result.exaggeration == 0.3
+        assert result.cfg_weight == 0.7
+
+    def test_expressiveness_dramatic_when_loud(self):
+        from videopython.ai.dubbing.pipeline import _expressiveness_for
+
+        # ratio = 1.5 > DRAMATIC_RATIO_THRESHOLD (1.3) → dramatic
+        result = _expressiveness_for(self._audio_with_amplitude(1.5), baseline_rms=1.0)
+        assert result.exaggeration == 0.85
+        assert result.cfg_weight == 0.35
+
+    def test_expressiveness_normal_in_band(self):
+        from videopython.ai.dubbing import Expressiveness
+        from videopython.ai.dubbing.pipeline import _expressiveness_for
+
+        # ratio = 1.0 sits squarely in the normal band → no-knobs profile
+        result = _expressiveness_for(self._audio_with_amplitude(1.0), baseline_rms=1.0)
+        assert result == Expressiveness()

--- a/src/videopython/ai/dubbing/__init__.py
+++ b/src/videopython/ai/dubbing/__init__.py
@@ -2,7 +2,13 @@
 
 from videopython.ai.dubbing.cache import DubCache, dub_cache_clear
 from videopython.ai.dubbing.dubber import VideoDubber
-from videopython.ai.dubbing.models import DubbingResult, RevoiceResult, SeparatedAudio, TranslatedSegment
+from videopython.ai.dubbing.models import (
+    DubbingResult,
+    Expressiveness,
+    RevoiceResult,
+    SeparatedAudio,
+    TranslatedSegment,
+)
 from videopython.ai.dubbing.pipeline import LocalDubbingPipeline
 from videopython.ai.dubbing.quality import GarbageTranscriptError, TranscriptQuality, assess_transcript
 from videopython.ai.dubbing.timing import TimingSynchronizer
@@ -22,4 +28,5 @@ __all__ = [
     "UnsupportedLanguageError",
     "DubCache",
     "dub_cache_clear",
+    "Expressiveness",
 ]

--- a/src/videopython/ai/dubbing/cache.py
+++ b/src/videopython/ai/dubbing/cache.py
@@ -157,14 +157,27 @@ class DubCache:
         translated_text: str,
         voice_sample_bytes: bytes | None,
         language: str,
+        exaggeration: float | None = None,
+        cfg_weight: float | None = None,
+        temperature: float | None = None,
     ) -> str:
-        """Per-segment key over text + voice sample + language."""
+        """Per-segment key over text + voice sample + language + expressiveness.
+
+        ``exaggeration`` / ``cfg_weight`` / ``temperature`` are the M4
+        Chatterbox knobs. Defaulting to ``None`` keeps pre-M4 callers that
+        omit them hashing the same way (no-knob profile collides with
+        absent kwargs), so cache invalidation is driven by *passing
+        non-None values*, not by the M4 code path being present.
+        """
         h = hashlib.sha256()
         h.update(translated_text.encode("utf-8"))
         h.update(b"\x00")
         h.update(voice_sample_bytes or b"")
         h.update(b"\x00")
         h.update(language.encode("utf-8"))
+        for knob in (exaggeration, cfg_weight, temperature):
+            h.update(b"\x00")
+            h.update(repr(knob).encode("utf-8"))
         return h.hexdigest()[:16]
 
     # ----- path resolution -------------------------------------------------

--- a/src/videopython/ai/dubbing/models.py
+++ b/src/videopython/ai/dubbing/models.py
@@ -19,6 +19,42 @@ if TYPE_CHECKING:
 CLEAN_SPEED_TOLERANCE = 0.01
 
 
+@dataclass(frozen=True)
+class Expressiveness:
+    """Chatterbox ``generate()`` knobs derived from source-segment prosody.
+
+    ``None`` on any field means "let Chatterbox use its own default" —
+    avoids pinning the dub against future Chatterbox default changes.
+
+    Attributes:
+        exaggeration: Emotional intensity. Chatterbox default ``0.5``;
+            ``0.7+`` produces dramatic output.
+        cfg_weight: Classifier-free guidance weight. Chatterbox default
+            ``0.5``; lower values (~``0.3``) slow pacing.
+        temperature: Sampling temperature. Chatterbox default ``0.8``.
+    """
+
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    temperature: float | None = None
+
+    def as_kwargs(self) -> dict[str, float]:
+        """Knobs as a dict, dropping ``None`` entries.
+
+        Suitable for ``**``-expansion into Chatterbox or
+        :meth:`DubCache.tts_key`.
+        """
+        return {
+            name: value
+            for name, value in (
+                ("exaggeration", self.exaggeration),
+                ("cfg_weight", self.cfg_weight),
+                ("temperature", self.temperature),
+            )
+            if value is not None
+        }
+
+
 @dataclass
 class TranslatedSegment:
     """A segment of translated text with timing information.

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from videopython.ai._device import select_device
 from videopython.ai.dubbing.cache import DubCache
-from videopython.ai.dubbing.models import DubbingResult, RevoiceResult, SeparatedAudio, TimingSummary
+from videopython.ai.dubbing.models import DubbingResult, Expressiveness, RevoiceResult, SeparatedAudio, TimingSummary
 from videopython.ai.dubbing.quality import GarbageTranscriptError, assess_transcript
 from videopython.ai.dubbing.timing import TimingSynchronizer
 from videopython.ai.generation.qwen3 import Qwen3Translator
@@ -117,6 +117,40 @@ logger = logging.getLogger(__name__)
 PEAK_CLIP_THRESHOLD = 0.99
 MIN_VOCAL_BG_RMS_RATIO = 1.5
 VOICE_SAMPLE_TARGET_DURATION = 6.0
+
+# Prosody-conditioning thresholds. Source-segment RMS / whole-vocals RMS
+# below CALM lands in the calm bucket; above DRAMATIC in the dramatic
+# bucket; in between gets Chatterbox's defaults. Knob values picked
+# by-ear on cam1_1min.mp4 — see RELEASE_NOTES 0.29.0.
+CALM_RATIO_THRESHOLD = 0.7
+DRAMATIC_RATIO_THRESHOLD = 1.3
+_CALM = Expressiveness(exaggeration=0.3, cfg_weight=0.7)
+_DRAMATIC = Expressiveness(exaggeration=0.85, cfg_weight=0.35)
+
+
+def _rms(data: np.ndarray) -> float:
+    """RMS over samples; ``0.0`` for empty input. float64 reduction so a
+    long slice can't overflow the squared accumulator."""
+    if data.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(data, dtype=np.float64))))
+
+
+def _expressiveness_for(source_slice: Audio, baseline_rms: float) -> Expressiveness:
+    """Map a source vocals slice to a Chatterbox expressiveness profile
+    by RMS ratio. Falls back to the no-knobs default for empty or silent
+    inputs."""
+    if baseline_rms <= 0.0:
+        return Expressiveness()
+    segment_rms = _rms(source_slice.data)
+    if segment_rms <= 0.0:
+        return Expressiveness()
+    ratio = segment_rms / baseline_rms
+    if ratio < CALM_RATIO_THRESHOLD:
+        return _CALM
+    if ratio > DRAMATIC_RATIO_THRESHOLD:
+        return _DRAMATIC
+    return Expressiveness()
 
 
 class LocalDubbingPipeline:
@@ -236,6 +270,7 @@ class LocalDubbingPipeline:
         voice_samples: dict[str, Audio],
         speaker_wav_paths: dict[str, Path],
         src_hash_for_tts: str,
+        expressiveness: Expressiveness = Expressiveness(),
     ) -> Audio | None:
         """Produce the TTS audio for a single segment, with cache-around-the-call.
 
@@ -244,6 +279,11 @@ class LocalDubbingPipeline:
         TTS model is lazy-initialized and the per-speaker temp WAV is
         materialized before generation; on cache hit none of that runs,
         so a fully-cached run never loads Chatterbox.
+
+        ``expressiveness`` carries the M4 Chatterbox knobs derived from
+        the source segment's prosody. Default is the no-knobs profile —
+        lets Chatterbox use its own defaults — so callers that don't yet
+        derive prosody (e.g. ``revoice``) keep pre-M4 behaviour.
         """
         from videopython.base.audio import Audio as _Audio
 
@@ -253,6 +293,7 @@ class LocalDubbingPipeline:
                 translated_text=segment.translated_text,
                 voice_sample_bytes=speaker_bytes,
                 language=target_lang,
+                **expressiveness.as_kwargs(),
             )
             cached_path = self._cache.get_tts_path(src_hash_for_tts, tts_cache_key)
             if cached_path is not None:
@@ -270,10 +311,11 @@ class LocalDubbingPipeline:
 
         wav_path = speaker_wav_paths.get(speaker) if voice_clone else None
         try:
-            if wav_path is not None:
-                dubbed_audio = self._tts.generate_audio(segment.translated_text, voice_sample_path=wav_path)
-            else:
-                dubbed_audio = self._tts.generate_audio(segment.translated_text)
+            dubbed_audio = self._tts.generate_audio(
+                segment.translated_text,
+                voice_sample_path=wav_path,
+                **expressiveness.as_kwargs(),
+            )
         except Exception as exc:
             # Chatterbox occasionally crashes on short translated text
             # (alignment_stream_analyzer indexing on tensors with <=5
@@ -748,15 +790,31 @@ class LocalDubbingPipeline:
             report_progress("Extracting voice samples", 0.25)
             voice_samples = self._extract_voice_samples(vocal_audio, background_audio, transcription)
 
-        # vocals is no longer needed; voice_samples are independent copies.
-        # In low_memory mode this is the only ref keeping the buffer alive
-        # (separated_audio was dropped above), so dropping the local frees it.
-        del vocal_audio
-
         report_progress("Translating text", 0.35)
         translated_segments, translation_failures = self._translate_with_cache(
             transcription, source_audio, detected_lang, target_lang, report_progress
         )
+
+        # Per-segment expressiveness derived from source vocals RMS.
+        # Computed before vocal_audio is released so the TTS loop doesn't
+        # hold the buffer. Segment ends are clamped to the vocals duration
+        # — transcription timestamps can drift past the buffer tail
+        # (especially on synthetic test audio) and Audio.slice rejects
+        # out-of-range ends past a 0.1s tolerance.
+        baseline_rms = _rms(vocal_audio.data)
+        vocal_duration = vocal_audio.metadata.duration_seconds
+        expressiveness_per_segment = [
+            _expressiveness_for(
+                vocal_audio.slice(min(s.start, vocal_duration), min(s.end, vocal_duration)),
+                baseline_rms,
+            )
+            for s in translated_segments
+        ]
+
+        # vocals is no longer needed; voice_samples are independent copies.
+        # In low_memory mode this is the only ref keeping the buffer alive
+        # (separated_audio was dropped above), so dropping the local frees it.
+        del vocal_audio
 
         report_progress("Generating dubbed speech", 0.50)
 
@@ -800,6 +858,7 @@ class LocalDubbingPipeline:
                     voice_samples=voice_samples,
                     speaker_wav_paths=speaker_wav_paths,
                     src_hash_for_tts=src_hash_for_tts,
+                    expressiveness=expressiveness_per_segment[i],
                 )
                 if dubbed_audio is None:
                     continue

--- a/src/videopython/ai/generation/audio.py
+++ b/src/videopython/ai/generation/audio.py
@@ -51,6 +51,9 @@ class TextToSpeech:
         text: str,
         voice_sample: Audio | None = None,
         voice_sample_path: str | Path | None = None,
+        exaggeration: float | None = None,
+        cfg_weight: float | None = None,
+        temperature: float | None = None,
     ) -> Audio:
         """Generate speech audio from text.
 
@@ -64,6 +67,15 @@ class TextToSpeech:
                 precedence over ``voice_sample`` and ``self.voice``. Used by
                 the dubbing pipeline to encode each speaker's sample once and
                 reuse it across all of that speaker's segments.
+            exaggeration: Chatterbox emotional-intensity knob (default
+                ``0.5``). ``None`` (default) means do not pass the kwarg —
+                Chatterbox uses its own default and we stay forward-compatible
+                with changes to it. ``0.7+`` produces dramatic output.
+            cfg_weight: Chatterbox classifier-free-guidance weight (default
+                ``0.5``). ``None`` means do not pass. Lower values (~``0.3``)
+                slow pacing.
+            temperature: Chatterbox sampling temperature (default ``0.8``).
+                ``None`` means do not pass.
         """
         import tempfile
         from pathlib import Path
@@ -86,11 +98,23 @@ class TextToSpeech:
                     speaker_wav_path = Path(f.name)
                     cleanup_path = True
 
+        # Only forward knobs the caller explicitly set. Passing nothing
+        # for a knob lets Chatterbox use its own default — important so a
+        # future Chatterbox default change doesn't get pinned by us.
+        knobs: dict[str, float] = {}
+        if exaggeration is not None:
+            knobs["exaggeration"] = exaggeration
+        if cfg_weight is not None:
+            knobs["cfg_weight"] = cfg_weight
+        if temperature is not None:
+            knobs["temperature"] = temperature
+
         try:
             wav = self._model.generate(
                 text=text,
                 language_id=self.language,
                 audio_prompt_path=str(speaker_wav_path) if speaker_wav_path else None,
+                **knobs,
             )
 
             audio_data = wav.cpu().float().numpy().squeeze()

--- a/uv.lock
+++ b/uv.lock
@@ -5640,7 +5640,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.28.2"
+version = "0.28.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
ChatterboxMultilingualTTS.generate() exposes exaggeration, cfg_weight, and temperature knobs that we were never passing — every segment got flat defaults regardless of source character. New Expressiveness dataclass carries the trio; pipeline derives it per-segment from the source vocals RMS (vs whole-vocals baseline) and forwards. Three buckets: <0.7× baseline → calm (0.3 / 0.7), >1.3× → dramatic (0.85 / 0.35), in between → Chatterbox defaults. Values picked by-ear on cam1_1min.mp4. DubCache.tts_key folds the knobs in.

Pure numpy. No new dep. Pitch-variance refinement deferred until A/B data shows RMS alone misses something.