### PR TITLE
refactor(ai): unify predictor lifecycle drifts (0.33.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## 0.33.1
+
+Point-fix cleanup of the AI predictor classes. No new abstractions —
+just removing six drifts the broader DESIGN.md §4 mixin was meant to
+unify, but at a fraction of the churn.
+
+### Changes
+
+- `TextToSpeech._init_model` renamed to `_init_local` for parity with
+  the other predictors.
+- `SemanticSceneDetector._load_model` renamed to `_init_local`, and
+  the `_device` field is now public `device` (matches every other
+  predictor in `ai/`).
+- `unload()` added to `AudioClassifier`, `TextToMusic`, `TextToImage`,
+  `TextToVideo`, `ImageToVideo`, `SemanticSceneDetector` (previously
+  missing — these leaked VRAM across pipeline stages in low-memory
+  dubbing).
+- `SceneVLM.unload` now goes through `release_device_memory` instead of
+  open-coding `gc.collect()` + `torch.cuda.empty_cache()`.
+- `TextToMusic`, `TextToVideo`, `ImageToVideo` no longer carry a
+  redundant `_device` field alongside `self.device`.
+- `MarianTranslator` device-init log line corrected from
+  `"TextTranslator"` (the old class name) to `"MarianTranslator"`.
+
+These renames are technically breaking for any external code that
+subclassed the predictors and overrode `_init_model` / `_load_model`,
+or read `SemanticSceneDetector._device` directly. All three surfaces
+were underscore-prefixed (internal).
+
 ## 0.33.0
 
 `videopython.ai` refactor. The 8.5k-LOC `ai/` subtree had two god

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.33.0"
+version = "0.33.1"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/videopython/ai/generation/audio.py
+++ b/src/videopython/ai/generation/audio.py
@@ -32,7 +32,7 @@ class TextToSpeech:
         self.language = language
         self._model: Any = None
 
-    def _init_model(self) -> None:
+    def _init_local(self) -> None:
         from chatterbox.mtl_tts import ChatterboxMultilingualTTS  # type: ignore[import-untyped]
 
         requested_device = self.device
@@ -83,7 +83,7 @@ class TextToSpeech:
         import numpy as np
 
         if self._model is None:
-            self._init_model()
+            self._init_local()
 
         speaker_wav_path: Path | None = None
         cleanup_path = False
@@ -149,7 +149,6 @@ class TextToMusic:
         self.device = device
         self._processor: Any = None
         self._model: Any = None
-        self._device: str | None = None
 
     def _init_local(self) -> None:
         """Initialize local MusicGen model."""
@@ -160,17 +159,17 @@ class TextToMusic:
         os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
         requested_device = self.device
-        self._device = select_device(self.device, mps_allowed=True)
+        device = select_device(self.device, mps_allowed=True)
 
         model_name = "facebook/musicgen-small"
         self._processor = AutoProcessor.from_pretrained(model_name)
         self._model = MusicgenForConditionalGeneration.from_pretrained(model_name)
-        self._model.to(self._device)
-        self.device = self._device
+        self._model.to(device)
+        self.device = device
         log_device_initialization(
             "TextToMusic",
             requested_device=requested_device,
-            resolved_device=self._device,
+            resolved_device=device,
         )
 
     def generate_audio(self, text: str, max_new_tokens: int = 256) -> Audio:
@@ -179,7 +178,7 @@ class TextToMusic:
             self._init_local()
 
         inputs = self._processor(text=[text], padding=True, return_tensors="pt")
-        inputs = {k: v.to(self._device) if hasattr(v, "to") else v for k, v in inputs.items()}
+        inputs = {k: v.to(self.device) if hasattr(v, "to") else v for k, v in inputs.items()}
         audio_values = self._model.generate(**inputs, max_new_tokens=max_new_tokens)
         sampling_rate = self._model.config.audio_encoder.sampling_rate
 
@@ -193,3 +192,9 @@ class TextToMusic:
             frame_count=len(audio_data),
         )
         return Audio(audio_data, metadata)
+
+    def unload(self) -> None:
+        """Release the MusicGen model so the next generate_audio() re-initializes."""
+        self._model = None
+        self._processor = None
+        release_device_memory(self.device)

--- a/src/videopython/ai/generation/image.py
+++ b/src/videopython/ai/generation/image.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from PIL import Image
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 
 
 class TextToImage:
@@ -49,3 +49,8 @@ class TextToImage:
         if self._pipeline is None:
             self._init_local()
         return self._pipeline(prompt=prompt).images[0]
+
+    def unload(self) -> None:
+        """Release the diffusion pipeline so the next generate_image() re-initializes."""
+        self._pipeline = None
+        release_device_memory(self.device)

--- a/src/videopython/ai/generation/translation.py
+++ b/src/videopython/ai/generation/translation.py
@@ -181,7 +181,7 @@ class MarianTranslator:
         self._model = MarianMTModel.from_pretrained(model_name).to(device)
         self.device = device
         log_device_initialization(
-            "TextTranslator",
+            "MarianTranslator",
             requested_device=requested_device,
             resolved_device=device,
         )

--- a/src/videopython/ai/generation/video.py
+++ b/src/videopython/ai/generation/video.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.base.video import Video
 
 if TYPE_CHECKING:
@@ -29,22 +29,21 @@ class TextToVideo:
     def __init__(self, device: str | None = None):
         self.device = device
         self._pipeline: Any = None
-        self._device: str | None = None
 
     def _init_local(self) -> None:
         from diffusers import CogVideoXPipeline
 
         requested_device = self.device
-        self._device, dtype = _get_torch_device_and_dtype(self.device)
+        device, dtype = _get_torch_device_and_dtype(self.device)
 
         model_name = "THUDM/CogVideoX1.5-5B"
         self._pipeline = CogVideoXPipeline.from_pretrained(model_name, torch_dtype=dtype)
-        self._pipeline.to(self._device)
-        self.device = self._device
+        self._pipeline.to(device)
+        self.device = device
         log_device_initialization(
             "TextToVideo",
             requested_device=requested_device,
-            resolved_device=self._device,
+            resolved_device=device,
         )
 
     def generate_video(
@@ -65,10 +64,15 @@ class TextToVideo:
             num_inference_steps=num_steps,
             num_frames=num_frames,
             guidance_scale=guidance_scale,
-            generator=torch.Generator(device=self._device).manual_seed(42),
+            generator=torch.Generator(device=self.device).manual_seed(42),
         ).frames[0]
         video_frames = np.asarray(video_frames, dtype=np.uint8)
         return Video.from_frames(video_frames, fps=16.0)
+
+    def unload(self) -> None:
+        """Release the diffusion pipeline so the next generate_video() re-initializes."""
+        self._pipeline = None
+        release_device_memory(self.device)
 
 
 class ImageToVideo:
@@ -77,22 +81,21 @@ class ImageToVideo:
     def __init__(self, device: str | None = None):
         self.device = device
         self._pipeline: Any = None
-        self._device: str | None = None
 
     def _init_local(self) -> None:
         from diffusers import CogVideoXImageToVideoPipeline
 
         requested_device = self.device
-        self._device, dtype = _get_torch_device_and_dtype(self.device)
+        device, dtype = _get_torch_device_and_dtype(self.device)
 
         model_name = "THUDM/CogVideoX1.5-5B-I2V"
         self._pipeline = CogVideoXImageToVideoPipeline.from_pretrained(model_name, torch_dtype=dtype)
-        self._pipeline.to(self._device)
-        self.device = self._device
+        self._pipeline.to(device)
+        self.device = device
         log_device_initialization(
             "ImageToVideo",
             requested_device=requested_device,
-            resolved_device=self._device,
+            resolved_device=device,
         )
 
     def generate_video(
@@ -115,7 +118,12 @@ class ImageToVideo:
             num_inference_steps=num_steps,
             num_frames=num_frames,
             guidance_scale=guidance_scale,
-            generator=torch.Generator(device=self._device).manual_seed(42),
+            generator=torch.Generator(device=self.device).manual_seed(42),
         ).frames[0]
         video_frames = np.asarray(video_frames, dtype=np.uint8)
         return Video.from_frames(video_frames, fps=16.0)
+
+    def unload(self) -> None:
+        """Release the diffusion pipeline so the next generate_video() re-initializes."""
+        self._pipeline = None
+        release_device_memory(self.device)

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -520,6 +520,15 @@ class AudioClassifier:
 
         self._labels = [self._model.config.id2label[i] for i in range(len(self._model.config.id2label))]
 
+    def unload(self) -> None:
+        """Release the AST model so the next classify() re-initializes.
+
+        Used by low-memory dubbing to free VRAM between pipeline stages.
+        """
+        self._model = None
+        self._processor = None
+        release_device_memory(self.device)
+
     def _merge_events(self, events: list[AudioEvent], gap_threshold: float = 0.5) -> list[AudioEvent]:
         """Merge consecutive events of the same class."""
         if not events:

--- a/src/videopython/ai/understanding/image.py
+++ b/src/videopython/ai/understanding/image.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 import numpy as np
 from PIL import Image
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.base.description import SceneDescription
 
 logger = logging.getLogger(__name__)
@@ -190,16 +190,7 @@ class SceneVLM:
         """
         self._model = None
         self._processor = None
-        try:
-            import gc
-
-            import torch
-
-            gc.collect()
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
-        except ImportError:
-            pass
+        release_device_memory(self.device)
 
     def _downscale_image(self, img: Image.Image) -> Image.Image:
         """Downscale image to fit within max_image_pixels budget, preserving aspect ratio."""

--- a/src/videopython/ai/understanding/temporal.py
+++ b/src/videopython/ai/understanding/temporal.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from videopython.ai._device import log_device_initialization, select_device
+from videopython.ai._device import log_device_initialization, release_device_memory, select_device
 from videopython.base.description import SceneBoundary
 
 if TYPE_CHECKING:
@@ -56,25 +56,31 @@ class SemanticSceneDetector:
 
         self.threshold = threshold
         self.min_scene_length = min_scene_length
-        self._device: str | None = device
+        self.device: str | None = device
         self._model: Any = None
 
-    def _load_model(self) -> None:
+    def _init_local(self) -> None:
         """Load the TransNetV2 model with pretrained weights."""
         if self._model is not None:
             return
 
         from transnetv2_pytorch import TransNetV2
 
-        requested_device = self._device
-        device = select_device(self._device, mps_allowed=True)
+        requested_device = self.device
+        device = select_device(self.device, mps_allowed=True)
         log_device_initialization(
             "SemanticSceneDetector",
             requested_device=requested_device,
             resolved_device=device,
         )
+        self.device = device
         self._model = TransNetV2(device=device)
         self._model.eval()
+
+    def unload(self) -> None:
+        """Release the TransNetV2 model so the next call re-initializes."""
+        self._model = None
+        release_device_memory(self.device)
 
     def detect(self, video: Video) -> list[SceneBoundary]:
         """Detect scenes in a video using ML-based boundary detection.
@@ -114,7 +120,7 @@ class SemanticSceneDetector:
         Returns:
             List of SceneBoundary objects representing detected scenes.
         """
-        self._load_model()
+        self._init_local()
 
         # Use TransNetV2's detect_scenes which handles everything internally
         raw_scenes = self._model.detect_scenes(str(path), threshold=self.threshold)

--- a/uv.lock
+++ b/uv.lock
@@ -5416,7 +5416,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.33.0"
+version = "0.33.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Point-fix cleanup of six drifts across the twelve AI predictor classes, done without introducing a LoadableModel mixin -- the cost of the abstraction outweighed the savings once the survey showed how non-uniform the classes actually are.

- Renamed TextToSpeech._init_model -> _init_local and SemanticSceneDetector._load_model -> _init_local for parity.
- Renamed SemanticSceneDetector._device -> device to match every other predictor.
- Added unload() to AudioClassifier, TextToMusic, TextToImage, TextToVideo, ImageToVideo, SemanticSceneDetector -- these previously leaked VRAM across pipeline stages in low-memory dubbing.
- Replaced SceneVLM.unload hand-rolled gc.collect/empty_cache with release_device_memory.
- Dropped redundant _device field from TextToMusic, TextToVideo, ImageToVideo.
- Fixed MarianTranslator log label "TextTranslator" -> "MarianTranslator".