### PR TITLE
feat(editing): streamability report + strict_streaming (0.40.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,46 @@
 # Release Notes
 
+## 0.40.0
+
+Streamability becomes a contract instead of a silent behavior. Whether
+`run_to_file` streams in O(1) memory or eager-loads the whole video is now
+inspectable before running anything, and enforceable. Second step of the
+streaming-first migration (TODO.md P0.2).
+
+- **Per-op streamability report.** `VideoEdit.streamability()` classifies
+  every op in plan order by streaming class — `filter` (ffmpeg `-vf`),
+  `frame_effect` (`streaming_init`/`process_frame`), or `eager` (no streaming
+  strategy; forces the whole-plan fallback) — with the reason on each `eager`
+  entry. Purely structural: no source files, metadata, or context needed, so
+  admission gating can happen before anything is downloaded.
+  `report.streamable` is the plan-level verdict; `report.errors()` renders
+  the fallbacks as structured `PlanError`s.
+- **`check(..., strict_streaming=True)`** appends one `STREAMING_FALLBACK`
+  error per fallback-forcing op (after the regular validity errors, in plan
+  order), so an LLM refine loop treats "won't stream" like any other plan
+  violation. Default `check()` behavior is unchanged.
+- **`run_to_file(..., strict_streaming=True)`** raises `PlanValidationError`
+  carrying those errors instead of silently eager-loading — before any
+  decode. The former fallback sites are also guarded: if a plan stops
+  streaming despite a clean report (e.g. a third-party transform whose
+  `streamable` flag disagrees with its `to_ffmpeg_filter`), strict mode
+  raises rather than eager-loading. Default behavior is unchanged.
+- **New error vocabulary.** `PlanErrorCode.STREAMING_FALLBACK`, plus an
+  optional `PlanError.detail: str | None` field carrying a human-readable
+  cause for codes where the code alone isn't actionable (populated for
+  streaming fallbacks; `None` everywhere else, so existing constructions and
+  comparisons are unaffected).
+- **The `streamable` flag is now authoritative for transforms.** The plan
+  builder consults it before compiling `to_ffmpeg_filter`, so a transform
+  declaring `streamable=False` takes the eager path even if its filter
+  compiles — the report and the runtime can no longer disagree in that
+  direction. Affects only third-party ops with a mismatched declaration
+  (a working filter but `streamable=False` previously streamed silently);
+  all built-in ops declare coherently, pinned by registry tests in both the
+  editing and ai suites.
+- New exports: `StreamabilityReport`, `OpStreamability`, `StreamingClass`
+  from `videopython.editing`.
+
 ## 0.39.0
 
 Context-requiring effects now stream. `add_subtitles` — previously the most

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -101,6 +101,31 @@ streamable, `run_to_file` falls back to eager (`run()` + `save()`).
 **Streamable effects**: every `Effect`, including the context-requiring
 `add_subtitles` (pass `context=` to `run_to_file`).
 
+### Streamability report and strict mode
+
+`edit.streamability()` classifies every op by streaming class without
+touching the disk — `filter` (ffmpeg `-vf`), `frame_effect`
+(`process_frame`), or `eager` (forces the whole-plan fallback, with the
+reason on the entry):
+
+```python
+report = edit.streamability()
+report.streamable        # will run_to_file stream in O(1) memory?
+report.fallbacks         # the offending ops, with reasons
+report.errors()          # the same as structured STREAMING_FALLBACK PlanErrors
+```
+
+To make the fallback an error instead of a silent behavior change:
+
+- `edit.check(meta, strict_streaming=True)` appends one
+  `STREAMING_FALLBACK` error per offending op (location, op, and the
+  reason in `detail`) after the regular validity errors.
+- `edit.run_to_file(path, strict_streaming=True)` raises
+  `PlanValidationError` with those errors before any decode.
+
+Streamability is purely structural (op classes, order, plan shape), so a
+consumer can gate job admission on the report before downloading sources.
+
 ## Context Data
 
 Operations that need side-channel data (e.g. `silence_removal` and

--- a/docs/examples/large-videos.md
+++ b/docs/examples/large-videos.md
@@ -47,7 +47,10 @@ edit.run_to_file("output.mp4", crf=20, preset="medium")
 
 When all operations are streamable, frames are never loaded into memory. If any operation
 is not streamable (e.g. `reverse`, `speed_change`), the pipeline falls back to eager
-mode automatically.
+mode automatically. To find out ahead of time, `edit.streamability()` returns a per-op
+report without touching the disk; to forbid the fallback outright, pass
+`strict_streaming=True` to `run_to_file` (raises `PlanValidationError` before any
+decode) or to `check` (reports structured `STREAMING_FALLBACK` errors).
 
 Context-requiring effects stream too: pass `context=` to `run_to_file` and
 e.g. `add_subtitles` burns word-level subtitles on the streaming path, with

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -188,6 +188,14 @@ for err in errors:
 # Re-prompt once with the full structured list instead of one-at-a-time
 ```
 
+With `check(source_metadata, strict_streaming=True)`, ops that would force
+`run_to_file`'s silent eager fallback are reported too — one
+`STREAMING_FALLBACK` error per op, with the actionable cause in
+`err.detail` (e.g. "transform follows an effect in plan order ... move the
+transform before the effect to stream"), so the refine loop can treat
+"won't stream" like any other violation. The full per-op classification
+(including the ops that do stream) is `edit.streamability()`.
+
 ### Auto-repair the mechanical violations: `repair()`
 
 Most mechanical faults need no LLM at all — clamping is the obvious fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.39.0"
+version = "0.40.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_streamability_alignment.py
+++ b/src/tests/ai/test_streamability_alignment.py
@@ -1,0 +1,33 @@
+"""Registry-alignment twin of ``editing/test_streamability.py`` for ai ops.
+
+The editing suite must not import the optional ``[ai]`` extra, so its
+alignment test only sees ops registered by the editing layer. This twin runs
+in the ai suite, where importing the ai op modules registers ``face_crop``
+and ``object_detection_overlay``, and re-checks the whole registry.
+"""
+
+from videopython.ai.effects import ObjectDetectionOverlay  # noqa: F401  -- registers the op
+from videopython.ai.transforms import FaceTrackingCrop  # noqa: F401  -- registers the op
+from videopython.editing.effects import Effect
+from videopython.editing.operation import Operation
+
+
+def test_streamable_flag_matches_filter_compilation_including_ai_ops():
+    """Every registered transform must declare ``streamable`` coherently.
+
+    Both ``analyze_streamability`` and ``_build_streaming_plan`` treat the
+    ``streamable`` ClassVar as authoritative, but a flag-True transform
+    without a working ``to_ffmpeg_filter`` only fails at runtime (the
+    strict-mode drift guard), and a flag-False transform with one carries
+    dead filter code.
+    """
+    assert "face_crop" in Operation._registry
+    assert "object_detection_overlay" in Operation._registry
+    for op_id, cls in Operation._registry.items():
+        if issubclass(cls, Effect):
+            continue
+        overrides_filter = cls.to_ffmpeg_filter is not Operation.to_ffmpeg_filter
+        assert overrides_filter == cls.streamable, (
+            f"op '{op_id}': streamable={cls.streamable} but "
+            f"{'overrides' if overrides_filter else 'does not override'} to_ffmpeg_filter"
+        )

--- a/src/tests/editing/test_streamability.py
+++ b/src/tests/editing/test_streamability.py
@@ -1,0 +1,249 @@
+"""Tests for the per-op streamability report and ``strict_streaming`` (P0.2)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tests.test_config import SMALL_VIDEO_METADATA, SMALL_VIDEO_PATH
+from videopython.base.exceptions import PlanErrorCode, PlanValidationError
+from videopython.editing import StreamingClass
+from videopython.editing.effects import Effect, Fade
+from videopython.editing.operation import Operation
+from videopython.editing.transforms import Resize
+from videopython.editing.video_edit import VideoEdit
+
+FADE = {"op": "fade", "mode": "in", "duration": 0.5}
+RESIZE = {"op": "resize", "width": 640, "height": 480}
+SUBTITLES = {"op": "add_subtitles", "font_scale": 0.1}
+FREEZE = {"op": "freeze_frame", "timestamp": 0.5, "duration": 0.2}
+SILENCE = {"op": "silence_removal"}
+
+
+def _plan(
+    operations: list[dict[str, Any]],
+    *,
+    post_operations: list[dict[str, Any]] | None = None,
+    n_segments: int = 1,
+) -> VideoEdit:
+    return VideoEdit.model_validate(
+        {
+            "segments": [
+                {"source": SMALL_VIDEO_PATH, "start": 0.0, "end": 2.0, "operations": operations}
+                for _ in range(n_segments)
+            ],
+            "post_operations": post_operations or [],
+        }
+    )
+
+
+class TestStreamabilityReport:
+    """The pure structural classification behind ``VideoEdit.streamability()``."""
+
+    def test_filter_and_frame_effect_classes(self):
+        report = _plan([RESIZE, FADE, SUBTITLES]).streamability()
+
+        assert [e.streaming_class for e in report.entries] == [
+            StreamingClass.FILTER,
+            StreamingClass.FRAME_EFFECT,
+            StreamingClass.FRAME_EFFECT,
+        ]
+        assert [e.location for e in report.entries] == [
+            "segments[0].operations[0]",
+            "segments[0].operations[1]",
+            "segments[0].operations[2]",
+        ]
+        assert report.streamable
+        assert report.fallbacks == ()
+        assert report.errors() == []
+        assert all(e.reason is None for e in report.entries)
+
+    def test_transform_after_effect_is_eager(self):
+        report = _plan([FADE, RESIZE]).streamability()
+
+        fade, resize = report.entries
+        assert fade.streams
+        assert resize.streaming_class is StreamingClass.EAGER
+        assert resize.reason is not None and "follows an effect" in resize.reason
+        assert not report.streamable
+
+    def test_context_requiring_transform_is_eager(self):
+        report = _plan([SILENCE]).streamability()
+
+        (entry,) = report.entries
+        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.reason is not None and "transcription" in entry.reason
+
+    def test_unfilterable_transform_is_eager(self):
+        report = _plan([FREEZE]).streamability()
+
+        (entry,) = report.entries
+        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.reason is not None and "no ffmpeg filter" in entry.reason
+
+    def test_non_streamable_effect_is_eager(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(Fade, "streamable", False)
+        report = _plan([FADE]).streamability()
+
+        (entry,) = report.entries
+        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.reason is not None and "streamable=False" in entry.reason
+
+    def test_post_op_effect_on_single_segment_streams(self):
+        report = _plan([], post_operations=[FADE]).streamability()
+
+        (entry,) = report.entries
+        assert entry.location == "post_operations[0]"
+        assert entry.streaming_class is StreamingClass.FRAME_EFFECT
+        assert report.streamable
+
+    def test_post_op_on_multi_segment_plan_is_eager(self):
+        report = _plan([], post_operations=[FADE], n_segments=2).streamability()
+
+        (entry,) = report.entries
+        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.reason is not None and "multi-segment" in entry.reason
+
+    def test_context_requiring_post_op_is_eager(self):
+        report = _plan([], post_operations=[SUBTITLES]).streamability()
+
+        (entry,) = report.entries
+        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.reason is not None and "transcription" in entry.reason
+
+    def test_transform_post_op_is_eager(self):
+        report = _plan([], post_operations=[RESIZE]).streamability()
+
+        (entry,) = report.entries
+        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.reason is not None and "post-operations" in entry.reason
+
+    def test_errors_carry_location_op_and_detail(self):
+        errors = _plan([FADE, RESIZE]).streamability().errors()
+
+        (err,) = errors
+        assert err.code is PlanErrorCode.STREAMING_FALLBACK
+        assert err.location == "segments[0].operations[1]"
+        assert err.op == "resize"
+        assert err.detail is not None and "follows an effect" in err.detail
+
+
+class TestRegistryAlignment:
+    def test_streamable_flag_matches_filter_compilation(self):
+        """Every registered transform must declare ``streamable`` coherently.
+
+        Both the report and the plan builder treat the ``streamable`` ClassVar
+        as authoritative, but a flag-True transform without a working
+        ``to_ffmpeg_filter`` only fails at runtime (the strict-mode drift
+        guard), and a flag-False transform with one carries dead filter code.
+        This covers ops registered by the editing layer; a twin test under
+        ``src/tests/ai`` covers the ai layer, which this suite must not
+        import.
+        """
+        for op_id, cls in Operation._registry.items():
+            if issubclass(cls, Effect):
+                continue
+            overrides_filter = cls.to_ffmpeg_filter is not Operation.to_ffmpeg_filter
+            assert overrides_filter == cls.streamable, (
+                f"op '{op_id}': streamable={cls.streamable} but "
+                f"{'overrides' if overrides_filter else 'does not override'} to_ffmpeg_filter"
+            )
+
+
+class TestCheckStrictStreaming:
+    def test_default_check_ignores_streamability(self):
+        plan = _plan([FADE, RESIZE])
+        assert plan.check(SMALL_VIDEO_METADATA) == []
+
+    def test_strict_check_reports_fallbacks(self):
+        plan = _plan([FADE, RESIZE])
+        errors = plan.check(SMALL_VIDEO_METADATA, strict_streaming=True)
+
+        (err,) = errors
+        assert err.code is PlanErrorCode.STREAMING_FALLBACK
+        assert err.location == "segments[0].operations[1]"
+        assert err.op == "resize"
+
+    def test_strict_check_on_streamable_plan_is_clean(self):
+        plan = _plan([RESIZE, FADE])
+        assert plan.check(SMALL_VIDEO_METADATA, strict_streaming=True) == []
+
+    def test_fallback_errors_append_after_validity_errors(self):
+        bad_window = {"op": "fade", "mode": "in", "duration": 0.5, "window": {"start": 50.0, "stop": 60.0}}
+        plan = _plan([bad_window, RESIZE])
+        errors = plan.check(SMALL_VIDEO_METADATA, strict_streaming=True)
+
+        assert len(errors) >= 2
+        assert errors[0].code is not PlanErrorCode.STREAMING_FALLBACK
+        assert errors[-1].code is PlanErrorCode.STREAMING_FALLBACK
+
+
+class TestRunToFileStrict:
+    def test_streamable_plan_streams_under_strict(self, tmp_path):
+        plan = _plan([RESIZE, FADE])
+        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
+            out = plan.run_to_file(tmp_path / "out.mp4", strict_streaming=True)
+        assert out.exists()
+
+    def test_multi_segment_streamable_plan_streams_under_strict(self, tmp_path):
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [
+                    {"source": SMALL_VIDEO_PATH, "start": 0.0, "end": 1.0, "operations": [RESIZE]},
+                    {"source": SMALL_VIDEO_PATH, "start": 1.0, "end": 2.0, "operations": [RESIZE, FADE]},
+                ],
+            }
+        )
+        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
+            out = plan.run_to_file(tmp_path / "out.mp4", strict_streaming=True)
+        assert out.exists()
+
+    def test_fallback_plan_raises_under_strict(self, tmp_path):
+        plan = _plan([FADE, RESIZE])
+        out_path = tmp_path / "out.mp4"
+
+        with pytest.raises(PlanValidationError, match="strict_streaming=True rejects this plan") as exc_info:
+            plan.run_to_file(out_path, strict_streaming=True)
+
+        assert not out_path.exists()
+        (err,) = exc_info.value.errors
+        assert err.code is PlanErrorCode.STREAMING_FALLBACK
+        assert err.op == "resize"
+
+    def test_fallback_plan_still_falls_back_without_strict(self, tmp_path):
+        plan = _plan([FADE, RESIZE])
+        with patch.object(
+            VideoEdit, "_run_to_file_eager", autospec=True, side_effect=VideoEdit._run_to_file_eager
+        ) as eager_spy:
+            out = plan.run_to_file(tmp_path / "out.mp4")
+        assert eager_spy.call_count == 1
+        assert out.exists()
+
+    def test_builder_drift_raises_instead_of_silent_eager(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        """A streamable-flagged transform that fails to compile must not eager-load."""
+        monkeypatch.setattr(Resize, "to_ffmpeg_filter", lambda self, ctx: None)
+        plan = _plan([RESIZE])
+
+        with pytest.raises(PlanValidationError, match="despite a clean streamability report"):
+            plan.run_to_file(tmp_path / "out.mp4", strict_streaming=True)
+
+    def test_flag_false_transform_goes_eager_even_with_working_filter(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        """The ``streamable`` flag is authoritative in both directions.
+
+        A transform declaring ``streamable=False`` must take the eager path
+        even if its ``to_ffmpeg_filter`` compiles -- otherwise the runtime
+        would stream while the report (which classifies by the flag) says
+        eager, and strict mode would reject a plan that actually streams.
+        """
+        monkeypatch.setattr(Resize, "streamable", False)
+        plan = _plan([RESIZE])
+
+        assert not plan.streamability().streamable
+        with patch.object(
+            VideoEdit, "_run_to_file_eager", autospec=True, side_effect=VideoEdit._run_to_file_eager
+        ) as eager_spy:
+            out = plan.run_to_file(tmp_path / "out.mp4")
+        assert eager_spy.call_count == 1
+        assert out.exists()

--- a/src/videopython/base/exceptions.py
+++ b/src/videopython/base/exceptions.py
@@ -105,6 +105,8 @@ class PlanErrorCode(str, Enum):
     CONCAT_MISMATCH = "concat_mismatch"
     SUBTITLE_UNFITTABLE = "subtitle_unfittable"
     POST_OP_REQUIRES_CONTEXT = "post_op_requires_context"
+    # Streaming strictness (opt-in via strict_streaming).
+    STREAMING_FALLBACK = "streaming_fallback"
 
 
 @dataclass
@@ -113,6 +115,9 @@ class PlanError:
 
     ``location`` is a path into the plan (e.g. ``'segments[1].operations[0]'``);
     the remaining fields are populated when meaningful for the ``code``.
+    ``detail`` carries a short human-readable cause when the code alone is not
+    actionable (e.g. *why* an op forces the eager fallback) -- prose meant for
+    LLM refine-loop feedback, not for branching.
     """
 
     code: PlanErrorCode
@@ -122,6 +127,7 @@ class PlanError:
     value: float | None = None
     limit: float | None = None
     predicted_duration: float | None = None
+    detail: str | None = None
 
 
 @dataclass

--- a/src/videopython/editing/__init__.py
+++ b/src/videopython/editing/__init__.py
@@ -22,6 +22,7 @@ from .effects import (
     Zoom,
 )
 from .operation import FilterCtx, OpCategory, Operation, TimeRange
+from .streaming import OpStreamability, StreamabilityReport, StreamingClass
 from .transcription_overlay import SubtitleRegion, SubtitleStyle, TranscriptionOverlay
 from .transforms import (
     Crop,
@@ -82,4 +83,8 @@ __all__ = [
     # Plan runner
     "VideoEdit",
     "SegmentConfig",
+    # Streamability report
+    "StreamabilityReport",
+    "OpStreamability",
+    "StreamingClass",
 ]

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import logging
 import subprocess
 import tempfile
+from collections.abc import Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from types import TracebackType
 from typing import Any, get_args
@@ -22,10 +24,202 @@ from tqdm import tqdm
 from videopython.audio import Audio
 from videopython.base import _ffmpeg
 from videopython.base._dimensions import require_even
+from videopython.base.exceptions import PlanError, PlanErrorCode
 from videopython.base.video import ALLOWED_VIDEO_FORMATS, ALLOWED_VIDEO_PRESETS, FrameIterator
 from videopython.editing.effects import Effect
+from videopython.editing.operation import Operation
 
 logger = logging.getLogger(__name__)
+
+
+class StreamingClass(str, Enum):
+    """How an op executes on the streaming path -- its memory class.
+
+    ``FILTER`` and ``FRAME_EFFECT`` stream in O(1) memory w.r.t. video length;
+    ``EAGER`` means the op has no streaming strategy (yet), which forces the
+    *whole plan* onto the eager in-memory path. Future classes from the
+    streaming-first contract (frame mapper, cut list, bounded buffer) will be
+    added here as they are implemented.
+    """
+
+    FILTER = "filter"
+    """Compiles to an ffmpeg ``-vf`` filter applied at decode time."""
+    FRAME_EFFECT = "frame_effect"
+    """Shape-preserving per-frame Python (``streaming_init`` + ``process_frame``)."""
+    EAGER = "eager"
+    """No streaming strategy; forces the whole-plan eager fallback."""
+
+
+@dataclass(frozen=True)
+class OpStreamability:
+    """Streaming classification for a single op within a plan."""
+
+    location: str
+    """Path into the plan, e.g. ``'segments[1].operations[0]'``."""
+    op: str
+    """The op discriminator, e.g. ``'add_subtitles'``."""
+    streaming_class: StreamingClass
+    reason: str | None = None
+    """Why the op forces the eager fallback; ``None`` unless ``EAGER``."""
+
+    @property
+    def streams(self) -> bool:
+        return self.streaming_class is not StreamingClass.EAGER
+
+
+@dataclass(frozen=True)
+class StreamabilityReport:
+    """Per-op streaming classification for a whole plan.
+
+    Built by :meth:`VideoEdit.streamability` from the plan structure alone --
+    no source files, metadata, or runtime context needed -- so a consumer can
+    gate job admission on it before downloading anything. ``streamable`` is
+    the plan-level verdict: one ``EAGER`` op forces the *entire*
+    ``run_to_file`` onto the eager in-memory path.
+    """
+
+    entries: tuple[OpStreamability, ...]
+
+    @property
+    def streamable(self) -> bool:
+        """True when ``run_to_file`` will stream (no op forces the fallback)."""
+        return all(e.streams for e in self.entries)
+
+    @property
+    def fallbacks(self) -> tuple[OpStreamability, ...]:
+        """The ops that force the eager fallback, in plan order."""
+        return tuple(e for e in self.entries if not e.streams)
+
+    def errors(self) -> list[PlanError]:
+        """The fallbacks as structured ``STREAMING_FALLBACK`` plan errors.
+
+        The same shape :meth:`VideoEdit.check` returns, so an LLM refine loop
+        can treat "would not stream" exactly like any other plan violation.
+        """
+        return [
+            PlanError(code=PlanErrorCode.STREAMING_FALLBACK, location=e.location, op=e.op, detail=e.reason)
+            for e in self.fallbacks
+        ]
+
+
+def analyze_streamability(
+    segment_operations: Sequence[Sequence[Operation]],
+    post_operations: Sequence[Operation],
+) -> StreamabilityReport:
+    """Classify every op in a plan by streaming class, in plan order.
+
+    Mirrors the decision points of ``VideoEdit._build_streaming_plan`` and the
+    post-op folding in ``VideoEdit.run_to_file`` exactly -- this function is
+    the single documented source of those rules. Both deciders treat the
+    ``streamable`` ClassVar as the authoritative declaration (a flag-False
+    transform never streams, even with a working ``to_ffmpeg_filter``); the
+    one divergence the flag cannot express -- flag True but the filter
+    compiles to ``None`` -- is caught at runtime by the strict-mode drift
+    guard, and a registry test pins flag-True transforms to an actual
+    ``to_ffmpeg_filter`` override. Purely structural: no disk access and no
+    runtime context.
+    """
+    entries: list[OpStreamability] = []
+    for i, ops in enumerate(segment_operations):
+        seen_effect = False
+        for j, op in enumerate(ops):
+            location = f"segments[{i}].operations[{j}]"
+            if isinstance(op, Effect):
+                if op.streamable:
+                    entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
+                else:
+                    entries.append(
+                        OpStreamability(
+                            location,
+                            op.op,
+                            StreamingClass.EAGER,
+                            reason="effect has no streaming implementation (streamable=False)",
+                        )
+                    )
+                seen_effect = True
+            elif op.requires:
+                entries.append(
+                    OpStreamability(
+                        location,
+                        op.op,
+                        StreamingClass.EAGER,
+                        reason=(
+                            f"transform requires runtime context {sorted(op.requires)} and has no "
+                            "streaming strategy yet -- an ffmpeg filter cannot consume runtime context"
+                        ),
+                    )
+                )
+            elif seen_effect:
+                entries.append(
+                    OpStreamability(
+                        location,
+                        op.op,
+                        StreamingClass.EAGER,
+                        reason=(
+                            "transform follows an effect in plan order; ffmpeg filters run at decode "
+                            "time, before every scheduled effect, so plan order cannot be preserved -- "
+                            "move the transform before the effect to stream"
+                        ),
+                    )
+                )
+            elif op.streamable:
+                entries.append(OpStreamability(location, op.op, StreamingClass.FILTER))
+            else:
+                entries.append(
+                    OpStreamability(
+                        location,
+                        op.op,
+                        StreamingClass.EAGER,
+                        reason="transform has no ffmpeg filter compilation",
+                    )
+                )
+
+    multi_segment = len(segment_operations) > 1
+    for j, op in enumerate(post_operations):
+        location = f"post_operations[{j}]"
+        if multi_segment:
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.EAGER,
+                    reason="post-operations on a multi-segment plan cannot stream yet (no cross-segment schedule)",
+                )
+            )
+        elif op.requires:
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.EAGER,
+                    reason=(
+                        f"post-operation requires runtime context {sorted(op.requires)}, which is not "
+                        "re-based onto the assembled timeline -- move it into the segment to stream"
+                    ),
+                )
+            )
+        elif isinstance(op, Effect) and op.streamable:
+            entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
+        elif isinstance(op, Effect):
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.EAGER,
+                    reason="effect has no streaming implementation (streamable=False)",
+                )
+            )
+        else:
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.EAGER,
+                    reason="transforms cannot stream as post-operations -- move the transform into the segment",
+                )
+            )
+
+    return StreamabilityReport(entries=tuple(entries))
 
 
 @dataclass

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -33,7 +33,14 @@ from videopython.base.exceptions import PlanError, PlanErrorCode, PlanRepair, Pl
 from videopython.base.video import ALLOWED_VIDEO_FORMATS, ALLOWED_VIDEO_PRESETS, Video, VideoMetadata
 from videopython.editing.effects import Effect, Fade, VolumeAdjust
 from videopython.editing.operation import FilterCtx, Operation, _to_strict_schema
-from videopython.editing.streaming import EffectScheduleEntry, StreamingSegmentPlan, concat_files, stream_segment
+from videopython.editing.streaming import (
+    EffectScheduleEntry,
+    StreamabilityReport,
+    StreamingSegmentPlan,
+    analyze_streamability,
+    concat_files,
+    stream_segment,
+)
 from videopython.editing.transforms import DURATION_EPS, CutSeconds, Resize
 
 __all__ = [
@@ -737,6 +744,7 @@ class VideoEdit(BaseModel):
         context: dict[str, Any] | None = None,
         *,
         clamp_windows: bool = False,
+        strict_streaming: bool = False,
     ) -> list[PlanError]:
         """Collect **every** plan error in one pass; ``[]`` means valid.
 
@@ -754,10 +762,35 @@ class VideoEdit(BaseModel):
         (no bare ``ValueError`` escapes the walk), so a consumer branches on
         ``code`` rather than substring-matching prose. ``clamp_windows`` matches
         :meth:`validate`: a clampable ``window.stop`` overrun is not reported.
+
+        With ``strict_streaming=True``, ops that would force
+        :meth:`run_to_file`'s silent eager fallback are additionally reported as
+        ``STREAMING_FALLBACK`` errors (appended after the validity errors, in
+        plan order), with the cause in :attr:`PlanError.detail` -- the gating
+        twin of ``run_to_file(strict_streaming=True)``. See
+        :meth:`streamability` for the full per-op report including the ops that
+        *do* stream.
         """
         metas = self._resolve_source_metas(source_metadata)
         _, errors = self._collect(metas, context, clamp_windows=clamp_windows, stop_first=False)
+        if strict_streaming:
+            errors.extend(self.streamability().errors())
         return errors
+
+    def streamability(self) -> StreamabilityReport:
+        """Classify every op by streaming class, without touching the disk.
+
+        Streamability is purely structural -- it depends on op classes, their
+        order, and the plan shape, never on source metadata or runtime context
+        -- so this needs no source files and is safe to call before a job is
+        admitted. ``report.streamable`` answers "will :meth:`run_to_file`
+        stream in O(1) memory, or eager-load the whole video?"; each entry
+        carries the op's memory class and, for fallbacks, the reason.
+        """
+        return analyze_streamability(
+            [list(seg.operations) for seg in self.segments],
+            list(self.post_operations),
+        )
 
     def repair(
         self,
@@ -1188,29 +1221,58 @@ class VideoEdit(BaseModel):
         preset: ALLOWED_VIDEO_PRESETS = "medium",
         crf: int = 23,
         context: dict[str, Any] | None = None,
+        *,
+        strict_streaming: bool = False,
     ) -> Path:
         """Execute the plan, streaming directly to a file when possible.
 
         Falls back to eager (``self.run().save(...)``) for any operation that
         isn't streamable. Memory usage is O(1) w.r.t. video length for fully
         streamable pipelines.
+
+        With ``strict_streaming=True`` the silent fallback becomes a
+        :class:`PlanValidationError` carrying one ``STREAMING_FALLBACK``
+        :class:`PlanError` per offending op -- raised before any decode, so a
+        consumer that priced a job as O(1) memory never eager-loads the whole
+        video instead. Gate plans early with ``check(strict_streaming=True)``
+        or :meth:`streamability`, which report the same fallbacks without
+        running anything.
         """
         self._assert_post_ops_supported(context)
+        if strict_streaming:
+            report = self.streamability()
+            if not report.streamable:
+                causes = "; ".join(f"{e.location} '{e.op}': {e.reason}" for e in report.fallbacks)
+                message = (
+                    f"strict_streaming=True rejects this plan: {len(report.fallbacks)} op(s) "
+                    f"would force the eager in-memory fallback -- {causes}"
+                )
+                raise PlanValidationError(message, report.errors())
         output_path = Path(output_path).with_suffix(f".{format}")
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         target_fps, target_w, target_h = self._matching_targets_from_disk()
         plans: list[StreamingSegmentPlan] = []
-        for segment in self.segments:
+        for i, segment in enumerate(self.segments):
             plan = self._build_streaming_plan(segment, target_fps, target_w, target_h, context)
             if plan is None:
-                return self._run_to_file_eager(output_path, format, preset, crf, context)
+                return self._eager_fallback(
+                    strict_streaming,
+                    f"segments[{i}] did not compile to a streaming plan",
+                    output_path,
+                    format,
+                    preset,
+                    crf,
+                    context,
+                )
             plans.append(plan)
 
         # Post-ops only fold cleanly into a single segment plan; multi-segment
         # post-ops would need a second pass we don't bother with.
         if self.post_operations and len(plans) != 1:
-            return self._run_to_file_eager(output_path, format, preset, crf, context)
+            return self._eager_fallback(
+                strict_streaming, "post-operations on a multi-segment plan", output_path, format, preset, crf, context
+            )
         if self.post_operations:
             plan = plans[0]
             total_frames = round((plan.end_second - plan.start_second) * plan.output_fps)
@@ -1222,9 +1284,25 @@ class VideoEdit(BaseModel):
                     # schedule is the P0.4 scheduling work. Defer to eager.
                     # (Multi-segment + requires already raised by
                     # _assert_post_ops_supported.)
-                    return self._run_to_file_eager(output_path, format, preset, crf, context)
+                    return self._eager_fallback(
+                        strict_streaming,
+                        f"post-operation '{op.op}' requires runtime context",
+                        output_path,
+                        format,
+                        preset,
+                        crf,
+                        context,
+                    )
                 if not isinstance(op, Effect) or not op.streamable:
-                    return self._run_to_file_eager(output_path, format, preset, crf, context)
+                    return self._eager_fallback(
+                        strict_streaming,
+                        f"post-operation '{op.op}' is not a streamable effect",
+                        output_path,
+                        format,
+                        preset,
+                        crf,
+                        context,
+                    )
                 start_f, end_f = _effect_frame_range(op, plan.output_fps, total_frames)
                 plan.effect_schedule.append(EffectScheduleEntry(op, start_f, end_f))
 
@@ -1245,6 +1323,31 @@ class VideoEdit(BaseModel):
         finally:
             for f in temp_files:
                 f.unlink(missing_ok=True)
+
+    def _eager_fallback(
+        self,
+        strict_streaming: bool,
+        detail: str,
+        output_path: Path,
+        format: ALLOWED_VIDEO_FORMATS,
+        preset: ALLOWED_VIDEO_PRESETS,
+        crf: int,
+        context: dict[str, Any] | None,
+    ) -> Path:
+        """Take the eager path -- or refuse to, under ``strict_streaming``.
+
+        When the :meth:`streamability` report is in sync with the plan builder
+        the strict branch is unreachable: the upfront gate in
+        :meth:`run_to_file` already raised. Reaching it means the two drifted
+        (e.g. a third-party transform whose ``streamable`` flag does not match
+        its ``to_ffmpeg_filter``) -- refuse to silently eager-load anyway.
+        """
+        if strict_streaming:
+            raise PlanValidationError(
+                f"strict_streaming=True: plan stopped streaming despite a clean streamability report ({detail})",
+                [PlanError(code=PlanErrorCode.STREAMING_FALLBACK, detail=detail)],
+            )
+        return self._run_to_file_eager(output_path, format, preset, crf, context)
 
     def _run_to_file_eager(
         self,
@@ -1321,6 +1424,14 @@ class VideoEdit(BaseModel):
                 # to the eager path, which executes ops strictly in plan order.
                 return None
             # Non-effect transform: compile to ffmpeg filter if streamable.
+            # The `streamable` flag is the authoritative declaration -- checked
+            # first so the streamability report (which classifies by the flag)
+            # can never disagree with the builder in this direction: a
+            # flag-False transform goes eager even if it has a working
+            # to_ffmpeg_filter. The remaining drift class (flag True, filter
+            # compiles to None) is caught by _eager_fallback under strict mode.
+            if not op.streamable:
+                return None
             ctx = FilterCtx(width=out_w, height=out_h, fps=out_fps)
             filter_expr = op.to_ffmpeg_filter(ctx)
             if filter_expr is None:

--- a/uv.lock
+++ b/uv.lock
@@ -4536,7 +4536,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.39.0"
+version = "0.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Streamability becomes a contract instead of a silent behavior. Whether run_to_file streams in O(1) memory or eager-loads the whole video is now inspectable before running anything, and enforceable.

- VideoEdit.streamability() classifies every op in plan order by streaming class (filter / frame_effect / eager + reason), computed by analyze_streamability, which mirrors _build_streaming_plan's decision points exactly. Purely structural: no source files, metadata, or context needed, so admission gating can happen before anything is downloaded.
- check(strict_streaming=True) appends one STREAMING_FALLBACK error per fallback-forcing op after the regular validity errors, with the actionable cause in the new optional PlanError.detail field, so an LLM refine loop treats "won't stream" like any other plan violation.
- run_to_file(strict_streaming=True) raises PlanValidationError with those errors before any decode. The former silent-fallback sites are guarded: reaching one under strict mode (report/builder drift) raises instead of eager-loading.

Hardening from adversarial review of the change:
- the streamable flag is now authoritative for transforms in both deciders: the plan builder consults it before compiling to_ffmpeg_filter, so a flag-False transform with a working filter goes eager (matching the report) instead of streaming while the report says eager -- which would have made strict mode reject a plan that streams
- registry tests in both the editing and ai suites pin declaration coherence (flag-True transforms must override to_ffmpeg_filter, and only those); the ai twin exists because the editing suite never imports videopython.ai, so its registry check could not see ai ops

Default behavior of check() and run_to_file() is unchanged.