### PR TITLE
feat(ai): object detection overlay effect (0.37.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See the [LLM Integration Guide](https://videopython.com/guides/llm-integration/)
 - **`videopython.base`** — `Video`, `VideoMetadata`, `FrameIterator`, `ImageText`, `Transcription`, and shared result types (`BoundingBox`, `FaceTrack`, `SceneBoundary`, ...). No AI dependencies.
 - **`videopython.audio`** — `Audio` with overlay, concat, normalize, time-stretch, silence detection, segment classification.
 - **`videopython.editing`** — `Operation`/`Effect` foundation, `VideoEdit` plan runner with JSON Schema + streaming execution. Transforms (cut, resize, crop, fps, speed, reverse, freeze, silence removal) and effects (blur, zoom, color grading, vignette, Ken Burns, fade, overlays, animated subtitles).
-- **`videopython.ai`** *(install with `[ai]`)* — generation (`TextToVideo`, `ImageToVideo`, `TextToImage`, `TextToSpeech`, `TextToMusic`), understanding (`AudioToText`, `AudioClassifier`, `SceneVLM`, `FaceTracker`, `SemanticSceneDetector`), `FaceTrackingCrop` transform, and the full-pipeline `VideoAnalyzer`.
+- **`videopython.ai`** *(install with `[ai]`)* — generation (`TextToVideo`, `ImageToVideo`, `TextToImage`, `TextToSpeech`, `TextToMusic`), understanding (`AudioToText`, `AudioClassifier`, `SceneVLM`, `FaceTracker`, `ObjectDetector`, `SemanticSceneDetector`), the `FaceTrackingCrop` transform, the `ObjectDetectionOverlay` effect (per-frame bounding boxes + labels), and the full-pipeline `VideoAnalyzer`.
 - **`videopython.ai.dubbing`** — `VideoDubber` for voice-cloned revoicing with timing sync.
 
 ## Examples

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## 0.37.0
+
+Adds `ObjectDetectionOverlay`, an AI-powered, streamable effect (op
+`object_detection_overlay`) that detects objects per frame with a YOLOv8-COCO
+model and draws labelled bounding boxes. Built as three small,
+independently-testable layers mirroring the `FaceTracker` / `FaceTrackingCrop`
+split, so the `editing` layer stays AI-free:
+
+- **AI-free renderer** (`videopython.base.draw_detections`): `draw_detections()`
+  plus a `DetectionStyle` value object and deterministic per-class
+  `class_color()`, reusing the existing `DetectedObject` / `BoundingBox` /
+  `load_font` primitives. Anti-aliased PIL label chips in the box colour,
+  resolution-scaled stroke/font, and edge-aware label placement; testable with
+  synthetic detections, no GPU.
+- **`ObjectDetector`** (`videopython.ai.understanding.objects`): a lazy
+  YOLOv8-COCO detector returning `list[DetectedObject]` with normalized boxes —
+  a near line-for-line counterpart to the face detector (`detect` /
+  `detect_batch`, device selection, confidence threshold, optional
+  `class_filter`).
+- **`ObjectDetectionOverlay`** (`videopython.ai.effects`): a real
+  shape-preserving `Effect`. Only `streaming_init` / `process_frame` are
+  overridden, so the base `Effect._apply` replays the identical contract and
+  eager / streaming cannot drift. `requires=()` keeps it both streamable and
+  LLM-exposed. Detection runs on a `detection_interval` cadence (default 2) and
+  boxes hold between detections, so cost is compute-bound, not memory-bound; cap
+  it with `window`, `detection_interval`, `class_filter`, and `model_size`
+  (`n` / `s` / `m`). The infra `backend` field is `llm_hidden`.
+
+Additive only — no wire-format or behavior change to existing ops. Requires the
+`[ai]` extra.
+
 ## 0.36.1
 
 Internal refactor of the editing core; no wire-format or runtime-behavior

--- a/docs/api/ai/effects.md
+++ b/docs/api/ai/effects.md
@@ -1,0 +1,76 @@
+# AI Effects
+
+AI-powered, shape-preserving [effects](../effects.md). Unlike plain effects,
+these run a model per frame, so they physically live in `videopython.ai` and the
+core editing layer keeps no AI dependency.
+
+## ObjectDetectionOverlay
+
+Detects objects in every frame with a YOLOv8-COCO model and composites tidy,
+colour-coded bounding boxes with class labels (and optional confidence). The
+detector ([`ObjectDetector`](understanding.md#objectdetector)) is constructed
+internally; the box/label drawing is done by the AI-free renderer
+[`videopython.base.draw_detections`](#renderer).
+
+```python
+from videopython.ai import ObjectDetectionOverlay
+from videopython.base import Video
+
+video = Video.from_path("street.mp4")
+
+# Default: per-class colours, confidence shown, detect every 2nd frame.
+annotated = ObjectDetectionOverlay().apply(video)
+
+# Only people and cars, detect every frame, larger model for accuracy.
+annotated = ObjectDetectionOverlay(
+    class_filter=["person", "car"],
+    detection_interval=1,
+    model_size="s",
+).apply(video)
+
+annotated.save("annotated.mp4")
+```
+
+In a JSON editing plan (it is exposed in the LLM-facing schema):
+
+```json
+{
+  "op": "object_detection_overlay",
+  "class_filter": ["person", "car", "dog"],
+  "confidence_threshold": 0.4,
+  "detection_interval": 2,
+  "window": {"start": 0, "stop": 5}
+}
+```
+
+### Performance
+
+`object_detection_overlay` is **streamable** — memory stays bounded on long
+clips — but detection is **compute**-bound: a YOLO forward pass runs per
+sampled frame. To cap cost:
+
+- **`window`** — restrict the overlay (and therefore detection) to a time range.
+- **`detection_interval`** — run detection every Nth frame and hold the boxes in
+  between (default `2`). Higher is faster; fast-moving objects show more lag.
+- **`class_filter`** — fewer classes to draw.
+- **`model_size`** — `"n"` (nano, default, fastest) → `"s"` → `"m"` (most accurate).
+
+::: videopython.ai.ObjectDetectionOverlay
+
+## Renderer
+
+The drawing is a pure, AI-free function reusable with any list of
+[`DetectedObject`](understanding.md#detectedobject). Colours are deterministic
+per class, so a class is the same colour in every frame and across runs.
+
+```python
+from videopython.base import DetectionStyle, class_color, draw_detections
+
+frame = draw_detections(frame, detections, DetectionStyle(show_confidence=False))
+```
+
+::: videopython.base.draw_detections.draw_detections
+
+::: videopython.base.draw_detections.DetectionStyle
+
+::: videopython.base.draw_detections.class_color

--- a/docs/api/ai/understanding.md
+++ b/docs/api/ai/understanding.md
@@ -13,6 +13,7 @@ For a single aggregate, serializable analysis object across multiple analyzers, 
 | AudioClassifier | AST |
 | SemanticSceneDetector | TransNetV2 |
 | FaceTracker | YOLOv8-face |
+| ObjectDetector | YOLOv8-COCO |
 
 ## AudioToText
 
@@ -199,6 +200,33 @@ for track in tracks:
 ```
 
 ::: videopython.ai.FaceTracker
+
+## ObjectDetector
+
+`ObjectDetector` runs a YOLOv8-COCO model and returns a list of
+[`DetectedObject`](#detectedobject) per frame, with normalized bounding boxes
+sorted by confidence. It is the object-detection counterpart to `FaceTracker`
+and powers [`ObjectDetectionOverlay`](effects.md#objectdetectionoverlay).
+
+The Ultralytics weights auto-download on first use; class names come from the
+loaded model. Detection is gated by `confidence_threshold` and optionally
+restricted to `class_filter`.
+
+```python
+from videopython.ai import ObjectDetector
+from videopython.base import Video
+
+video = Video.from_path("street.mp4")
+
+detector = ObjectDetector(model_name="yolov8n.pt", class_filter=("person", "car"))
+for obj in detector.detect(video.frames[0]):
+    print(f"{obj.label} {obj.confidence:.2f} @ {obj.bounding_box}")
+
+# Batched detection over several frames.
+per_frame = detector.detect_batch(video.frames[:16])
+```
+
+::: videopython.ai.ObjectDetector
 
 ## Scene Data Classes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,3 +94,4 @@ nav:
       - AI Video Analysis: api/ai/video_analysis.md
       - AI Dubbing: api/ai/dubbing.md
       - AI Transforms: api/ai/transforms.md
+      - AI Effects: api/ai/effects.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.36.1"
+version = "0.37.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_effects.py
+++ b/src/tests/ai/test_effects.py
@@ -1,0 +1,153 @@
+"""Tests for AI-powered effects (object detection overlay).
+
+The detector is mocked, so these run without GPU or model weights and stay in
+the ai/ suite (the editing suite must not import the optional ``[ai]`` extra).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from videopython.ai.effects import ObjectDetectionOverlay
+from videopython.base.description import BoundingBox, DetectedObject
+from videopython.base.video import Video, VideoMetadata
+from videopython.editing.operation import Operation
+
+
+def _detection() -> DetectedObject:
+    return DetectedObject(
+        label="person",
+        confidence=0.92,
+        bounding_box=BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5),
+    )
+
+
+def _mock_detector(detections):
+    inst = MagicMock()
+    inst.detect.return_value = detections
+    return inst
+
+
+class TestRegistrationAndSchema:
+    def test_registered(self):
+        assert Operation.registry().get("object_detection_overlay") is ObjectDetectionOverlay
+
+    def test_llm_exposed(self):
+        assert "object_detection_overlay" in Operation.llm_registry()
+        assert "object_detection_overlay" in json.dumps(Operation.json_schema())
+
+    def test_backend_is_llm_hidden(self):
+        schema = ObjectDetectionOverlay.llm_json_schema()
+        props = schema["properties"]
+        assert "backend" not in props
+        assert "model_size" in props
+        assert "confidence_threshold" in props
+
+    def test_predict_metadata_is_identity(self):
+        meta = VideoMetadata(height=480, width=640, fps=30, frame_count=60, total_seconds=2.0)
+        out = ObjectDetectionOverlay().predict_metadata(meta)
+        assert (out.width, out.height, out.frame_count) == (640, 480, 60)
+
+
+class TestApply:
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_apply_preserves_shape_and_draws(self, mock_cls):
+        mock_cls.return_value = _mock_detector([_detection()])
+        video = Video.from_frames(np.zeros((5, 200, 200, 3), dtype=np.uint8), fps=30)
+
+        out = ObjectDetectionOverlay().apply(video)
+
+        assert out.frame_shape == (200, 200, 3)
+        assert len(out.frames) == 5
+        assert out.frames.sum() > 0  # boxes were drawn
+
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_no_detections_is_noop(self, mock_cls):
+        mock_cls.return_value = _mock_detector([])
+        video = Video.from_frames(np.zeros((4, 64, 64, 3), dtype=np.uint8), fps=30)
+
+        out = ObjectDetectionOverlay().apply(video)
+        assert out.frames.sum() == 0
+
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_detection_interval_controls_cadence(self, mock_cls):
+        inst = _mock_detector([])
+        mock_cls.return_value = inst
+        video = Video.from_frames(np.zeros((7, 64, 64, 3), dtype=np.uint8), fps=30)
+
+        ObjectDetectionOverlay(detection_interval=3).apply(video)
+
+        # Frames 0, 3, 6 trigger detection; the rest reuse the cache.
+        assert inst.detect.call_count == 3
+
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_class_filter_passed_to_detector(self, mock_cls):
+        mock_cls.return_value = _mock_detector([])
+        video = Video.from_frames(np.zeros((2, 64, 64, 3), dtype=np.uint8), fps=30)
+
+        ObjectDetectionOverlay(class_filter=["person", "car"]).apply(video)
+
+        _, kwargs = mock_cls.call_args
+        assert kwargs["class_filter"] == ("person", "car")
+        assert kwargs["model_name"] == "yolov8n.pt"
+
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_model_size_maps_to_weights(self, mock_cls):
+        mock_cls.return_value = _mock_detector([])
+        video = Video.from_frames(np.zeros((1, 64, 64, 3), dtype=np.uint8), fps=30)
+
+        ObjectDetectionOverlay(model_size="m").apply(video)
+        _, kwargs = mock_cls.call_args
+        assert kwargs["model_name"] == "yolov8m.pt"
+
+
+class TestStreamingContract:
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_streaming_smoke(self, mock_cls):
+        mock_cls.return_value = _mock_detector([_detection()])
+        eff = ObjectDetectionOverlay(detection_interval=1)
+        eff.streaming_init(3, 30.0, 64, 64)
+
+        for i in range(3):
+            out = eff.process_frame(np.zeros((64, 64, 3), dtype=np.uint8), i)
+            assert out.shape == (64, 64, 3)
+            assert out.dtype == np.uint8
+
+        assert eff.streamable is True
+        assert eff.requires == ()  # stays in the streaming plan path
+
+    @patch("videopython.ai.effects.ObjectDetector")
+    def test_eager_matches_streaming(self, mock_cls):
+        # Shared mock instance -> deterministic detections on both paths.
+        mock_cls.return_value = _mock_detector([_detection()])
+        frames = np.zeros((6, 96, 96, 3), dtype=np.uint8)
+
+        eager = ObjectDetectionOverlay(detection_interval=2).apply(Video.from_frames(frames.copy(), fps=30))
+
+        eff = ObjectDetectionOverlay(detection_interval=2)
+        eff.streaming_init(6, 30.0, 96, 96)
+        streamed = np.stack([eff.process_frame(frames[i].copy(), i) for i in range(6)])
+
+        np.testing.assert_array_equal(eager.frames, streamed)
+
+
+class TestPlanValidation:
+    def test_validates_in_a_plan(self):
+        from videopython.editing.video_edit import VideoEdit
+
+        plan = {
+            "segments": [
+                {
+                    "source": "fake.mp4",
+                    "start": 0.0,
+                    "end": 2.0,
+                    "operations": [
+                        {"op": "object_detection_overlay", "class_filter": ["person"], "detection_interval": 2}
+                    ],
+                }
+            ]
+        }
+        source = VideoMetadata(height=480, width=640, fps=30, frame_count=60, total_seconds=2.0)
+        out = VideoEdit.from_dict(plan).validate_with_metadata(source)
+        assert (out.width, out.height) == (640, 480)  # shape-preserving

--- a/src/tests/ai/test_objects.py
+++ b/src/tests/ai/test_objects.py
@@ -1,0 +1,108 @@
+"""Tests for the ObjectDetector understanding primitive (mocked YOLO)."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from videopython.ai.understanding.objects import ObjectDetector
+
+
+class FakeBoxes:
+    """Minimal stand-in for an Ultralytics Results.boxes object."""
+
+    def __init__(self, xyxy, conf, cls):
+        self.xyxy = [np.array(b, dtype=float) for b in xyxy]
+        self.conf = list(conf)
+        self.cls = list(cls)
+
+    def __len__(self):
+        return len(self.xyxy)
+
+
+class FakeResult:
+    def __init__(self, boxes, orig_shape):
+        self.boxes = boxes
+        self.orig_shape = orig_shape
+
+
+def _detector_with(results, class_names=None, **kwargs):
+    """Build an ObjectDetector whose model is a mock returning ``results``."""
+    det = ObjectDetector(**kwargs)
+    det._class_names = class_names or {0: "person", 2: "car"}
+    det._yolo_model = MagicMock(return_value=results)
+    return det
+
+
+def _two_object_result():
+    # person (conf 0.9) and car (conf 0.8) in a 100h x 200w image.
+    boxes = FakeBoxes(
+        xyxy=[[20.0, 10.0, 120.0, 60.0], [0.0, 0.0, 100.0, 50.0]],
+        conf=[0.9, 0.8],
+        cls=[0, 2],
+    )
+    return [FakeResult(boxes, orig_shape=(100, 200))]
+
+
+class TestObjectDetector:
+    def test_detect_normalizes_boxes(self):
+        det = _detector_with(_two_object_result())
+        objs = det.detect(np.zeros((100, 200, 3), dtype=np.uint8))
+
+        assert [o.label for o in objs] == ["person", "car"]
+        person = objs[0]
+        assert person.confidence == pytest.approx(0.9)
+        bb = person.bounding_box
+        assert bb is not None
+        # 20/200, 10/100, 100/200, 50/100
+        assert bb.x == pytest.approx(0.1)
+        assert bb.y == pytest.approx(0.1)
+        assert bb.width == pytest.approx(0.5)
+        assert bb.height == pytest.approx(0.5)
+
+    def test_results_sorted_by_confidence(self):
+        # Provide lower-confidence first; detector should sort descending.
+        boxes = FakeBoxes(
+            xyxy=[[0, 0, 10, 10], [0, 0, 20, 20]],
+            conf=[0.4, 0.95],
+            cls=[2, 0],
+        )
+        det = _detector_with([FakeResult(boxes, (100, 100))])
+        objs = det.detect(np.zeros((100, 100, 3), dtype=np.uint8))
+        assert [o.confidence for o in objs] == [0.95, 0.4]
+
+    def test_class_filter_drops_other_labels(self):
+        det = _detector_with(_two_object_result(), class_filter=("person",))
+        objs = det.detect(np.zeros((100, 200, 3), dtype=np.uint8))
+        assert [o.label for o in objs] == ["person"]
+
+    def test_detect_handles_empty_results(self):
+        det = _detector_with([])
+        assert det.detect(np.zeros((10, 10, 3), dtype=np.uint8)) == []
+
+    def test_detect_batch_list(self):
+        det = _detector_with(_two_object_result() * 2)
+        frames = [np.zeros((100, 200, 3), dtype=np.uint8) for _ in range(2)]
+        batched = det.detect_batch(frames)
+        assert len(batched) == 2
+        assert all(len(d) == 2 for d in batched)
+
+    def test_detect_batch_ndarray(self):
+        det = _detector_with(_two_object_result() * 3)
+        frames = np.zeros((3, 100, 200, 3), dtype=np.uint8)
+        batched = det.detect_batch(frames)
+        assert len(batched) == 3
+
+    def test_detect_batch_empty(self):
+        det = _detector_with([])
+        assert det.detect_batch([]) == []
+
+    def test_cpu_backend_resolves_without_torch(self):
+        det = ObjectDetector(backend="cpu")
+        assert det.execution_device() == "cpu"
+
+    def test_confidence_threshold_passed_to_model(self):
+        det = _detector_with(_two_object_result(), confidence_threshold=0.7)
+        det.detect(np.zeros((100, 200, 3), dtype=np.uint8))
+        _, kwargs = det._yolo_model.call_args
+        assert kwargs["conf"] == 0.7

--- a/src/tests/base/test_draw_detections.py
+++ b/src/tests/base/test_draw_detections.py
@@ -1,0 +1,87 @@
+"""Tests for the AI-free detection overlay renderer."""
+
+import numpy as np
+
+from videopython.base.description import BoundingBox, DetectedObject
+from videopython.base.draw_detections import DetectionStyle, class_color, draw_detections
+
+
+def _frame(h: int = 240, w: int = 320) -> np.ndarray:
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+def _person(conf: float = 0.9) -> DetectedObject:
+    return DetectedObject(
+        label="person",
+        confidence=conf,
+        bounding_box=BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5),
+    )
+
+
+class TestClassColor:
+    def test_reserved_class_is_stable(self):
+        assert class_color("person") == (76, 175, 80)
+
+    def test_deterministic_across_calls(self):
+        assert class_color("zebra") == class_color("zebra")
+
+    def test_distinct_classes_differ(self):
+        assert class_color("person") != class_color("car")
+        assert class_color("zebra") != class_color("giraffe")
+
+    def test_unknown_class_is_valid_rgb(self):
+        r, g, b = class_color("teapot")
+        assert all(0 <= c <= 255 for c in (r, g, b))
+
+
+class TestDrawDetections:
+    def test_preserves_shape_and_dtype(self):
+        out = draw_detections(_frame(), [_person()])
+        assert out.shape == (240, 320, 3)
+        assert out.dtype == np.uint8
+
+    def test_empty_list_is_identity(self):
+        frame = _frame()
+        assert draw_detections(frame, []) is frame
+
+    def test_all_filtered_out_is_identity(self):
+        frame = _frame()
+        style = DetectionStyle(min_confidence=0.95)
+        # Single detection below threshold -> nothing drawn -> same array back.
+        assert draw_detections(frame, [_person(conf=0.5)], style) is frame
+
+    def test_box_color_appears_in_output(self):
+        out = draw_detections(_frame(), [_person()])
+        person = np.array((76, 175, 80))
+        assert np.any(np.all(out == person, axis=-1))
+
+    def test_box_color_override(self):
+        style = DetectionStyle(box_color=(255, 0, 0), show_confidence=False)
+        out = draw_detections(_frame(), [_person()], style)
+        assert np.any(np.all(out == np.array((255, 0, 0)), axis=-1))
+
+    def test_off_frame_box_clips_without_raising(self):
+        det = DetectedObject(
+            label="car",
+            confidence=0.8,
+            bounding_box=BoundingBox(x=0.8, y=-0.2, width=0.6, height=0.5),
+        )
+        out = draw_detections(_frame(), [det])
+        assert out.shape == (240, 320, 3)
+
+    def test_label_chip_flips_inside_when_box_at_top_edge(self):
+        # Box flush with the top edge: chip would overflow above, so it flips
+        # to sit inside the box. Render must still succeed and draw something.
+        det = DetectedObject(
+            label="dog",
+            confidence=0.7,
+            bounding_box=BoundingBox(x=0.1, y=0.0, width=0.3, height=0.4),
+        )
+        out = draw_detections(_frame(), [det])
+        assert np.any(out != 0)
+
+    def test_does_not_mutate_input(self):
+        frame = _frame()
+        original = frame.copy()
+        draw_detections(frame, [_person()])
+        assert np.array_equal(frame, original)

--- a/src/videopython/ai/__init__.py
+++ b/src/videopython/ai/__init__.py
@@ -1,9 +1,11 @@
+from .effects import ObjectDetectionOverlay
 from .generation import ImageToVideo, TextToImage, TextToMusic, TextToSpeech, TextToVideo
 from .transforms import FaceTrackingCrop
 from .understanding import (
     AudioClassifier,
     AudioToText,
     FaceTracker,
+    ObjectDetector,
     SceneVLM,
     SemanticSceneDetector,
 )
@@ -20,10 +22,13 @@ __all__ = [
     "AudioToText",
     "AudioClassifier",
     "FaceTracker",
+    "ObjectDetector",
     "SceneVLM",
     "SemanticSceneDetector",
     # Transforms (AI-powered)
     "FaceTrackingCrop",
+    # Effects (AI-powered)
+    "ObjectDetectionOverlay",
     # Video analysis
     "VideoAnalysis",
     "VideoAnalysisConfig",

--- a/src/videopython/ai/effects.py
+++ b/src/videopython/ai/effects.py
@@ -1,0 +1,112 @@
+"""AI-powered video effects that require object detection.
+
+Effects here are real :class:`~videopython.editing.operation.Effect` subclasses
+(shape-preserving, streamable) that physically live in ``videopython.ai`` so the
+``videopython.editing`` layer keeps no AI dependency -- the same direction
+``FaceTrackingCrop`` imports ``Operation``. The pixel work is delegated to the
+AI-free renderer in :mod:`videopython.base.draw_detections`.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+import numpy as np
+from pydantic import Field, PrivateAttr
+
+from videopython.ai.understanding.objects import ObjectDetector
+from videopython.base.description import DetectedObject
+from videopython.base.draw_detections import DetectionStyle, draw_detections
+from videopython.editing.operation import Effect
+
+__all__ = ["ObjectDetectionOverlay"]
+
+
+class ObjectDetectionOverlay(Effect):
+    """Detect objects per frame and overlay labelled bounding boxes.
+
+    Runs a YOLOv8-COCO detector and composites tidy, colour-coded boxes with
+    class labels (and optional confidence) onto every frame in the window.
+
+    Detection runs on a ``detection_interval`` cadence in the streaming path and
+    boxes are held between detections, so the cost is *compute*-bound, not
+    *memory*-bound: ``"streamable"`` here means bounded memory, not bounded
+    compute. On long clips, cap cost with ``window`` (limit the time range),
+    a larger ``detection_interval``, a ``class_filter``, and/or the smaller
+    ``model_size``. Because only ``streaming_init`` and ``process_frame`` are
+    overridden, the base ``Effect._apply`` replays the identical contract for
+    in-memory execution, so eager and streaming results cannot drift.
+    """
+
+    op: Literal["object_detection_overlay"] = "object_detection_overlay"
+    streamable: ClassVar[bool] = True
+
+    confidence_threshold: float = Field(0.5, ge=0, le=1, description="Minimum detection confidence to draw a box, 0-1.")
+    class_filter: list[str] | None = Field(
+        None,
+        description='Only draw these COCO class names, e.g. ["person", "car", "dog"]. Null draws all classes.',
+    )
+    show_confidence: bool = Field(True, description="Append the detection confidence as a percentage to each label.")
+    box_color: tuple[int, int, int] | None = Field(
+        None,
+        description="Fixed box color as [R, G, B] (0-255) for every box, or null for distinct per-class colors.",
+    )
+    line_thickness: float = Field(
+        0.003, gt=0, description="Box stroke width as a fraction of the frame's longer side (~3px at 1080p)."
+    )
+    label_font_size: float = Field(
+        0.022, gt=0, description="Label text height as a fraction of the frame's longer side (~24px at 1080p)."
+    )
+    detection_interval: int = Field(
+        2,
+        ge=1,
+        description="Run detection every Nth frame and reuse the last result in between. Higher is faster.",
+    )
+    model_size: Literal["n", "s", "m"] = Field(
+        "n",
+        description=(
+            "YOLOv8 model size: 'n' (nano, fastest), 's' (small), 'm' (medium, most accurate). "
+            "Larger detects better but is slower."
+        ),
+    )
+    backend: Literal["cpu", "gpu", "auto"] = Field(
+        "auto",
+        description="Detection device: 'cpu', 'gpu', or 'auto'.",
+        json_schema_extra={"llm_hidden": True},
+    )
+
+    _detector: ObjectDetector | None = PrivateAttr(default=None)
+    _last: list[DetectedObject] = PrivateAttr(default_factory=list)
+
+    def _style(self) -> DetectionStyle:
+        return DetectionStyle(
+            box_color=self.box_color,
+            line_thickness=self.line_thickness,
+            show_confidence=self.show_confidence,
+            label_font_size=self.label_font_size,
+            min_confidence=self.confidence_threshold,
+        )
+
+    def _init_detector(self) -> None:
+        """Build the detector lazily. Single patch point for tests."""
+        if self._detector is None:
+            self._detector = ObjectDetector(
+                model_name=f"yolov8{self.model_size}.pt",
+                confidence_threshold=self.confidence_threshold,
+                class_filter=tuple(self.class_filter or ()),
+                backend=self.backend,
+            )
+
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+        self._last = []
+        self._init_detector()
+
+    def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
+        if self._detector is None:
+            self._init_detector()
+        assert self._detector is not None
+        # frame_index is 0-based within the effect's window, so frame 0 always
+        # detects; intermediate frames reuse the last result.
+        if frame_index % self.detection_interval == 0:
+            self._last = self._detector.detect(frame)
+        return draw_detections(frame, self._last, self._style())

--- a/src/videopython/ai/understanding/__init__.py
+++ b/src/videopython/ai/understanding/__init__.py
@@ -1,12 +1,14 @@
 from .audio import AudioClassifier, AudioToText
 from .faces import FaceTracker
 from .image import SceneVLM
+from .objects import ObjectDetector
 from .temporal import SemanticSceneDetector
 
 __all__ = [
     "AudioToText",
     "AudioClassifier",
     "FaceTracker",
+    "ObjectDetector",
     "SceneVLM",
     "SemanticSceneDetector",
 ]

--- a/src/videopython/ai/understanding/objects.py
+++ b/src/videopython/ai/understanding/objects.py
@@ -1,0 +1,145 @@
+"""General object detection for the understanding layer.
+
+``ObjectDetector`` is the object-detection counterpart to the face detector in
+``faces.py``: a lazy YOLOv8-COCO wrapper returning
+:class:`~videopython.base.description.DetectedObject` with normalized bounding
+boxes. It mirrors ``_FaceDetector`` (lazy init, device selection, ``detect`` /
+``detect_batch``) so the two share one mental model. Consumed by
+``videopython.ai.effects.ObjectDetectionOverlay``; usable directly for any
+per-frame object analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+import numpy as np
+
+from videopython.ai._device import select_device
+from videopython.base.description import BoundingBox, DetectedObject
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ObjectDetector"]
+
+
+class ObjectDetector:
+    """Lazy YOLOv8-COCO object detector returning normalized detections.
+
+    The Ultralytics weights (default ``yolov8n.pt``) auto-download on first
+    real use; class names come from the loaded model. Detection is gated by
+    ``confidence_threshold`` and optionally restricted to ``class_filter``.
+    """
+
+    DEFAULT_CONFIDENCE_THRESHOLD = 0.5
+
+    def __init__(
+        self,
+        model_name: str = "yolov8n.pt",
+        confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+        class_filter: tuple[str, ...] = (),
+        backend: Literal["cpu", "gpu", "auto"] = "auto",
+    ):
+        """Initialize the detector.
+
+        Args:
+            model_name: Ultralytics COCO model id or path (e.g. ``yolov8n.pt``,
+                ``yolov8s.pt``, ``yolov8m.pt``). Downloaded on first use.
+            confidence_threshold: Minimum detection confidence in ``[0, 1]``.
+            class_filter: If non-empty, only these COCO class names are kept.
+            backend: Detection device - ``"cpu"``, ``"gpu"``, or ``"auto"``.
+        """
+        self.model_name = model_name
+        self.confidence_threshold = confidence_threshold
+        self.class_filter = class_filter
+        self.backend: Literal["cpu", "gpu", "auto"] = backend
+        self._resolved_device: Literal["cpu", "cuda"] | None = None
+        self._yolo_model: Any = None
+        self._class_names: dict[int, str] = {}
+        logger.info("ObjectDetector initialized with model=%s backend=%s", model_name, backend)
+
+    def _resolve_device(self) -> Literal["cpu", "cuda"]:
+        if self._resolved_device is not None:
+            return self._resolved_device
+
+        if self.backend == "cpu":
+            self._resolved_device = "cpu"
+            return self._resolved_device
+
+        if self.backend == "gpu":
+            resolved = select_device(None, mps_allowed=False)
+            if resolved != "cuda":
+                raise ValueError("GPU backend requested but CUDA is not available.")
+            self._resolved_device = "cuda"
+            return self._resolved_device
+
+        resolved_auto = select_device(None, mps_allowed=False)
+        self._resolved_device = "cuda" if resolved_auto == "cuda" else "cpu"
+        return self._resolved_device
+
+    def execution_device(self) -> Literal["cpu", "cuda"]:
+        """Resolved execution device for this detector."""
+        return self._resolve_device()
+
+    def _init_yolo(self) -> None:
+        from ultralytics import YOLO
+
+        self._yolo_model = YOLO(self.model_name)
+        self._class_names = dict(self._yolo_model.names)
+
+        if self._resolve_device() == "cuda":
+            self._yolo_model.to("cuda")
+
+    def _objects_from_yolo_result(self, result: Any) -> list[DetectedObject]:
+        detected: list[DetectedObject] = []
+        boxes = result.boxes
+        if boxes is None:
+            return detected
+
+        img_h, img_w = result.orig_shape
+        for i in range(len(boxes)):
+            label = self._class_names.get(int(boxes.cls[i]), str(int(boxes.cls[i])))
+            if self.class_filter and label not in self.class_filter:
+                continue
+
+            x1, y1, x2, y2 = boxes.xyxy[i].tolist()
+            detected.append(
+                DetectedObject(
+                    label=label,
+                    confidence=float(boxes.conf[i]),
+                    bounding_box=BoundingBox(
+                        x=x1 / img_w,
+                        y=y1 / img_h,
+                        width=(x2 - x1) / img_w,
+                        height=(y2 - y1) / img_h,
+                    ),
+                )
+            )
+        detected.sort(key=lambda d: d.confidence, reverse=True)
+        return detected
+
+    def detect(self, image: np.ndarray) -> list[DetectedObject]:
+        """Detect objects in a single ``(H, W, 3)`` frame."""
+        if self._yolo_model is None:
+            self._init_yolo()
+        assert self._yolo_model is not None
+
+        results = self._yolo_model(image, conf=self.confidence_threshold, verbose=False)
+        if not results:
+            return []
+        return self._objects_from_yolo_result(results[0])
+
+    def detect_batch(self, images: list[np.ndarray] | np.ndarray) -> list[list[DetectedObject]]:
+        """Detect objects in a batch of frames (list or stacked ``(N, H, W, 3)``)."""
+        if isinstance(images, np.ndarray):
+            images = [images[i] for i in range(images.shape[0])] if images.ndim == 4 else [images]
+        if not images:
+            return []
+
+        if self._yolo_model is None:
+            self._init_yolo()
+        assert self._yolo_model is not None
+
+        results = self._yolo_model(images, conf=self.confidence_threshold, verbose=False)
+        return [self._objects_from_yolo_result(result) for result in results]

--- a/src/videopython/base/__init__.py
+++ b/src/videopython/base/__init__.py
@@ -10,6 +10,7 @@ from .description import (
     SceneBoundary,
     SceneDescription,
 )
+from .draw_detections import DetectionStyle, class_color, draw_detections
 from .exceptions import (
     AudioError,
     AudioLoadError,
@@ -44,6 +45,10 @@ __all__ = [
     "ImageText",
     "TextAlign",
     "AnchorPoint",
+    # Detection overlay renderer (AI-free)
+    "draw_detections",
+    "DetectionStyle",
+    "class_color",
     # Transcription data classes
     "Transcription",
     "TranscriptionSegment",

--- a/src/videopython/base/draw_detections.py
+++ b/src/videopython/base/draw_detections.py
@@ -1,0 +1,164 @@
+"""Pure, AI-free renderer for object-detection overlays.
+
+Draws labelled bounding boxes onto a frame from a list of
+:class:`~videopython.base.description.DetectedObject`. This module has **no AI
+dependencies** -- it is the single source of truth for how detections look, so
+it can be unit-tested with synthetic detections and reused by any detector. The
+AI side (``videopython.ai``) only produces the ``DetectedObject`` list and calls
+:func:`draw_detections`.
+
+Visuals: a resolution-scaled box stroke plus a label chip filled in the box's
+own colour (so chip and box read as one unit) with anti-aliased text. Colours
+are deterministic per class via :func:`class_color`, so the same class is the
+same colour in every frame and across runs.
+"""
+
+from __future__ import annotations
+
+import colorsys
+import hashlib
+from dataclasses import dataclass
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from videopython.base.description import DetectedObject
+from videopython.base.fonts import load_font
+
+__all__ = ["DetectionStyle", "class_color", "draw_detections"]
+
+# Hand-picked Material-palette hues for common COCO classes so busy scenes read
+# clearly. Any class not listed gets a deterministic colour from ``class_color``.
+_RESERVED_COLORS: dict[str, tuple[int, int, int]] = {
+    "person": (76, 175, 80),  # green
+    "bicycle": (0, 188, 212),  # cyan
+    "car": (33, 150, 243),  # blue
+    "motorcycle": (156, 39, 176),  # purple
+    "bus": (255, 193, 7),  # amber
+    "truck": (255, 87, 34),  # deep orange
+    "cat": (233, 30, 99),  # pink
+    "dog": (255, 152, 0),  # orange
+}
+
+
+def class_color(label: str) -> tuple[int, int, int]:
+    """Deterministic RGB colour for a class label.
+
+    Common COCO classes get a reserved Material hue; everything else maps
+    ``md5(label) -> HSV hue`` at fixed saturation/value. ``md5`` (not the
+    salted built-in ``hash``) is used so colours are stable across processes
+    and test runs.
+    """
+    reserved = _RESERVED_COLORS.get(label)
+    if reserved is not None:
+        return reserved
+    digest = int(hashlib.md5(label.encode("utf-8")).hexdigest(), 16)
+    hue = (digest % 360) / 360.0
+    r, g, b = colorsys.hsv_to_rgb(hue, 0.7, 0.95)
+    return int(r * 255), int(g * 255), int(b * 255)
+
+
+@dataclass(frozen=True)
+class DetectionStyle:
+    """Styling for :func:`draw_detections`.
+
+    Lengths expressed as a fraction of the frame's longer side are
+    resolution-independent: the same style reads consistently at 1080p and 4k.
+    """
+
+    box_color: tuple[int, int, int] | None = None
+    """Fixed ``(R, G, B)`` for every box, or ``None`` for per-class colours."""
+    line_thickness: float = 0.003
+    """Box stroke width as a fraction of ``max(height, width)`` (~3px at 1080p)."""
+    show_confidence: bool = True
+    """Append the confidence as a whole-number percent to each label."""
+    label_font_size: float = 0.022
+    """Label text height as a fraction of ``max(height, width)`` (~24px at 1080p)."""
+    label_text_color: tuple[int, int, int] = (255, 255, 255)
+    """Colour of the label text drawn on the chip."""
+    label_bg_alpha: int = 200
+    """Opacity (0-255) of the label chip background."""
+    min_confidence: float = 0.0
+    """Detections below this confidence are skipped."""
+    font: str | None = None
+    """Bundled font name or path; ``None`` uses the default font."""
+
+
+def draw_detections(
+    frame: np.ndarray,
+    detections: list[DetectedObject],
+    style: DetectionStyle = DetectionStyle(),
+) -> np.ndarray:
+    """Return a copy of ``frame`` with ``detections`` drawn as labelled boxes.
+
+    Shape-preserving: the result is the same ``(H, W, 3)`` ``uint8`` array. An
+    empty ``detections`` list (or one filtered out by ``min_confidence``) is a
+    no-op that returns ``frame`` unchanged. Boxes are clamped to the frame, so
+    off-frame coordinates clip cleanly instead of raising. Label chips flip
+    inside the box when they would overflow the top edge and clamp horizontally
+    so they never leave the frame.
+
+    Args:
+        frame: Source frame as ``(H, W, 3)`` ``uint8`` (RGB).
+        detections: Objects to draw; each uses its normalized ``bounding_box``.
+        style: Visual styling (colours, stroke width, label options).
+
+    Returns:
+        A new ``(H, W, 3)`` ``uint8`` frame with the overlays composited on.
+    """
+    if not detections:
+        return frame
+
+    h, w = frame.shape[:2]
+    scale = max(h, w)
+    thickness = max(1, round(style.line_thickness * scale))
+    font_px = max(8, round(style.label_font_size * scale))
+    font = load_font(style.font, font_px)
+
+    canvas = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(canvas)
+
+    drew_any = False
+    for det in detections:
+        box = det.bounding_box
+        if box is None or det.confidence < style.min_confidence:
+            continue
+        drew_any = True
+        color = style.box_color or class_color(det.label)
+
+        x0 = max(0, min(w - 1, int(box.x * w)))
+        y0 = max(0, min(h - 1, int(box.y * h)))
+        x1 = max(0, min(w - 1, int((box.x + box.width) * w)))
+        y1 = max(0, min(h - 1, int((box.y + box.height) * h)))
+        draw.rectangle((x0, y0, x1, y1), outline=(*color, 255), width=thickness)
+
+        text = det.label.title()
+        if style.show_confidence:
+            text = f"{text} {det.confidence * 100:.0f}%"
+
+        tb = draw.textbbox((0, 0), text, font=font)
+        text_w, text_h = tb[2] - tb[0], tb[3] - tb[1]
+        pad = max(2, thickness)
+        chip_w, chip_h = text_w + 2 * pad, text_h + 2 * pad
+
+        # Flip the chip inside the box when it would overflow the top edge,
+        # and clamp horizontally so it never leaves the frame.
+        chip_y = y0 - chip_h if y0 - chip_h >= 0 else y0
+        chip_x = max(0, min(x0, w - chip_w))
+        draw.rectangle(
+            (chip_x, chip_y, chip_x + chip_w, chip_y + chip_h),
+            fill=(*color, style.label_bg_alpha),
+        )
+        draw.text(
+            (chip_x + pad - tb[0], chip_y + pad - tb[1]),
+            text,
+            font=font,
+            fill=(*style.label_text_color, 255),
+        )
+
+    if not drew_any:
+        return frame
+
+    out = Image.fromarray(frame).convert("RGBA")
+    out.alpha_composite(canvas)
+    return np.array(out.convert("RGB"), dtype=np.uint8)

--- a/uv.lock
+++ b/uv.lock
@@ -4536,7 +4536,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.36.1"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Add ObjectDetectionOverlay, a streamable AI effect that detects objects per frame with a YOLOv8-COCO model and draws labelled bounding boxes. Three small layers mirror the FaceTracker/FaceTrackingCrop split so the editing layer stays AI-free:

- base/draw_detections.py: AI-free renderer (draw_detections, DetectionStyle, deterministic per-class class_color).
- ai/understanding/objects.py: ObjectDetector, a lazy YOLOv8-COCO detector (detect/detect_batch -> list[DetectedObject]).
- ai/effects.py: ObjectDetectionOverlay Effect. Only streaming_init/ process_frame are overridden, so Effect._apply replays the same contract (eager/streaming parity). requires=() keeps it streamable and LLM-exposed; detection_interval cadence (default 2); model_size n/s/m; backend is llm_hidden.

Includes tests for all three layers (mocked detector, no GPU), docs (api/ai/effects.md, understanding.md, mkdocs nav, README), and exports. Bump version to 0.37.0 with a RELEASE_NOTES entry.