### PR TITLE
feat(editing): stream context-requiring effects (0.39.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,60 @@
 # Release Notes
 
+## 0.39.0
+
+Context-requiring effects now stream. `add_subtitles` — previously the most
+common reason a whole plan silently fell back to eager, in-memory execution —
+runs on the O(1)-memory streaming path. First step of the streaming-first
+migration (TODO.md P0.1).
+
+- **Context threading.** `run_to_file` resolves each segment's `requires`
+  context at plan-build time, re-based onto the segment-local timeline by the
+  same `_segment_context` machinery the eager path uses (slice to
+  `[start, end)`, shift by `-start`, drop empty slices). The resolved kwargs
+  travel on `EffectScheduleEntry.context` and are forwarded to the effect's
+  `streaming_init` — the streaming twin of `_apply_with_context`. Context
+  errors (missing/non-overlapping transcription) raise *before that segment
+  decodes*, with the same exception as the eager path. Context-requiring
+  *transforms* (`silence_removal`) still fall back to eager: an ffmpeg filter
+  string can't consume runtime context.
+- **Transform-after-effect plans now fall back to eager** instead of
+  streaming with reordered semantics. Streaming hoists all transform filters
+  to decode time, *before* every per-frame effect, so a segment like
+  `[fade, resample_fps]` or `[add_subtitles, crop]` streamed against a
+  different timeline/dims than plan order prescribes — mistimed envelopes,
+  and for subtitles a layout resolved at post-transform dims that could fail
+  *after* `validate()` passed. Such plans (a pre-existing latent bug for
+  context-free effects, newly reachable for `add_subtitles`) now execute
+  eagerly, in strict plan order. Transforms-then-effects plans stream as
+  before.
+- **Bounded subtitle overlay cache.** The per-stream overlay memo evicts on
+  cue change (frames arrive in time order; only the active cue's highlight
+  variants are needed), bounding it to `max_words_per_cue + 1` full-frame
+  overlays regardless of video length — without this, an hour of 1080p
+  speech would accumulate gigabytes on the "O(1)-memory" path.
+- **Trailing-frame fix in `stream_segment`.** The scheduled frame count is
+  an estimate (`round(duration * fps)`); on rounding ties ffmpeg can emit
+  one extra frame, which previously escaped every full-range effect (an
+  unfaded frame popping after a fade-out, subtitles vanishing on the last
+  frame). Full-range entries are now open-ended with a clamped window-local
+  index.
+- **`TranscriptionOverlay` ported to the streaming contract**
+  (`streamable=True`): subtitle layout/cue state precomputes in
+  `streaming_init`, per-frame rendering lives in `process_frame`, and the
+  eager path replays exactly that contract via the base `Effect._apply` — one
+  pixel path, parity by construction (the 0.36.1 principle).
+- **`Effect.streaming_init` signature widened** to
+  `streaming_init(total_frames, fps, width, height, **context)`; the base
+  `apply`/`_apply` thread `**context` through. Effects without `requires` are
+  always called without context kwargs. **External `Effect` subclasses must
+  widen their `streaming_init`/`_apply` overrides with `**_context: Any`.**
+- **Behavior changes in `TranscriptionOverlay`:** `window` is now honored
+  (previously ignored — the overlay rendered over the full clip regardless);
+  window-local frame indices are mapped back to segment time, so cue timing is
+  unchanged. `apply()` now mutates input frames in place, like every other
+  effect (it used to return a fresh `Video`); snapshot frames before applying
+  if you compare against the input.
+
 ## 0.38.0
 
 Validation/repair primitives that let an LLM-driven compiler converge on a valid

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -98,7 +98,8 @@ Each operation contributes either a ffmpeg `-vf` filter
 streamable, `run_to_file` falls back to eager (`run()` + `save()`).
 
 **Streamable transforms**: `resize`, `crop`, `resample_fps`.
-**Streamable effects**: every `Effect` except `add_subtitles`.
+**Streamable effects**: every `Effect`, including the context-requiring
+`add_subtitles` (pass `context=` to `run_to_file`).
 
 ## Context Data
 
@@ -110,7 +111,12 @@ of the `context` dict and threads them into `apply` / `predict_metadata`:
 ```python
 edit = VideoEdit.from_dict(plan)
 video = edit.run(context={"transcription": my_transcription})
+edit.run_to_file("out.mp4", context={"transcription": my_transcription})
 ```
+
+On both paths, time-based context values are re-based onto each cut
+segment's local timeline; on the streaming path the resolved values are
+delivered to the effect's `streaming_init`.
 
 ## Validation
 

--- a/docs/api/effects.md
+++ b/docs/api/effects.md
@@ -72,8 +72,10 @@ list. The `window` field travels inline as a nested object:
 
 ## Available Effects
 
-Every effect except `add_subtitles` is streamable (compatible with
-`VideoEdit.run_to_file()` for constant-memory processing).
+Every effect is streamable (compatible with `VideoEdit.run_to_file()` for
+constant-memory processing). Context-requiring effects (`add_subtitles`)
+stream too: pass `context=` to `run_to_file` and the runner re-bases it onto
+each segment's local timeline.
 
 | op | Class | Description |
 |---|---|---|
@@ -87,7 +89,7 @@ Every effect except `add_subtitles` is streamable (compatible with
 | `fade` | `Fade` | Audio + video fade in/out/in_out |
 | `volume_adjust` | `VolumeAdjust` | Audio-only effect |
 | `text_overlay` | `TextOverlay` | Rendered text on top of frames |
-| `add_subtitles` | `TranscriptionOverlay` | Requires `transcription` context |
+| `add_subtitles` | `TranscriptionOverlay` | Word-level subtitles; requires `transcription` context |
 | `shake` | `Shake` | Per-frame jitter (random / rhythmic / decay) |
 | `punch_in` | `PunchIn` | Snap-zoom emphasis with optional release |
 | `flash` | `Flash` | Solid-color frame flash with attack/decay |

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -189,7 +189,7 @@ llm_schema = cls.llm_json_schema()       # LLM-facing (llm_hidden dropped)
 | `fade` | `Fade` | effect | yes |
 | `volume_adjust` | `VolumeAdjust` | effect | yes |
 | `text_overlay` | `TextOverlay` | effect | yes |
-| `add_subtitles` | `TranscriptionOverlay` | effect | no (requires `transcription`) |
+| `add_subtitles` | `TranscriptionOverlay` | effect | yes (requires `transcription` context) |
 | `shake` | `Shake` | effect | yes |
 | `punch_in` | `PunchIn` | effect | yes |
 | `flash` | `Flash` | effect | yes |

--- a/docs/examples/large-videos.md
+++ b/docs/examples/large-videos.md
@@ -49,6 +49,14 @@ When all operations are streamable, frames are never loaded into memory. If any 
 is not streamable (e.g. `reverse`, `speed_change`), the pipeline falls back to eager
 mode automatically.
 
+Context-requiring effects stream too: pass `context=` to `run_to_file` and
+e.g. `add_subtitles` burns word-level subtitles on the streaming path, with
+the transcription re-based onto each segment's local timeline:
+
+```python
+edit.run_to_file("output.mp4", context={"transcription": transcription})
+```
+
 See the [Operations](../api/operations.md#registered-operations) table for the
 list of streamable ops. Inspect `Operation.get(op_id).streamable` programmatically.
 

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -264,7 +264,13 @@ out of the `context` dict and threads them into the op:
 # silence_removal and add_subtitles both need a transcription
 edit = VideoEdit.from_dict(plan)
 video = edit.run(context={"transcription": transcription})
+# ... or stream to disk; context-requiring effects stream too
+edit.run_to_file("out.mp4", context={"transcription": transcription})
 ```
+
+Time-based context values (e.g. a `Transcription` with source-absolute
+timestamps) are re-based onto each cut segment's local timeline
+automatically, on both the eager and streaming paths.
 
 Discover requires-aware ops via the registry:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.38.0"
+version = "0.39.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/base/test_transcription.py
+++ b/src/tests/base/test_transcription.py
@@ -7,9 +7,15 @@ from videopython.base.video import Video
 from videopython.editing.transcription_overlay import TranscriptionOverlay
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def dummy_video():
-    """Create a 10-second video with black frames."""
+    """Create a 10-second video with black frames.
+
+    Function-scoped: ``TranscriptionOverlay.apply`` replays the streaming
+    contract via ``Effect._apply``, which (like every effect) mutates the
+    input frames in place, so a shared instance would leak overlays across
+    tests.
+    """
     return Video.from_image(np.zeros((360, 640, 3), dtype=np.uint8), fps=30, length_seconds=10.0)
 
 
@@ -106,21 +112,17 @@ def test_transcription_overlay_frame_content_changes(dummy_video, dummy_transcri
     """Test that TranscriptionOverlay actually modifies frame content during active segments."""
     overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH)
 
+    # apply() mutates frames in place (the Effect contract), so snapshot first.
+    original_frame_at_1s = dummy_video.frames[30].copy()  # 30fps * 1s = frame 30
+    original_frame_at_4s = dummy_video.frames[120].copy()  # 30fps * 4s = frame 120
+
     result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
 
     # Frame at timestamp 1.0 should have text overlay (within first segment 0.0-1.8)
-    frame_at_1s = result_video.frames[30]  # 30fps * 1s = frame 30
-    original_frame_at_1s = dummy_video.frames[30]
-
-    # The frames should be different (overlay was applied)
-    assert not np.array_equal(frame_at_1s, original_frame_at_1s)
+    assert not np.array_equal(result_video.frames[30], original_frame_at_1s)
 
     # Frame at timestamp 4.0 should be unchanged (no active segment)
-    frame_at_4s = result_video.frames[120]  # 30fps * 4s = frame 120
-    original_frame_at_4s = dummy_video.frames[120]
-
-    # The frames should be identical (no overlay applied)
-    assert np.array_equal(frame_at_4s, original_frame_at_4s)
+    assert np.array_equal(result_video.frames[120], original_frame_at_4s)
 
 
 def test_transcription_overlay_defaults_font_when_none(dummy_video, dummy_transcription):
@@ -129,12 +131,16 @@ def test_transcription_overlay_defaults_font_when_none(dummy_video, dummy_transc
 
     assert overlay.font_filename is None
 
+    # apply() mutates frames in place (the Effect contract), so snapshot first.
+    original_at_1s = dummy_video.frames[30].copy()
+    original_at_4s = dummy_video.frames[120].copy()
+
     result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
 
     # Active segment (0.0-1.8): frame at 1s must be modified despite no font path.
-    assert not np.array_equal(result_video.frames[30], dummy_video.frames[30])
+    assert not np.array_equal(result_video.frames[30], original_at_1s)
     # Inactive region (~4s): frame unchanged.
-    assert np.array_equal(result_video.frames[120], dummy_video.frames[120])
+    assert np.array_equal(result_video.frames[120], original_at_4s)
 
 
 def test_transcription_with_offset(dummy_transcription):
@@ -739,12 +745,16 @@ def test_overlay_normalizes_long_lowercase_segment(dummy_video):
     )
     overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH, font_size=20)
 
+    # apply() mutates frames in place (the Effect contract), so snapshot first.
+    original_at_1s = dummy_video.frames[30].copy()
+    original_at_4s = dummy_video.frames[120].copy()
+
     result_video = overlay.apply(video=dummy_video, transcription=transcription)
 
     assert isinstance(result_video, Video)
     # Active region (~1s) is modified; inactive region (~4s) is untouched.
-    assert not np.array_equal(result_video.frames[30], dummy_video.frames[30])
-    assert np.array_equal(result_video.frames[120], dummy_video.frames[120])
+    assert not np.array_equal(result_video.frames[30], original_at_1s)
+    assert np.array_equal(result_video.frames[120], original_at_4s)
 
 
 def test_overlay_normalization_can_be_disabled(dummy_video, dummy_transcription):

--- a/src/tests/editing/test_operation.py
+++ b/src/tests/editing/test_operation.py
@@ -8,7 +8,7 @@ behavioural tests live in ``test_transforms.py`` / ``test_effects.py``.
 from __future__ import annotations
 
 import json
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 import numpy as np
 import pytest
@@ -182,7 +182,7 @@ class _Brighten(Effect):
 
     delta: int = Field(10, ge=-255, le=255, description="Amount added to every pixel (clipped to uint8).")
 
-    def _apply(self, video: Video) -> Video:
+    def _apply(self, video: Video, **_context: Any) -> Video:
         from videopython.base.video import Video as _V
 
         out = np.clip(video.frames.astype(np.int16) + self.delta, 0, 255).astype(np.uint8)
@@ -194,7 +194,7 @@ class _Brighten(Effect):
 class _ShapeBreaker(Effect):
     op: Literal["_shape_breaker"] = "_shape_breaker"
 
-    def _apply(self, video: Video) -> Video:
+    def _apply(self, video: Video, **_context: Any) -> Video:
         from videopython.base.video import Video as _V
 
         return _V.from_frames(video.frames[:-1], fps=video.fps)

--- a/src/tests/editing/test_streaming.py
+++ b/src/tests/editing/test_streaming.py
@@ -1,17 +1,22 @@
 """Tests for the streaming video processing pipeline."""
 
+import subprocess
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 from PIL import Image
 
 from tests.test_config import SMALL_VIDEO_PATH
+from videopython.base.transcription import Transcription, TranscriptionWord
 from videopython.base.video import Video, VideoMetadata
 from videopython.editing import VideoEdit
 from videopython.editing.effects import ColorGrading, Fade
+from videopython.editing.operation import TimeRange
 from videopython.editing.streaming import EffectScheduleEntry, FrameEncoder, StreamingSegmentPlan, stream_segment
+from videopython.editing.transcription_overlay import TranscriptionOverlay
 
 
 @pytest.fixture
@@ -567,3 +572,227 @@ class TestFrameEncoder:
             assert meta.height == 64
         finally:
             out_path.unlink(missing_ok=True)
+
+
+class TestContextStreaming:
+    """Context-requiring effects (add_subtitles) run on the streaming path.
+
+    The plan builder resolves `requires` context onto the segment-local
+    timeline and carries it on the schedule entry; the segment uses a
+    mid-video cut (start > 0) so these tests fail if re-basing is skipped.
+    """
+
+    _PLAN = {
+        "segments": [
+            {
+                "source": SMALL_VIDEO_PATH,
+                "start": 4.0,
+                "end": 8.0,
+                "operations": [{"op": "add_subtitles", "font_scale": 0.1}],
+            }
+        ],
+    }
+
+    @staticmethod
+    def _absolute_transcription() -> Transcription:
+        # Source-absolute words overlapping the [4.0, 8.0) cut.
+        return Transcription(
+            words=[
+                TranscriptionWord(start=4.5, end=5.5, word="hello"),
+                TranscriptionWord(start=5.5, end=6.5, word="streaming"),
+                TranscriptionWord(start=6.5, end=7.5, word="world"),
+            ]
+        )
+
+    def test_add_subtitles_streams_and_matches_eager(self, tmp_path):
+        """run_to_file must not fall back to eager, and must match run()."""
+        context = {"transcription": self._absolute_transcription()}
+        eager_video = VideoEdit.from_dict(self._PLAN).run(context=context)
+
+        out_path = tmp_path / "subtitled.mp4"
+        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("fell back to eager")):
+            VideoEdit.from_dict(self._PLAN).run_to_file(out_path, context=context)
+        streamed_video = Video.from_path(str(out_path))
+
+        assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
+
+        # Frame inside the first cue (segment-local t=1.0s == source t=5.0s).
+        active = round(1.0 * 24)
+        eager_frame = eager_video.frames[active].astype(np.float32)
+        stream_frame = streamed_video.frames[active].astype(np.float32)
+        mae = np.abs(eager_frame - stream_frame).mean()
+        assert mae < 15, f"Mean absolute error too high: {mae}"
+
+        # The subtitle was actually drawn: against the raw (no-subtitle) cut,
+        # a meaningful share of pixels changed by far more than codec noise.
+        # Guards the failure mode where both paths silently drop the context
+        # and the parity assertion above passes vacuously.
+        baseline = Video.from_path(SMALL_VIDEO_PATH, start_second=4.0, end_second=8.0)
+        drawn_diff = np.abs(baseline.frames[active].astype(np.float32) - stream_frame)
+        drawn_fraction = (drawn_diff > 50).mean()
+        assert drawn_fraction > 0.005, f"No subtitle pixels detected: {drawn_fraction}"
+
+        # Re-base proof: before the first re-based cue (local t=0.1s; words
+        # start at local 0.5s) the frame is the unmodified source. Absolute
+        # (un-re-based) timestamps would draw here (4.5-7.5s overlaps 0.1s
+        # only if timestamps were kept source-absolute -- they must not be).
+        quiet = round(0.1 * 24)
+        quiet_diff = np.abs(
+            baseline.frames[quiet].astype(np.float32) - streamed_video.frames[quiet].astype(np.float32)
+        ).mean()
+        assert quiet_diff < 15, f"Frame before first cue was modified: {quiet_diff}"
+
+    def test_missing_context_raises_before_decode(self, tmp_path):
+        """No transcription in context -> the op's own clear error, pre-decode."""
+        edit = VideoEdit.from_dict(self._PLAN)
+        with pytest.raises(ValueError, match="requires transcription data"):
+            edit.run_to_file(tmp_path / "out.mp4")
+
+    def test_no_overlap_context_raises_like_eager(self, tmp_path):
+        """Words entirely outside the cut are dropped by re-basing -> same error."""
+        context = {
+            "transcription": Transcription(words=[TranscriptionWord(start=50.0, end=51.0, word="late")]),
+        }
+        edit = VideoEdit.from_dict(self._PLAN)
+        with pytest.raises(ValueError, match="requires transcription data"):
+            edit.run_to_file(tmp_path / "out.mp4", context=context)
+
+    def test_effect_then_transform_falls_back_and_matches_eager(self, tmp_path):
+        """A transform after add_subtitles can't stream in plan order; the
+        plan falls back to eager so validate()/run()/run_to_file() agree.
+
+        Regression: streaming hoisted the crop to decode time and resolved
+        the subtitle layout at post-crop dims, so a plan that passed
+        validate() could raise SUBTITLE_UNFITTABLE mid-run_to_file (or
+        render visibly differently from run()).
+        """
+        plan = {
+            "segments": [
+                {
+                    "source": SMALL_VIDEO_PATH,
+                    "start": 4.0,
+                    "end": 8.0,
+                    "operations": [
+                        {"op": "add_subtitles", "font_scale": 0.1},
+                        {"op": "crop", "width": 400, "height": 300},
+                    ],
+                }
+            ],
+        }
+        context = {"transcription": self._absolute_transcription()}
+        eager_video = VideoEdit.from_dict(plan).run(context=context)
+
+        out_path = tmp_path / "out.mp4"
+        with patch.object(
+            VideoEdit, "_run_to_file_eager", autospec=True, side_effect=VideoEdit._run_to_file_eager
+        ) as eager_spy:
+            VideoEdit.from_dict(plan).run_to_file(out_path, context=context)
+        assert eager_spy.called, "effect-then-transform plan must take the eager fallback"
+        streamed_video = Video.from_path(str(out_path))
+
+        assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
+        active = round(1.0 * 24)
+        mae = np.abs(
+            eager_video.frames[active].astype(np.float32) - streamed_video.frames[active].astype(np.float32)
+        ).mean()
+        assert mae < 15, f"Mean absolute error too high: {mae}"
+
+
+class TestTranscriptionOverlayStreamingHooks:
+    """Deterministic synthetic-frame tests of the streaming contract itself."""
+
+    @staticmethod
+    def _local_transcription() -> Transcription:
+        return Transcription(
+            words=[
+                TranscriptionWord(start=0.5, end=1.0, word="hello"),
+                TranscriptionWord(start=1.0, end=1.5, word="world"),
+            ]
+        )
+
+    def test_process_frame_draws_inside_cue_only(self):
+        overlay = TranscriptionOverlay(font_scale=0.1)
+        overlay.streaming_init(48, 24.0, 640, 360, transcription=self._local_transcription())
+
+        frame = np.zeros((360, 640, 3), dtype=np.uint8)
+        # t = 0.75s: inside the cue -> pixels drawn.
+        inside = overlay.process_frame(frame.copy(), round(0.75 * 24))
+        assert inside.any()
+        # t = 0.1s: before the cue -> untouched.
+        outside = overlay.process_frame(frame.copy(), round(0.1 * 24))
+        assert not outside.any()
+
+    def test_window_offsets_timestamps(self):
+        """With a window, frame indices are window-local; timestamps must not be."""
+        overlay = TranscriptionOverlay(font_scale=0.1, window=TimeRange(start=1.0, stop=2.0))
+        overlay.streaming_init(24, 24.0, 640, 360, transcription=self._local_transcription())
+
+        frame = np.zeros((360, 640, 3), dtype=np.uint8)
+        # Window-local index 6 -> segment t = 1.25s: inside the "world" word.
+        inside = overlay.process_frame(frame.copy(), 6)
+        assert inside.any()
+        # Window-local index 20 -> segment t ~ 1.83s: past the last word.
+        outside = overlay.process_frame(frame.copy(), 20)
+        assert not outside.any()
+
+    def test_streaming_init_without_transcription_raises(self):
+        overlay = TranscriptionOverlay()
+        with pytest.raises(ValueError, match="requires transcription data"):
+            overlay.streaming_init(48, 24.0, 640, 360)
+
+    def test_overlay_cache_is_bounded_by_cue_change_eviction(self):
+        """Only the active cue's highlight variants stay cached.
+
+        Regression: the per-stream overlay memo accumulated a full-frame
+        RGBA canvas per (cue, highlight) pair for the whole stream --
+        gigabytes on long subtitled videos, on the "O(1)-memory" path.
+        """
+        overlay = TranscriptionOverlay(font_scale=0.1, max_words_per_cue=2)
+        transcription = Transcription(
+            words=[
+                TranscriptionWord(start=0.0, end=0.5, word="one"),
+                TranscriptionWord(start=0.5, end=1.0, word="two"),
+                TranscriptionWord(start=1.0, end=1.5, word="three"),
+                TranscriptionWord(start=1.5, end=2.0, word="four"),
+            ]
+        )
+        overlay.streaming_init(48, 24.0, 640, 360, transcription=transcription)
+
+        frame = np.zeros((360, 640, 3), dtype=np.uint8)
+        for i in range(48):
+            overlay.process_frame(frame.copy(), i)
+
+        # Two 2-word cues were rendered; only the second (active) cue's
+        # variants may remain: at most one per word plus a no-highlight one.
+        assert 0 < len(overlay._stream_cache) <= 3
+        assert all(text == overlay._stream_current_cue for text, _ in overlay._stream_cache)
+
+
+class TestTrailingFrameSchedule:
+    """Frames past the round(duration*fps) estimate still get full-range effects."""
+
+    def test_fade_out_covers_rounding_tie_extra_frame(self, tmp_path):
+        # At 10 fps, the cut [1.0, 4.05] schedules round(3.05 * 10) = 30
+        # frames while ffmpeg can emit 31 on the rounding tie. Without
+        # open-ended schedule entries the extra frame escaped the fade-out
+        # and popped back to full brightness on the last frame.
+        src_10fps = tmp_path / "src_10fps.mp4"
+        subprocess.run(
+            ["ffmpeg", "-y", "-loglevel", "error", "-i", SMALL_VIDEO_PATH, "-r", "10", "-an", str(src_10fps)],
+            check=True,
+        )
+        plan = {
+            "segments": [
+                {
+                    "source": str(src_10fps),
+                    "start": 1.0,
+                    "end": 4.05,
+                    "operations": [{"op": "fade", "mode": "out", "duration": 1.0}],
+                }
+            ],
+        }
+        out_path = tmp_path / "faded.mp4"
+        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("fell back to eager")):
+            VideoEdit.from_dict(plan).run_to_file(out_path)
+        result = Video.from_path(str(out_path))
+        assert result.frames[-1].mean() < 5, f"Last frame escaped the fade: {result.frames[-1].mean()}"

--- a/src/tests/editing/test_video_edit.py
+++ b/src/tests/editing/test_video_edit.py
@@ -920,9 +920,16 @@ class TestGenericContextRebasing:
 
 
 class TestStreamingRequiresGuard:
-    """An op that `requires` runtime context forces the eager path."""
+    """How `requires` interacts with the streaming plan builder.
 
-    def test_build_streaming_plan_returns_none_for_requires_op(self, monkeypatch):
+    Context-requiring *effects* stream: their requires-keys are resolved,
+    re-based onto the segment-local timeline, and carried on the schedule
+    entry. Context-requiring *transforms* (the ffmpeg-filter path) still
+    force the eager fallback -- a filter string can't consume runtime
+    context.
+    """
+
+    def test_build_streaming_plan_returns_none_for_requires_transform(self, monkeypatch):
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -938,9 +945,105 @@ class TestStreamingRequiresGuard:
         seg = plan.segments[0]
         # resize is streamable, so without the guard a plan is built.
         assert plan._build_streaming_plan(seg, None, None, None) is not None
-        # Same streamable op, now declaring a context requirement -> eager.
+        # Same streamable transform, now declaring a context requirement -> eager.
         monkeypatch.setattr(Resize, "requires", ("transcription",))
         assert plan._build_streaming_plan(seg, None, None, None) is None
+
+    def test_requires_effect_builds_plan_with_rebased_context(self):
+        plan = VideoEdit.from_dict(
+            {
+                "segments": [
+                    _segment(
+                        source=SMALL_VIDEO_PATH,
+                        start=4.0,
+                        end=8.0,
+                        operations=[{"op": "add_subtitles"}],
+                    )
+                ]
+            }
+        )
+        tx = _make_transcription([(4.5, 5.5, "hello"), (5.5, 6.5, "world")])
+        built = plan._build_streaming_plan(plan.segments[0], None, None, None, {"transcription": tx})
+
+        assert built is not None
+        [entry] = built.effect_schedule
+        rebased = entry.context["transcription"]
+        words = [w for s in rebased.segments for w in s.words]
+        # Source-absolute 4.5-6.5s -> segment-local 0.5-2.5s (offset by -start).
+        assert words[0].start == pytest.approx(0.5)
+        assert words[-1].end == pytest.approx(2.5)
+
+    def test_requires_effect_without_context_builds_plan_with_empty_context(self):
+        # The plan still builds; streaming_init raises the op's own clear
+        # "requires transcription data" error pre-decode, mirroring eager.
+        plan = VideoEdit.from_dict(
+            {
+                "segments": [
+                    _segment(
+                        source=SMALL_VIDEO_PATH,
+                        start=0.0,
+                        end=1.0,
+                        operations=[{"op": "add_subtitles"}],
+                    )
+                ]
+            }
+        )
+        built = plan._build_streaming_plan(plan.segments[0], None, None, None)
+        assert built is not None
+        assert built.effect_schedule[0].context == {}
+
+    def test_context_free_effect_gets_empty_entry_context(self):
+        plan = VideoEdit.from_dict(
+            {
+                "segments": [
+                    _segment(
+                        source=SMALL_VIDEO_PATH,
+                        start=0.0,
+                        end=1.0,
+                        operations=[{"op": "color_adjust", "brightness": 0.2}],
+                    )
+                ]
+            }
+        )
+        tx = _make_transcription([(0.2, 0.8, "hello")])
+        built = plan._build_streaming_plan(plan.segments[0], None, None, None, {"transcription": tx})
+        assert built is not None
+        # Only `requires` keys land on the entry -- never the whole context.
+        assert built.effect_schedule[0].context == {}
+
+
+class TestStreamingOpOrderGuard:
+    """A transform after a scheduled effect forces the eager fallback.
+
+    vf filters run at decode time, before every scheduled effect's
+    process_frame, so an effect-then-transform plan cannot stream in plan
+    order: the effect's frame range and streaming_init dims/fps would be
+    computed against a timeline the later filter changes.
+    """
+
+    @staticmethod
+    def _plan(operations: list[dict[str, Any]]) -> VideoEdit:
+        return VideoEdit.from_dict(
+            {"segments": [_segment(source=SMALL_VIDEO_PATH, start=0.0, end=2.0, operations=operations)]}
+        )
+
+    def test_transform_after_effect_returns_none(self):
+        plan = self._plan(
+            [
+                {"op": "fade", "mode": "in", "duration": 0.5},
+                {"op": "resize", "width": 64, "height": 64},
+            ]
+        )
+        assert plan._build_streaming_plan(plan.segments[0], None, None, None) is None
+
+    def test_transform_before_effect_streams(self):
+        plan = self._plan(
+            [
+                {"op": "resize", "width": 64, "height": 64},
+                {"op": "fade", "mode": "in", "duration": 0.5},
+            ]
+        )
+        assert plan._build_streaming_plan(plan.segments[0], None, None, None) is not None
 
 
 class TestPostOpsGuard:

--- a/src/videopython/ai/effects.py
+++ b/src/videopython/ai/effects.py
@@ -9,7 +9,7 @@ AI-free renderer in :mod:`videopython.base.draw_detections`.
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 import numpy as np
 from pydantic import Field, PrivateAttr
@@ -97,7 +97,7 @@ class ObjectDetectionOverlay(Effect):
                 backend=self.backend,
             )
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._last = []
         self._init_detector()
 

--- a/src/videopython/editing/effects.py
+++ b/src/videopython/editing/effects.py
@@ -109,7 +109,7 @@ class FullImageOverlay(Effect):
         img_pil.paste(overlay_pil, (0, 0), overlay_pil)
         return np.array(img_pil)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._load_overlay()
         self._stream_total = total_frames
         self._stream_fade_frames = round(self.fade_time * fps) if self.fade_time > 0 else 0
@@ -121,7 +121,7 @@ class FullImageOverlay(Effect):
         fade_alpha = 1.0 if dist_from_end >= self._stream_fade_frames else dist_from_end / self._stream_fade_frames
         return self._overlay_frame(frame, fade_alpha)
 
-    def _apply(self, video: Video) -> Video:
+    def _apply(self, video: Video, **_context: Any) -> Video:
         overlay = self._load_overlay()
         if video.frame_shape != overlay[:, :, :3].shape:
             raise ValueError(f"Mismatch of overlay shape `{overlay.shape}` with video shape: `{video.frame_shape}`!")
@@ -181,7 +181,7 @@ class Blur(Effect):
             ratios = np.linspace(1.0, 1 / n_frames, n_frames)
         return base_sigma * np.sqrt(np.maximum(1, np.round(ratios * self.iterations)))
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_sigmas = self._compute_sigmas(total_frames)
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -215,7 +215,7 @@ class Zoom(Effect):
             crop_w, crop_h = crop_w[::-1], crop_h[::-1]
         return np.stack([crop_w, crop_h], axis=1)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_crops = self._crop_sizes(total_frames, width, height)
         self._stream_width = width
         self._stream_height = height
@@ -317,7 +317,7 @@ class Vignette(Effect):
         mask = 1.0 - np.clip(distance - 0.5, 0, 1) * 2 * self.strength
         return mask.astype(np.float32)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         if self._mask is None or self._mask.shape != (height, width):
             self._mask = self._create_mask(height, width)
         self._stream_mask_3d = self._mask[:, :, np.newaxis]
@@ -326,7 +326,7 @@ class Vignette(Effect):
         assert self._stream_mask_3d is not None
         return (frame.astype(np.float32) * self._stream_mask_3d).astype(np.uint8)
 
-    def _apply(self, video: Video) -> Video:
+    def _apply(self, video: Video, **_context: Any) -> Video:
         logger.info("Applying vignette effect...")
         height, width = video.frame_shape[:2]
         if self._mask is None or self._mask.shape != (height, width):
@@ -404,7 +404,7 @@ class KenBurns(Effect):
             regions[i] = (x, y, crop_w, crop_h)
         return regions
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_regions = self._precompute_regions(total_frames, width, height)
         self._stream_target_w = width
         self._stream_target_h = height
@@ -461,7 +461,7 @@ class Fade(Effect):
             alpha[-ramp:] = np.minimum(alpha[-ramp:], _compute_curve(t, self.curve))
         return alpha
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_alpha = self._fade_envelope(total_frames, fps)
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -649,7 +649,7 @@ class _AnchoredOverlay(Effect):
         rgb = region[:, :, :3].astype(np.float32)
         return alpha, rgb, (dst_y, dst_x, paste_h, paste_w)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         params = self._blend_params(width, height)
         if params is None:
             self._stream_noop = True
@@ -966,7 +966,7 @@ class Shake(Effect):
         M = np.array([[1.0, 0.0, dx], [0.0, 1.0, dy]], dtype=np.float32)
         return cv2.warpAffine(frame, M, (w, h), borderMode=cv2.BORDER_REFLECT)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_offsets = self._compute_offsets(total_frames, fps)
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -1028,7 +1028,7 @@ class PunchIn(Effect):
         cropped = frame[y : y + crop_h, x : x + crop_w]
         return cv2.resize(cropped, (width, height), interpolation=cv2.INTER_LINEAR)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_zooms = self._zoom_envelope(total_frames)
         self._stream_width = width
         self._stream_height = height
@@ -1091,7 +1091,7 @@ class Flash(Effect):
             alpha[:] = self.peak_alpha
         return alpha
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_alpha = self._alpha_envelope(total_frames)
         self._stream_color = np.array(self.color, dtype=np.float32)
 
@@ -1163,7 +1163,7 @@ class ChromaticAberration(Effect):
             out[:, :, 2] = cv2.remap(b, b_map_x, b_map_y, cv2.INTER_LINEAR, borderMode=cv2.BORDER_REPLICATE)
         return out
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         if self.mode == "radial":
             self._stream_maps = self._build_radial_maps(width, height)
 
@@ -1226,7 +1226,7 @@ class Glitch(Effect):
 
         return out
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         return None
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -1266,7 +1266,7 @@ class FilmGrain(Effect):
             noise = rng.standard_normal((h, w, 3), dtype=np.float32) * amp
         return np.clip(frame.astype(np.float32) + noise, 0, 255).astype(np.uint8)
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         return None
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -1308,7 +1308,7 @@ class Sharpen(Effect):
         sharpened = cv2.addWeighted(frame, 1.0 + self.amount, blurred, -self.amount, 0)
         return sharpened
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         return None
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -1355,7 +1355,7 @@ class Pixelate(Effect):
         frame[y : y + h, x : x + w] = big
         return frame
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_region_px = self._resolve_region(width, height)
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -1410,7 +1410,7 @@ class MirrorFlip(Effect):
             out[:half, :] = out[h - half :, :][::-1, :]
         return out
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         return None
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
@@ -1470,7 +1470,7 @@ class Kaleidoscope(Effect):
             borderMode=cv2.BORDER_REFLECT,
         )
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         self._stream_map_x, self._stream_map_y = self._build_maps(width, height)
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:

--- a/src/videopython/editing/operation.py
+++ b/src/videopython/editing/operation.py
@@ -397,12 +397,12 @@ class Effect(Operation):
         original_shape = video.video_shape
 
         if self.window is None or (self.window.start is None and self.window.stop is None):
-            result = self._apply(video)
+            result = self._apply(video, **context)
         else:
             start_s, stop_s = self._resolved_window(video.total_seconds)
             start_f = round(start_s * video.fps)
             end_f = round(stop_s * video.fps)
-            inner = self._apply(video[start_f:end_f])
+            inner = self._apply(video[start_f:end_f], **context)
             old_audio = video.audio
             result = _Video.from_frames(
                 np.r_["0,2", video.frames[:start_f], inner.frames, video.frames[end_f:]],
@@ -436,22 +436,29 @@ class Effect(Operation):
             raise ValueError(f"Effect stop ({stop_s}) must be >= start ({start_s})")
         return start_s, stop_s
 
-    def _apply(self, video: Video) -> Video:
+    def _apply(self, video: Video, **context: Any) -> Video:
         """Apply the effect to ``video`` in memory by replaying the streaming path.
 
         Runs :meth:`streaming_init` once, then :meth:`process_frame` over every
         frame in order -- the same logic streaming uses, so eager and streaming
-        cannot drift. Subclasses that need a genuinely different eager path
-        (extra validation, batched vectorisation) override this.
+        cannot drift. ``context`` carries resolved ``requires`` values through
+        to :meth:`streaming_init`, mirroring the streaming scheduler.
+        Subclasses that need a genuinely different eager path (extra
+        validation, batched vectorisation) override this.
         """
         height, width = video.frame_shape[:2]
-        self.streaming_init(len(video.frames), video.fps, width, height)
+        self.streaming_init(len(video.frames), video.fps, width, height, **context)
         for i in tqdm(range(len(video.frames)), desc=type(self).__name__):
             video.frames[i] = self.process_frame(video.frames[i], i)
         return video
 
-    def streaming_init(self, total_frames: int, fps: float, width: int, height: int) -> None:
+    def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         """Hook for per-stream precomputation (per-frame alphas, sigma curves...).
+
+        ``_context`` carries resolved ``requires`` values for context-aware
+        effects (e.g. ``transcription=...`` for ``TranscriptionOverlay``),
+        already re-based onto the local timeline by the runner. Effects that
+        declare no ``requires`` are always called without context kwargs.
 
         Default: no-op. Override in subclasses that need it.
         """

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -14,7 +14,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
-from typing import get_args
+from typing import Any, get_args
 
 import numpy as np
 from tqdm import tqdm
@@ -30,11 +30,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class EffectScheduleEntry:
-    """An effect with its active frame range for streaming."""
+    """An effect with its active frame range for streaming.
+
+    ``context`` carries the effect's resolved ``requires`` values (already
+    re-based onto the segment-local timeline by the plan builder), forwarded
+    as keyword arguments to ``streaming_init``. Empty for context-free
+    effects.
+    """
 
     effect: Effect
     start_frame: int
     end_frame: int  # exclusive
+    context: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -187,10 +194,14 @@ def stream_segment(
     duration = plan.end_second - plan.start_second
     total_frames = round(duration * plan.output_fps)
 
-    # Initialize effects for streaming
+    # Initialize effects for streaming. Runs before this segment's decode,
+    # so a context-requiring effect with missing context fails before any
+    # frame work on this segment.
     for entry in plan.effect_schedule:
         n_effect_frames = entry.end_frame - entry.start_frame
-        entry.effect.streaming_init(n_effect_frames, plan.output_fps, plan.output_width, plan.output_height)
+        entry.effect.streaming_init(
+            n_effect_frames, plan.output_fps, plan.output_width, plan.output_height, **entry.context
+        )
 
     # Save audio to temp file for muxing
     audio_path = None
@@ -224,8 +235,17 @@ def stream_segment(
                 frame_count = 0
                 for _, frame in tqdm(decoder, desc="Streaming", total=total_frames):
                     for entry in plan.effect_schedule:
-                        if entry.start_frame <= frame_count < entry.end_frame:
-                            frame = entry.effect.process_frame(frame, frame_count - entry.start_frame)
+                        # total_frames is an estimate (round(duration * fps));
+                        # ffmpeg can emit one more frame on rounding ties. An
+                        # entry covering the full estimated range is treated
+                        # as open-ended so trailing frames don't escape it
+                        # (an unfaded frame popping after a fade-out), with
+                        # the window-local index clamped so envelope arrays
+                        # sized to the estimate stay in bounds.
+                        open_ended = entry.end_frame >= total_frames
+                        if entry.start_frame <= frame_count and (frame_count < entry.end_frame or open_ended):
+                            local_index = min(frame_count, entry.end_frame - 1) - entry.start_frame
+                            frame = entry.effect.process_frame(frame, local_index)
 
                     encoder.write_frame(frame)
                     frame_count += 1

--- a/src/videopython/editing/transcription_overlay.py
+++ b/src/videopython/editing/transcription_overlay.py
@@ -34,8 +34,7 @@ from typing import Any, ClassVar, Literal
 
 import numpy as np
 from PIL import Image
-from pydantic import Field
-from tqdm import tqdm
+from pydantic import Field, PrivateAttr
 
 from videopython.base.exceptions import PlanError, PlanErrorCode, PlanValidationError
 from videopython.base.image_text import AnchorPoint, ImageText, TextAlign
@@ -155,7 +154,10 @@ class TranscriptionOverlay(Effect):
 
     Each word lights up in the highlight color as it is spoken, based on
     transcription timestamps. Requires a word-level transcription, which the
-    runner supplies via the ``requires=("transcription",)`` declaration.
+    runner supplies via the ``requires=("transcription",)`` declaration --
+    re-based onto the segment's local timeline and forwarded to
+    :meth:`streaming_init`, so subtitled edits run on the O(1)-memory
+    streaming path; the eager path replays the same contract.
 
     Geometry is resolution-relative by default (``font_scale``/``region``), so
     a plan validated by ``VideoEdit.validate()`` that passes will also render;
@@ -164,7 +166,7 @@ class TranscriptionOverlay(Effect):
     """
 
     op: Literal["add_subtitles"] = "add_subtitles"
-    streamable: ClassVar[bool] = False
+    streamable: ClassVar[bool] = True
     requires: ClassVar[tuple[str, ...]] = ("transcription",)
 
     # ---- primary, resolution-independent surface ----
@@ -287,6 +289,18 @@ class TranscriptionOverlay(Effect):
         None,
         description="Advanced override: space around the box in px (or [top, right, bottom, left]). None uses 20.",
     )
+
+    # Per-stream state precomputed by streaming_init (the PrivateAttr pattern
+    # shared by every streamable effect). Reset on every init, so a reused
+    # instance can render differently sized videos without serving a
+    # stale-resolution overlay.
+    _stream_layout: _SubtitleLayout | None = PrivateAttr(default=None)
+    _stream_transcription: Transcription | None = PrivateAttr(default=None)
+    _stream_cache: dict[tuple[str, int | None], np.ndarray] = PrivateAttr(default_factory=dict)
+    _stream_current_cue: str | None = PrivateAttr(default=None)
+    _stream_fps: float = PrivateAttr(default=0.0)
+    _stream_shape: tuple[int, int, int] = PrivateAttr(default=(0, 0, 3))
+    _stream_t0_frames: int = PrivateAttr(default=0)
 
     # ------------------------------------------------------------- resolution
 
@@ -470,53 +484,78 @@ class TranscriptionOverlay(Effect):
         cache[cache_key] = overlay_image
         return overlay_image
 
-    def apply(  # type: ignore[override]
+    def streaming_init(
         self,
-        video: Video,
+        total_frames: int,
+        fps: float,
+        width: int,
+        height: int,
         transcription: Transcription | None = None,
-    ) -> Video:
+        **_context: Any,
+    ) -> None:
+        """Precompute per-stream subtitle state (layout, cues, overlay cache).
+
+        ``transcription`` timestamps must be local to the timeline the frames
+        come from: the runner re-bases source-absolute context onto the cut
+        segment before this hook runs (``_segment_context``). With a
+        ``window`` set, frame indices arrive window-local, so timestamps are
+        offset by the window start (the window addresses segment time).
+        """
         if transcription is None:
             raise ValueError(
                 "TranscriptionOverlay requires transcription data. "
                 "Pass it via VideoEdit.run(context={'transcription': ...}) or directly to apply()."
             )
-
-        height, width = video.frame_shape[:2]
         layout = self._resolve_layout(width, height, transcription)
         if not layout.fits:
             # Should be unreachable when the plan went through validate(); kept
-            # as defense in depth so a direct apply() still fails clearly
-            # rather than crashing mid-render in ImageText.
+            # as defense in depth so direct/un-validated execution still fails
+            # clearly before any frame work, never mid-render. Raised before
+            # decode starts on both the eager and streaming paths.
             assert layout.error is not None
             raise PlanValidationError(
                 layout.error,
                 [PlanError(code=PlanErrorCode.SUBTITLE_UNFITTABLE, op=self.op)],
             )
+        self._stream_layout = layout
+        self._stream_transcription = Transcription(segments=layout.segments, language=transcription.language)
+        self._stream_cache = {}
+        self._stream_current_cue = None
+        self._stream_fps = fps
+        self._stream_shape = (height, width, 3)
+        win_start = 0.0 if self.window is None or self.window.start is None else float(self.window.start)
+        self._stream_t0_frames = round(win_start * fps)
+        logger.info("Rendering transcription overlay (font %dpx)...", layout.font_px)
 
-        # Per-call memo of rendered overlays, keyed by (cue text, highlighted
-        # word). Local rather than instance state so the model stays stateless
-        # and re-entrant -- a reused instance can render differently sized
-        # videos without serving a stale-resolution overlay.
-        cache: dict[tuple[str, int | None], np.ndarray] = {}
-        transformed = Transcription(segments=layout.segments, language=transcription.language)
+    def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
+        layout = self._stream_layout
+        transcription = self._stream_transcription
+        assert layout is not None and transcription is not None, "streaming_init was not called"
+        timestamp = (self._stream_t0_frames + frame_index) / self._stream_fps
+        active_segment = self._get_active_segment(transcription, timestamp)
+        if active_segment is None:
+            return frame
+        # Frames arrive in time order on both paths and only one cue is
+        # active at a time, so only the current cue's highlight variants are
+        # ever needed: evicting on cue change bounds the cache to
+        # (words_per_cue + 1) full-frame overlays regardless of video length,
+        # keeping the streaming path's O(1)-memory contract.
+        if active_segment.text != self._stream_current_cue:
+            self._stream_cache.clear()
+            self._stream_current_cue = active_segment.text
+        highlight_word_index = self._get_active_word_index(active_segment, timestamp)
+        text_overlay = self._create_text_overlay(
+            self._stream_shape, active_segment, highlight_word_index, layout, self._stream_cache
+        )
+        return self._apply_overlay_to_frame(frame, text_overlay)
 
-        logger.info("Applying transcription overlay (font %dpx)...", layout.font_px)
-        new_frames = []
-        for frame_index, frame in enumerate(tqdm(video.frames, desc="Transcription overlay")):
-            timestamp = frame_index / video.fps
-            active_segment = self._get_active_segment(transformed, timestamp)
-            if active_segment is None:
-                new_frames.append(frame)
-                continue
-            highlight_word_index = self._get_active_word_index(active_segment, timestamp)
-            text_overlay = self._create_text_overlay(
-                video.frame_shape, active_segment, highlight_word_index, layout, cache
-            )
-            new_frames.append(self._apply_overlay_to_frame(frame, text_overlay))
-
-        new_video = Video.from_frames(np.array(new_frames), fps=video.fps)
-        new_video.audio = video.audio
-        return new_video
+    def apply(  # type: ignore[override]
+        self,
+        video: Video,
+        transcription: Transcription | None = None,
+    ) -> Video:
+        """Eager render by replaying the streaming contract (one pixel path)."""
+        return super().apply(video, transcription=transcription)
 
     def predict_metadata(
         self,

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -1202,7 +1202,7 @@ class VideoEdit(BaseModel):
         target_fps, target_w, target_h = self._matching_targets_from_disk()
         plans: list[StreamingSegmentPlan] = []
         for segment in self.segments:
-            plan = self._build_streaming_plan(segment, target_fps, target_w, target_h)
+            plan = self._build_streaming_plan(segment, target_fps, target_w, target_h, context)
             if plan is None:
                 return self._run_to_file_eager(output_path, format, preset, crf, context)
             plans.append(plan)
@@ -1216,9 +1216,12 @@ class VideoEdit(BaseModel):
             total_frames = round((plan.end_second - plan.start_second) * plan.output_fps)
             for op in self.post_operations:
                 if op.requires:
-                    # Same reason as the per-segment guard: no runtime context
-                    # in the streaming path. (Multi-segment + requires already
-                    # raised by _assert_post_ops_supported.)
+                    # Segment ops get re-based context on their schedule entry,
+                    # but post-ops run on the assembled timeline where the eager
+                    # path passes context *raw* -- folding that into the segment
+                    # schedule is the P0.4 scheduling work. Defer to eager.
+                    # (Multi-segment + requires already raised by
+                    # _assert_post_ops_supported.)
                     return self._run_to_file_eager(output_path, format, preset, crf, context)
                 if not isinstance(op, Effect) or not op.streamable:
                     return self._run_to_file_eager(output_path, format, preset, crf, context)
@@ -1271,6 +1274,7 @@ class VideoEdit(BaseModel):
         target_fps: float | None,
         target_w: int | None,
         target_h: int | None,
+        context: dict[str, Any] | None = None,
     ) -> StreamingSegmentPlan | None:
         source_meta = VideoMetadata.from_path(str(segment.source))
         out_fps = target_fps or source_meta.fps
@@ -1283,21 +1287,39 @@ class VideoEdit(BaseModel):
         if target_fps and target_fps != source_meta.fps:
             vf_filters.append(f"fps={target_fps}")
 
+        # Resolve requires-context onto the segment's local timeline once; each
+        # context-requiring effect gets its keys on the schedule entry, which
+        # stream_segment forwards to streaming_init (the streaming twin of
+        # _apply_with_context). Like _segment_context's eager consumers, a
+        # missing/empty key is passed as absent so the effect raises its own
+        # clear "requires ..." error -- before that segment's decode.
+        seg_context = _segment_context(context, segment.start, segment.end)
+
         effect_schedule: list[EffectScheduleEntry] = []
         for op in segment.operations:
-            if op.requires:
-                # Streaming schedules effects by frame range with no runtime
-                # context, so it can't supply -- let alone re-base onto the
-                # segment's local timeline -- anything an op `requires`. Defer
-                # to the eager path, where _segment_context handles re-basing.
-                return None
             if isinstance(op, Effect):
                 if not op.streamable:
                     return None
+                op_context: dict[str, Any] = {}
+                if op.requires and seg_context:
+                    op_context = {k: seg_context[k] for k in op.requires if k in seg_context}
                 total_frames = round(segment.duration * out_fps)
                 start_f, end_f = _effect_frame_range(op, out_fps, total_frames)
-                effect_schedule.append(EffectScheduleEntry(op, start_f, end_f))
+                effect_schedule.append(EffectScheduleEntry(op, start_f, end_f, op_context))
                 continue
+            if op.requires:
+                # Context-requiring transforms (e.g. silence_removal) have no
+                # streaming strategy yet -- an ffmpeg filter string can't
+                # consume runtime context. Defer the plan to the eager path.
+                return None
+            if effect_schedule:
+                # vf_filters run at decode time, BEFORE every scheduled
+                # effect's process_frame, so a transform that follows an
+                # effect in plan order cannot be expressed without reordering:
+                # the effect's frame range and streaming_init dims/fps were
+                # computed against a timeline this filter would change. Defer
+                # to the eager path, which executes ops strictly in plan order.
+                return None
             # Non-effect transform: compile to ffmpeg filter if streamable.
             ctx = FilterCtx(width=out_w, height=out_h, fps=out_fps)
             filter_expr = op.to_ffmpeg_filter(ctx)

--- a/uv.lock
+++ b/uv.lock
@@ -4536,7 +4536,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.38.0"
+version = "0.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
add_subtitles runs on the O(1)-memory streaming path instead of forcing a whole-plan eager fallback: run_to_file resolves `requires` context at plan-build time, re-bases it onto the segment-local timeline via _segment_context, carries it on EffectScheduleEntry.context, and forwards it to streaming_init (the streaming twin of _apply_with_context). TranscriptionOverlay is ported to the streaming contract (streaming_init/process_frame); the eager path replays exactly that contract via the base Effect._apply, so the two paths cannot drift. Context errors raise before the segment decodes, with the same exception as eager. Context-requiring transforms (silence_removal) still fall back: an ffmpeg filter string cannot consume runtime context.

Hardening from adversarial review of the change:
- transform-after-effect plans fall back to eager: vf filters are hoisted before every scheduled effect at decode time, so such plans streamed against a different timeline/dims than plan order prescribes (latent for context-free effects, newly reachable for add_subtitles)
- the per-stream subtitle overlay cache evicts on cue change, bounding it to max_words_per_cue + 1 overlays regardless of video length
- trailing decoded frames past the round(duration*fps) estimate no longer escape full-range effects (e.g. an unfaded last frame after a fade-out): full-range entries are open-ended with a clamped local index

Behavior changes: Effect.streaming_init/_apply signatures gain **context (external subclasses must widen their overrides); TranscriptionOverlay now honors `window` and mutates frames in place like every other effect.