### PR TITLE
fix(dubbing): chunk Qwen3 translations to fit n_ctx (0.35.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 0.35.1
+
+Fixes a hard failure in `Qwen3Translator` on long sources. The translator
+built one prompt containing every segment, so a long source with hundreds
+of dense segments ballooned past the default 8192-token `n_ctx` and
+llama.cpp rejected the call with a context-window overflow.
+`translate_segments` now splits the input across as many Qwen calls as
+needed via a char-budget heuristic (`_chunk_segment_indices`), and the
+retry pass is chunked the same way. Indices, progress callback semantics
+(ramps 0 → 0.5 across first-pass chunks, then 0.9, then 1.0), and the
+Marian fallback path are preserved; the default 8192 `n_ctx` is now safe
+for sources of any length.
+
 ## 0.35.0
 
 New `image_overlay` operation: a scaled, anchored, time-windowed image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.35.0"
+version = "0.35.1"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_qwen3_translator.py
+++ b/src/tests/ai/test_qwen3_translator.py
@@ -12,6 +12,7 @@ from videopython.ai.generation.qwen3 import (
     Qwen3Translator,
     _build_system_prompt,
     _build_user_prompt,
+    _chunk_segment_indices,
     _parse_jsonl_response,
     _target_chars_for,
 )
@@ -333,3 +334,118 @@ class TestUnloadAndProtocol:
         langs = Qwen3Translator.get_supported_languages()
         assert isinstance(langs, dict)
         assert "en" in langs and "es" in langs
+
+
+class TestChunkSegmentIndices:
+    """Pure helper — exercises the char-budget splitter without any LLM."""
+
+    def test_small_input_one_chunk(self) -> None:
+        segs = [_seg(0, 1, "a"), _seg(1, 2, "b"), _seg(2, 3, "c")]
+        chunks = _chunk_segment_indices(segs, n_ctx=8192, max_tokens=4096)
+        assert chunks == [[0, 1, 2]]
+
+    def test_large_input_splits_into_multiple_chunks(self) -> None:
+        # 80 segments × ~300 chars each = ~24000 chars. With n_ctx=8192 and
+        # max_tokens=4096 the prompt budget is ~3796 tokens ≈ 7592 chars, so
+        # the result must be more than one chunk.
+        segs = [_seg(i, i + 1, "x" * 300) for i in range(80)]
+        chunks = _chunk_segment_indices(segs, n_ctx=8192, max_tokens=4096)
+        assert len(chunks) >= 2
+        # Every position covered exactly once, in order.
+        flattened = [i for chunk in chunks for i in chunk]
+        assert flattened == list(range(80))
+
+    def test_oversized_single_segment_isolated(self) -> None:
+        # A segment that on its own exceeds the budget must still appear,
+        # in its own chunk — we'd rather surface llama.cpp's own error on
+        # that one segment than drop it silently.
+        big = _seg(0, 10, "y" * 50_000)
+        small = _seg(10, 11, "ok")
+        chunks = _chunk_segment_indices([big, small], n_ctx=8192, max_tokens=4096)
+        assert chunks[0] == [0]
+        assert [1] in chunks
+
+    def test_pathological_n_ctx_falls_back_to_per_segment(self) -> None:
+        # If max_tokens leaves no room, the helper degrades to one-per-chunk
+        # instead of returning an empty list (which would silently drop work).
+        segs = [_seg(0, 1, "a"), _seg(1, 2, "b")]
+        chunks = _chunk_segment_indices(segs, n_ctx=1024, max_tokens=4096)
+        assert chunks == [[0], [1]]
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert _chunk_segment_indices([], n_ctx=8192, max_tokens=4096) == []
+
+
+class TestChunkedTranslation:
+    """End-to-end behaviour when input spans multiple Qwen calls."""
+
+    def test_multi_chunk_first_pass_maps_indices_correctly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 80 long segments → multiple chunks. Each fake call returns a
+        # response that uses the chunk-local indices (0..chunk_size-1).
+        segs = [_seg(i, i + 1, "x" * 300) for i in range(80)]
+        chunks = _chunk_segment_indices(segs, n_ctx=8192, max_tokens=4096)
+        assert len(chunks) >= 2  # sanity for the test premise
+
+        # For each chunk, build a response that translates seg-i to
+        # "tr-<original_position>" so we can verify index mapping.
+        scripted: list[str] = []
+        for chunk_positions in chunks:
+            lines = [f'{{"i": {local}, "translated": "tr-{orig}"}}' for local, orig in enumerate(chunk_positions)]
+            scripted.append("\n".join(lines))
+        fake = _FakeLlama(scripted)
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        assert [r.translated_text for r in result] == [f"tr-{i}" for i in range(80)]
+        assert translator.translation_failures == []
+        assert len(fake.prompts_seen) == len(chunks)
+
+    def test_retry_spans_chunks_when_many_segments_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # First pass: each chunk returns nothing parseable. Retry pass:
+        # the missing set is the whole input and must itself be chunked.
+        segs = [_seg(i, i + 1, "x" * 300) for i in range(80)]
+        chunks = _chunk_segment_indices(segs, n_ctx=8192, max_tokens=4096)
+
+        scripted: list[str] = []
+        # First pass: garbage for every chunk.
+        scripted.extend(["garbage"] * len(chunks))
+        # Retry pass: same chunking is applied, return clean responses.
+        for chunk_positions in chunks:
+            lines = [f'{{"i": {local}, "translated": "rt-{orig}"}}' for local, orig in enumerate(chunk_positions)]
+            scripted.append("\n".join(lines))
+        fake = _FakeLlama(scripted)
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu", marian_fallback=False)
+        result = translator.translate_segments(segs, target_lang="es", source_lang="en")
+
+        assert [r.translated_text for r in result] == [f"rt-{i}" for i in range(80)]
+        assert translator.translation_failures == []
+        # First-pass chunks + retry-pass chunks = 2× len(chunks).
+        assert len(fake.prompts_seen) == 2 * len(chunks)
+
+    def test_progress_callback_ramps_across_chunks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 3 chunks in the first pass → 3 ticks ramping to 0.5, then 0.9, 1.0.
+        segs = [_seg(i, i + 1, "x" * 300) for i in range(80)]
+        chunks = _chunk_segment_indices(segs, n_ctx=8192, max_tokens=4096)
+        scripted = []
+        for chunk_positions in chunks:
+            lines = [f'{{"i": {local}, "translated": "ok"}}' for local in range(len(chunk_positions))]
+            scripted.append("\n".join(lines))
+        fake = _FakeLlama(scripted)
+        _patch_qwen_with_fake(monkeypatch, fake)
+
+        translator = Qwen3Translator(device="cpu")
+        ticks: list[float] = []
+        translator.translate_segments(segs, target_lang="es", source_lang="en", progress_callback=ticks.append)
+
+        # One ramp tick per first-pass chunk, then 0.9 and 1.0.
+        assert len(ticks) == len(chunks) + 2
+        assert ticks[-2:] == [0.9, 1.0]
+        # First ramp ticks land between 0 and 0.5 inclusive, strictly increasing.
+        ramp = ticks[: len(chunks)]
+        assert ramp[-1] == pytest.approx(0.5)
+        assert all(0 < t <= 0.5 for t in ramp)
+        assert ramp == sorted(ramp)

--- a/src/videopython/ai/generation/qwen3.py
+++ b/src/videopython/ai/generation/qwen3.py
@@ -92,6 +92,56 @@ _SPEECH_CHARS_DEFAULT = 12.0
 _LOW_LOGPROB_HINT_THRESHOLD = -1.0
 
 
+# Conservative chars-per-token used to size chunks without invoking the
+# tokenizer. Morphologically rich languages land around 1.5-2.0
+# chars/token; ASCII is ~3-4. We use the low end so chunks stay safe for
+# any source language.
+_CHARS_PER_TOKEN = 2.0
+# Token reserve for the system prompt + user-prompt envelope ("Input
+# segments:" / "Translations (...)" wrappers). Empirical upper bound.
+_PROMPT_OVERHEAD_TOKENS = 300
+# Per-segment JSON wrapper cost (keys, braces, commas, index). Added on
+# top of len(seg.text) when sizing chunks.
+_SEGMENT_ENVELOPE_CHARS = 40
+
+
+def _chunk_segment_indices(
+    segments: list[TranscriptionSegment],
+    n_ctx: int,
+    max_tokens: int,
+) -> list[list[int]]:
+    """Group positions in ``segments`` into batches that fit one Qwen call.
+
+    Each batch must satisfy ``prompt_tokens + max_tokens <= n_ctx``, which
+    llama.cpp enforces. We approximate prompt token count from character
+    length using ``_CHARS_PER_TOKEN``; the conservative ratio means a chunk
+    estimated at the budget will tokenize to comfortably less.
+
+    A segment whose own serialized form exceeds the per-call budget goes in
+    its own chunk anyway — better to let llama.cpp report a clean overflow
+    on one giant segment than to silently swallow it.
+    """
+    prompt_token_budget = n_ctx - max_tokens - _PROMPT_OVERHEAD_TOKENS
+    if prompt_token_budget <= 0:
+        return [[i] for i in range(len(segments))]
+    char_budget = int(prompt_token_budget * _CHARS_PER_TOKEN)
+
+    chunks: list[list[int]] = []
+    current: list[int] = []
+    current_chars = 0
+    for i, seg in enumerate(segments):
+        seg_chars = len(seg.text) + _SEGMENT_ENVELOPE_CHARS
+        if current and current_chars + seg_chars > char_budget:
+            chunks.append(current)
+            current = []
+            current_chars = 0
+        current.append(i)
+        current_chars += seg_chars
+    if current:
+        chunks.append(current)
+    return chunks
+
+
 def _target_chars_for(duration_seconds: float, target_lang: str) -> int:
     """Character-count budget for a segment of ``duration_seconds`` in ``target_lang``."""
     rate = _SPEECH_CHARS_PER_SEC.get(target_lang, _SPEECH_CHARS_DEFAULT)
@@ -170,9 +220,12 @@ class Qwen3Translator:
             ``DEFAULT_REPO_ID``; override for eval harnesses.
         filename: GGUF filename within ``repo_id``. Defaults to
             ``DEFAULT_FILENAME``.
-        n_ctx: llama.cpp context window. 8192 is plenty for a 15-min source;
-            raise for very long sources. Hard cap is the model's training
-            context (262K for Qwen3-4B-Instruct-2507).
+        n_ctx: llama.cpp context window. ``translate_segments`` splits the
+            input across multiple calls when it doesn't fit, so 8192 stays
+            safe even for very long sources; raise to reduce the number of
+            calls (and gain cross-segment context per call) at the cost of
+            VRAM. Hard cap is the model's training context (262K for
+            Qwen3-4B-Instruct-2507).
         max_tokens: Generation cap per call. 4× the input character count
             is a safe upper bound for translation output.
         temperature: Decoding temperature. 0.1 keeps output structurally
@@ -257,6 +310,52 @@ class Qwen3Translator:
         raw = response["choices"][0]["text"]
         return _parse_jsonl_response(raw)
 
+    def _qwen_translate_chunked(
+        self,
+        segments: list[TranscriptionSegment],
+        target_lang: str,
+        source_lang: str,
+        progress_callback: Callable[[float], None] | None = None,
+        progress_start: float = 0.0,
+        progress_end: float = 1.0,
+    ) -> dict[int, str]:
+        """Translate ``segments`` across one or more Qwen calls.
+
+        Returns a dict keyed by position in ``segments``. Splitting into
+        chunks keeps each call under llama.cpp's ``n_ctx`` cap — without
+        chunking, a long source with hundreds of dense segments easily
+        blows past the default 8192 token window.
+
+        Progress is reported as a linear ramp from ``progress_start`` to
+        ``progress_end``, one tick per chunk completed.
+        """
+        results: dict[int, str] = {}
+        if not segments:
+            if progress_callback is not None:
+                progress_callback(progress_end)
+            return results
+
+        chunks = _chunk_segment_indices(segments, self.n_ctx, self.max_tokens)
+        if len(chunks) > 1:
+            logger.info(
+                "Qwen3Translator: splitting %d segments into %d chunks (n_ctx=%d)",
+                len(segments),
+                len(chunks),
+                self.n_ctx,
+            )
+        for chunk_num, chunk_positions in enumerate(chunks):
+            chunk_segments = [segments[p] for p in chunk_positions]
+            chunk_result = self._qwen_translate(chunk_segments, target_lang, source_lang)
+            # chunk_result keys are 0..len(chunk_positions)-1; map back to
+            # positions in the caller-provided ``segments`` list.
+            for local_idx, text in chunk_result.items():
+                if 0 <= local_idx < len(chunk_positions):
+                    results[chunk_positions[local_idx]] = text
+            if progress_callback is not None:
+                fraction = (chunk_num + 1) / len(chunks)
+                progress_callback(progress_start + (progress_end - progress_start) * fraction)
+        return results
+
     def translate_segments(
         self,
         segments: list[TranscriptionSegment],
@@ -266,10 +365,10 @@ class Qwen3Translator:
     ) -> list[TranslatedSegment]:
         """Translate segments via Qwen with parse-retry + optional Marian fallback.
 
-        The progress_callback fires three times: 0.5 after the first
-        Qwen call, 0.9 after the optional retry/fallback, 1.0 at the
-        end. M2.1 phase 2 confirmed smaller batches don't help on CPU,
-        so finer-grained progress isn't possible without fake ticks.
+        The progress_callback ramps from 0 to 0.5 across the first-pass
+        Qwen chunks, hits 0.9 after the optional retry/fallback, and 1.0
+        at the end. Input larger than the model's context window is split
+        across multiple Qwen calls (see ``_qwen_translate_chunked``).
         """
         effective_source = source_lang or "en"
         self._failures_last_call = []
@@ -277,13 +376,15 @@ class Qwen3Translator:
         translatable_indices = [i for i, seg in enumerate(segments) if _is_translatable_text(seg.text)]
         translatable_segments = [segments[i] for i in translatable_indices]
 
-        # First attempt.
-        if translatable_segments:
-            qwen_results = self._qwen_translate(translatable_segments, target_lang, effective_source)
-        else:
-            qwen_results = {}
-        if progress_callback is not None:
-            progress_callback(0.5)
+        # First attempt — chunked to fit n_ctx.
+        qwen_results = self._qwen_translate_chunked(
+            translatable_segments,
+            target_lang,
+            effective_source,
+            progress_callback=progress_callback,
+            progress_start=0.0,
+            progress_end=0.5,
+        )
 
         # Identify segments Qwen failed (unparseable or missing index).
         # Indices in qwen_results / translatable_segments are 0-based positions
@@ -299,11 +400,15 @@ class Qwen3Translator:
                 len(retry_segments),
                 len(translatable_segments),
             )
-            retry_results = self._qwen_translate(retry_segments, target_lang, effective_source)
-            # retry_results uses 0..len(retry_segments)-1 as keys; map back.
-            for retry_local, original_local in enumerate(missing_local_indices):
-                if retry_local in retry_results:
-                    qwen_results[original_local] = retry_results[retry_local]
+            retry_results = self._qwen_translate_chunked(
+                retry_segments,
+                target_lang,
+                effective_source,
+            )
+            # retry_results keys are positions in retry_segments; map back to
+            # translatable_segments.
+            for retry_local, translation in retry_results.items():
+                qwen_results[missing_local_indices[retry_local]] = translation
         if progress_callback is not None:
             progress_callback(0.9)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2195,7 +2195,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2206,7 +2206,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2233,9 +2233,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2246,7 +2246,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4536,7 +4536,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.35.0"
+version = "0.35.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Qwen3Translator built one prompt containing every segment, so a long source with hundreds of dense segments overflowed the default 8192-token n_ctx and llama.cpp aborted the call. translate_segments now splits the input across as many Qwen calls as needed via a char-budget heuristic (_chunk_segment_indices); the retry pass is chunked the same way. Indices, progress callback semantics (0 -> 0.5 ramp across first-pass chunks, then 0.9, then 1.0), and the Marian fallback path are preserved. The default 8192 n_ctx is now safe for sources of any length.