### PR TITLE
docs: cover dubbing pipeline additions and refresh home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Minimal, LLM-friendly Python library for programmatic video editing, processing,
 
 Full documentation: [videopython.com](https://videopython.com)
 
+> **Disclaimer:** This project started as a hand-written hobby project, but most of the code is now produced by LLM agents. Humans still drive direction, approve changes, and own design decisions.
+
 ## Installation
 
 ### 1. Install FFmpeg

--- a/docs/api/ai/dubbing.md
+++ b/docs/api/ai/dubbing.md
@@ -4,7 +4,7 @@ Dub videos into different languages or replace speech with custom text using voi
 
 ## Local Pipeline
 
-Video dubbing runs with a local pipeline combining Whisper, MarianMT translation, Chatterbox Multilingual TTS, and Demucs.
+Video dubbing runs with a local pipeline combining Whisper for transcription, MarianMT or Qwen3 for translation, Chatterbox Multilingual TTS for speech synthesis, and Demucs for source separation. Translation backend selection is automatic by default — see [Translation Backend](#translation-backend) for details.
 
 ## VideoDubber
 
@@ -83,8 +83,9 @@ result = dubber.dub(
 
 ### Memory-Efficient Dubbing
 
-The default pipeline keeps all four models (Whisper, Demucs, MarianMT, Chatterbox)
-resident in memory and operates on `Video` objects that hold every frame in RAM.
+The default pipeline keeps all four models (Whisper, Demucs, the translation
+backend, Chatterbox) resident in memory and operates on `Video` objects that
+hold every frame in RAM.
 For long or high-resolution sources — or memory-constrained hardware — two flags
 trade a modest amount of latency for a much lower memory ceiling.
 
@@ -150,6 +151,186 @@ dubber = VideoDubber(no_speech_threshold=0.85)
 ```
 
 See [`AudioToText`](understanding.md#audiototext) for the full rationale.
+
+### Translation Backend
+
+Two translation backends ship with the dubbing pipeline:
+
+- **MarianMT** (Helsinki-NLP) — fast on CPU, segment-isolated translation. Covers
+  ~30 high-resource language pairs out of the box.
+- **Qwen3** — Qwen3-4B-Instruct via `llama-cpp-python` (Q4_K_M GGUF, ~2.4 GB,
+  downloaded on first use). Context-aware: prompts include a per-segment
+  character budget derived from source duration and a `low_confidence` hint
+  sourced from Whisper `avg_logprob`. Per-segment fallback to Marian if Qwen
+  parse-retries both fail and the language pair is supported.
+
+```python
+# Auto resolver: Qwen3 on GPU when supported, MarianMT on CPU.
+dubber = VideoDubber(translator="auto")
+
+# Force MarianMT (e.g. CPU machines where Qwen3 wall time is impractical).
+dubber = VideoDubber(translator="marian")
+
+# Force Qwen3. Logs a WARNING on CPU because Qwen3-4B Q4_K_M runs ~10-15x
+# slower than Marian without GPU acceleration.
+dubber = VideoDubber(translator="qwen3")
+```
+
+Hard failures from Qwen3 (both the primary call and the per-segment Marian
+fallback fail) are surfaced on `DubbingResult.translation_failures` as a list
+of segment indices; those segments land on the result with empty translated
+text. Empty list under MarianTranslator.
+
+If neither backend covers the requested pair the auto resolver raises
+`UnsupportedLanguageError` (importable from `videopython.ai.dubbing`).
+
+### Resume Cache
+
+Long dubbing runs are restartable via `cache_dir`. When set, transcription,
+translated segments, and per-segment TTS WAVs are persisted under the directory
+and skipped on subsequent runs whose hash inputs match. Designed for resuming
+after a crash and for iterating on dub configuration without re-paying the
+transcription / translation cost each time.
+
+```python
+from videopython.ai.dubbing import VideoDubber, dub_cache_clear
+
+dubber = VideoDubber(cache_dir="./dub_cache")
+result = dubber.dub_file("movie.mp4", "movie_es.mp4", target_lang="es")
+
+# A second run with the same source + kwargs hits cache for every stage:
+dubber.dub_file("movie.mp4", "movie_es.mp4", target_lang="es")
+
+# Clear all cached artifacts when done.
+dub_cache_clear("./dub_cache")
+```
+
+Layout under `<cache_dir>` is keyed by source-audio sha256:
+
+```
+<cache_dir>/<src_hash>/
+    metadata.json              # schema version + hash inputs
+    transcription.json
+    translation_<lang_key>.json
+    tts/<seg_key>.wav
+```
+
+Cache keys are conservative — every kwarg that affects a stage's output is
+folded into the key. Whisper model, translator class, Whisper anti-hallucination
+flags, voice-sample sha256, and the Chatterbox `Expressiveness` knobs all
+invalidate independently. False misses are cheap; false hits would be bugs, so
+the design errs toward more re-computation.
+
+The cache grows unbounded; clear it with `dub_cache_clear(cache_dir)` or
+`dub_cache_clear(cache_dir, src_hash=...)` to drop a single source's artifacts.
+
+### Output Options for `dub_file`
+
+`dub_file()` writes the dubbed video by stream-copying the source video and
+muxing the new audio. Two extras carry through automatically and one is opt-in:
+
+- **Subtitles pass-through (automatic).** Subtitle streams from the source
+  video are stream-copied into the output by default. Sources without subtitles
+  are tolerated.
+- **Source loudness match (automatic).** The dubbed audio is gain-matched to
+  the source via BS.1770 integrated-loudness measurement (`pyloudnorm`,
+  BSD-3) so the dub lands within ~1 LU of the source on dialogue-heavy mixes.
+  Falls back to peak-amplitude match for clips shorter than 400 ms; post-gain
+  peaks are clamped to 0.99.
+- **`keep_original_audio=True` (opt-in).** Retains the source audio as a
+  secondary audio track behind the dubbed one. Useful for editorial A/B; the
+  dubbed track stays the default-playback track.
+
+```python
+result = dubber.dub_file(
+    input_path="interview.mp4",
+    output_path="interview_es.mp4",
+    target_lang="es",
+    keep_original_audio=True,  # source audio rides along as track #2
+)
+```
+
+### Transcript Quality Gating
+
+Even with `condition_on_previous_text=False`, sufficiently degenerate input
+(ambient music, mostly-silent windows misread as speech) can still produce
+unusable transcripts. The pipeline runs a cheap heuristic over the Whisper
+output and exposes the assessment on every result.
+
+Three checks fire flags:
+
+- **Dominant phrase** — one phrase covers ≥70% of segment characters
+  (catches cascades like the Japanese YouTube outro `「ご視聴ありがとうございました」`).
+- **Low decoder confidence** — median `avg_logprob` < `-1.5`.
+- **Sparse speech** — speech-region duration is <5% of clip duration on
+  inputs >30s.
+
+The `recommendation` is `"reject"` when the dominance flag fires together
+with at least one other flag, `"warn"` when any single flag fires, `"ok"`
+otherwise. Single repetition alone (chants, song lyrics) only warns.
+
+```python
+result = dubber.dub(video, target_lang="es")
+
+q = result.transcript_quality
+if q is not None:
+    print(q.recommendation)            # "ok" | "warn" | "reject"
+    print(q.dominant_phrase_fraction)  # 0.0-1.0
+    print(q.flags)                     # ["dominant_phrase", ...]
+```
+
+Use `strict_quality=True` to refuse low-quality transcripts before paying for
+Demucs, translation, and TTS:
+
+```python
+from videopython.ai.dubbing import GarbageTranscriptError
+
+dubber = VideoDubber(strict_quality=True)
+try:
+    dubber.dub(video, target_lang="es")
+except GarbageTranscriptError as exc:
+    print("Refused:", exc.quality.flags)
+```
+
+### Timing Summary
+
+`DubbingResult.timing_summary` aggregates the per-segment timing adjustments
+the synchronizer applied to fit translated speech into source durations. High
+truncation rates indicate translation produced text that was too long for the
+source's spoken regions — a quality red flag worth surfacing in eval harnesses
+or product UI.
+
+```python
+result = dubber.dub(video, target_lang="es")
+
+ts = result.timing_summary
+if ts is not None:
+    print(f"{ts.clean_count}/{ts.total_segments} clean")
+    print(f"{ts.truncated_count} truncated, worst {ts.max_truncation_seconds:.2f}s")
+    print(f"mean speed factor {ts.mean_speed_factor:.3f}")
+```
+
+### Source-Prosody Expressiveness
+
+`ChatterboxMultilingualTTS.generate()` exposes `exaggeration`, `cfg_weight`,
+and `temperature` knobs. The dubbing pipeline derives an `Expressiveness`
+profile per segment from source vocals RMS (relative to whole-vocals baseline)
+and forwards it to Chatterbox, so the dub tracks the source's loud/quiet shape
+instead of using flat defaults on every segment.
+
+Three buckets, picked by-ear on `cam1_1min.mp4`:
+
+| RMS ratio vs baseline | `exaggeration` | `cfg_weight` |
+|---|---|---|
+| `< 0.7×` (calm) | `0.3` | `0.7` |
+| `0.7×–1.3×` (normal) | Chatterbox default | Chatterbox default |
+| `> 1.3×` (dramatic) | `0.85` | `0.35` |
+
+The `Expressiveness` dataclass is exported from `videopython.ai.dubbing`. The
+three knobs are also folded into the TTS cache key, so re-runs after a knob
+change re-synthesize. Pre-0.28.3 cache entries miss on first hit and
+re-synthesize with the new values; old WAVs stay on disk until
+`dub_cache_clear`.
 
 ### Supplying a Pre-Computed Transcription
 
@@ -250,6 +431,55 @@ Individual translated speech segment with timing information.
 Audio separated into vocals and background components.
 
 ::: videopython.ai.dubbing.SeparatedAudio
+
+## Expressiveness
+
+Per-segment Chatterbox `generate()` knobs (`exaggeration`, `cfg_weight`,
+`temperature`). `None` on any field means "let Chatterbox use its default".
+The dubbing pipeline derives this from source vocals RMS automatically; the
+type is exposed for users who want to inspect or override per-segment values.
+
+::: videopython.ai.dubbing.Expressiveness
+
+## TimingSummary
+
+Aggregate stats over per-segment timing adjustments applied by the
+synchronizer. Surfaces truncation and speed-change counts that translation
+quality eval harnesses can compare across backends.
+
+::: videopython.ai.dubbing.models.TimingSummary
+
+## TranscriptQuality
+
+Heuristic quality assessment over a Whisper transcription. Surfaced on every
+`DubbingResult`; drives the optional `strict_quality` reject path.
+
+::: videopython.ai.dubbing.TranscriptQuality
+
+## GarbageTranscriptError
+
+Raised by the pipeline when `strict_quality=True` and the transcript-quality
+heuristic returns `recommendation="reject"`. Carries the triggering
+`TranscriptQuality` as `error.quality` for caller introspection.
+
+::: videopython.ai.dubbing.GarbageTranscriptError
+
+## DubCache
+
+Filesystem cache for dubbing pipeline artifacts. Most users only need
+`cache_dir=...` on `VideoDubber` plus `dub_cache_clear(cache_dir)`; `DubCache`
+is the lower-level handle for pre-warming, inspecting, or composing custom
+flows.
+
+::: videopython.ai.dubbing.DubCache
+
+## UnsupportedLanguageError
+
+Raised by the translator auto-resolver when neither MarianMT nor Qwen3 covers
+the requested `(source_lang, target_lang)` pair. Carries both fields for
+caller introspection without parsing the message.
+
+::: videopython.ai.dubbing.UnsupportedLanguageError
 
 ## Supported Languages
 

--- a/docs/api/ai/generation.md
+++ b/docs/api/ai/generation.md
@@ -26,6 +26,29 @@ Generate videos, images, audio, and music from text prompts.
 
 ## TextToSpeech
 
+`generate_audio` accepts three optional Chatterbox `generate()` knobs —
+`exaggeration`, `cfg_weight`, and `temperature` — for callers who want to
+shape per-utterance prosody. Each defaults to `None`, which means "don't pass
+the kwarg, let Chatterbox use its default". The dubbing pipeline derives them
+per-segment from source vocals RMS via the
+[`Expressiveness`](dubbing.md#expressiveness) dataclass.
+
+```python
+from videopython.ai import TextToSpeech
+
+tts = TextToSpeech()
+
+# Chatterbox defaults.
+audio = tts.generate_audio("Welcome to videopython.")
+
+# Dramatic delivery (higher exaggeration, lower cfg_weight slows pacing).
+dramatic = tts.generate_audio(
+    "We made it.",
+    exaggeration=0.85,
+    cfg_weight=0.35,
+)
+```
+
 ::: videopython.ai.TextToSpeech
 
 ## TextToMusic

--- a/docs/api/ai/understanding.md
+++ b/docs/api/ai/understanding.md
@@ -36,6 +36,27 @@ transcriber = AudioToText(no_speech_threshold=0.85)
 transcriber = AudioToText(condition_on_previous_text=True)
 ```
 
+### Per-segment confidence
+
+`TranscriptionSegment` carries three optional confidence fields populated from
+the raw Whisper output: `avg_logprob`, `no_speech_prob`, and
+`compression_ratio`. They are `None` when not available (e.g. on the
+diarization-only path that builds segments from words without overlap match,
+or on transcripts loaded from formats that don't carry the metadata).
+
+These signals feed the dubbing pipeline's transcript-quality gate (median
+`avg_logprob` is one of three reject flags) and Qwen3's confidence-aware
+translation prompt (segments below threshold get a `low_confidence` hint). They
+are also useful for downstream callers that want to drop low-quality segments
+before further processing.
+
+```python
+result = AudioToText().transcribe(video)
+for segment in result.segments:
+    if segment.avg_logprob is not None and segment.avg_logprob < -1.0:
+        print(f"low confidence: {segment.text!r}")
+```
+
 ::: videopython.ai.AudioToText
 
 ## AudioClassifier

--- a/docs/examples/large-videos.md
+++ b/docs/examples/large-videos.md
@@ -163,7 +163,7 @@ muxes the dubbed audio back into the source video using ffmpeg stream-copy
 track — independent of video length and resolution.
 
 Combine with `low_memory=True` so each pipeline stage's model (Whisper, Demucs,
-MarianMT, Chatterbox) is unloaded between stages:
+the translation backend, Chatterbox) is unloaded between stages:
 
 ```python
 from videopython.ai.dubbing import VideoDubber
@@ -183,8 +183,19 @@ result = dubber.dub_file(
 print(f"Translated {result.num_segments} segments")
 ```
 
+For runs that may need to resume after a crash, add a `cache_dir`. The
+pipeline persists transcription, translated segments, and per-segment TTS
+WAVs and skips stages whose hash inputs already match on a re-run:
+
+```python
+dubber = VideoDubber(low_memory=True, cache_dir="./dub_cache")
+dubber.dub_file("2_hour_movie.mp4", "dubbed.mp4", target_lang="es")
+# A second run with the same source + kwargs hits cache for every stage.
+```
+
 See [AI Dubbing](../api/ai/dubbing.md#memory-efficient-dubbing) for more on the
-`low_memory` flag and `dub_file()`.
+`low_memory` flag and `dub_file()`, and
+[Resume Cache](../api/ai/dubbing.md#resume-cache) for cache-key semantics.
 
 ## Method Comparison
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,15 +50,31 @@ Blur, zoom, color grading, vignette, Ken Burns, text and image overlay. Load, no
 
 ### LLM-Driven Editing
 
-JSON editing plans with full JSON Schema generation, dry-run validation, and an operation registry with rich constraints.
+JSON editing plans with full JSON Schema generation, dry-run validation, and an operation registry with rich constraints. [Learn more →](guides/llm-integration.md)
 
 </div>
 
 <div class="feature-card" markdown>
 
-### AI Video Workflows
+### AI Generation
 
-Generate images, video, speech, and music from prompts. Transcribe, describe scenes, dub to 50+ languages, swap objects.
+Generate images, video, speech, and music from text prompts. SDXL, CogVideoX, Chatterbox Multilingual TTS, MusicGen — all local, no API keys. [Learn more →](api/ai/generation.md)
+
+</div>
+
+<div class="feature-card" markdown>
+
+### AI Video Analysis
+
+Transcribe with speaker diarization, classify ambient audio, detect scene boundaries, and describe scenes with a vision-language model. One `VideoAnalyzer` runs the full pipeline and returns a serializable `VideoAnalysis`. [Learn more →](api/ai/video_analysis.md)
+
+</div>
+
+<div class="feature-card" markdown>
+
+### AI Dubbing
+
+Translate speech, clone the original voice, and re-time the dub onto the source — all in one pipeline. Whisper + MarianMT/Qwen3 + Chatterbox + Demucs. Resume cache for long runs, source-prosody-conditioned expressiveness, and a transcript-quality gate that rejects garbage input before paying for translation and TTS. [Learn more →](api/ai/dubbing.md)
 
 </div>
 


### PR DESCRIPTION
Documents the dubbing pipeline surface added across 0.28.0 -> 0.28.3 that the public docs hadn't caught up with: translator selection (Marian/Qwen3/auto), the resume cache and dub_cache_clear, dub_file output options (subtitle pass-through, LUFS match, keep_original_audio), the strict_quality / transcript_quality gate, timing_summary, and the source-prosody Expressiveness profile. Adds mkdocstrings stanzas for the new public types (Expressiveness, TimingSummary, TranscriptQuality, GarbageTranscriptError, DubCache, UnsupportedLanguageError). Mentions the new TranscriptionSegment confidence fields in understanding.md and the new TextToSpeech expressiveness kwargs in generation.md.

Splits the home page's single AI feature card into three (Generation, Video Analysis, Dubbing) so the analysis and dubbing surfaces are visible from the landing page, with deep links into each. Drops the overstated "50+ languages" claim. Feature grid is auto-fit, so the extra cards reflow cleanly across viewports without CSS changes.