### PR TITLE
feat(editing)!: streaming-first execution -- one engine, native trans…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ See the [LLM Integration Guide](https://videopython.com/guides/llm-integration/)
 
 ## Features
 
-- **`videopython.base`** — `Video`, `VideoMetadata`, `FrameIterator`, `ImageText`, `Transcription`, and shared result types (`BoundingBox`, `FaceTrack`, `SceneBoundary`, ...). No AI dependencies.
+- **`videopython.base`** — `Video`, `VideoMetadata`, `FrameIterator`, `Transcription`, and shared result types (`BoundingBox`, `FaceTrack`, `SceneBoundary`, ...). No AI dependencies.
 - **`videopython.audio`** — `Audio` with overlay, concat, normalize, time-stretch, silence detection, segment classification.
-- **`videopython.editing`** — `Operation`/`Effect` foundation, `VideoEdit` plan runner with JSON Schema + streaming execution. Transforms (cut, resize, crop, fps, speed, reverse, freeze, silence removal) and effects (blur, zoom, color grading, vignette, Ken Burns, fade, overlays, animated subtitles).
+- **`videopython.editing`** — `Operation`/`Effect` foundation, `VideoEdit` plan runner with JSON Schema + streaming execution. Transforms (cut, resize, crop, fps, speed, freeze, silence removal) and effects (blur, zoom, color grading, vignette, Ken Burns, fade, overlays, animated subtitles).
 - **`videopython.ai`** *(install with `[ai]`)* — generation (`TextToVideo`, `ImageToVideo`, `TextToImage`, `TextToSpeech`, `TextToMusic`), understanding (`AudioToText`, `AudioClassifier`, `SceneVLM`, `FaceTracker`, `ObjectDetector`, `SemanticSceneDetector`), the `FaceTrackingCrop` transform, the `ObjectDetectionOverlay` effect (per-frame bounding boxes + labels), and the full-pipeline `VideoAnalyzer`.
 - **`videopython.ai.dubbing`** — `VideoDubber` for voice-cloned revoicing with timing sync.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,68 @@
 # Release Notes
 
+## 0.42.0
+
+**Streaming-first migration complete: streaming is the only execution
+engine.** Every operation compiles to an ffmpeg filter chain or streams as a
+per-frame effect; the silent whole-plan eager fallback is gone, and `run()`
+is a view over the same engine that streams into memory (lossless rawvideo)
+instead of encoding. Plan shapes with no streaming strategy are rejected
+before any decode with structured `STREAMING_FALLBACK` errors carrying
+reorder hints.
+
+**Every remaining op streams natively:**
+
+- `speed_change`: `setpts` retime (bias-corrected nearest-frame for
+  speedups; closed-form log-curve ramps, exact to half a timebase tick) +
+  `fps`/`framerate` (blending) resample.
+- `freeze_frame`: linear `loop`/`select` chains for all three modes.
+- `silence_removal`: the transcription is consumed at plan compile and the
+  silent gaps drop via a `select` keep-window cut; gains a real
+  `predict_metadata` so validation folds the cut duration.
+- `face_crop` (ai extra): the detection pass runs at plan-compile time over
+  a bounded decode of exactly the frames the filter sees, compiling the
+  smoothed track to a per-frame `sendcmd` crop -- zero per-frame Python at
+  render time.
+
+**The engine folds duration and audio.** The plan builder threads real
+metadata through the chain (pipe stage vs final stage), the plan carries
+authoritative frame counts, effect envelopes size to the post-transform
+timeline, and segment audio follows through per-op audio twins
+(`Operation.transform_audio`: time-stretch, silence insertion, gap cuts)
+replayed in chain order around the effect envelopes.
+
+**Plan-order scheduling across two filter stages.** Transforms ordered
+after frame effects join the encoder's filter chain (`FrameEncoder -vf`),
+so `[fade, crop]` and `[fade, speed_change]` stream in plan order. Post-op
+effects fold across multi-segment plans with globally-rebased frame
+offsets -- envelopes continue across concat boundaries -- closing the last
+whole-plan fallback trigger (the brand-logo overlay on multi-segment
+plans).
+
+**The unstreamable shapes that remain** (all rejected with explicit
+errors): a frame effect ordered after encode-stage filters; time-based
+context after a duration-changing transform; transform post-ops;
+audio-coupled post-ops (`fade`/`volume_adjust`) on multi-segment plans;
+`face_crop` behind frame effects; in-plan `cut` ops.
+
+**BREAKING (no deprecation):**
+
+- The `reverse` op is removed (whole-video buffering has no place in a
+  streaming-first engine).
+- `silence_removal` loses `mode="speed_up"` and `speed_factor`.
+- `face_crop`: fixed crop-window size (the size-expansion clause is gone,
+  crops are pure slices); `fallback="full_frame"` behaves as `"center"`.
+- `strict_streaming` kwargs removed from `run_to_file()` and `check()` --
+  strictness is the only behavior; `check()` always reports unstreamable
+  ops as plan errors.
+- `StreamingClass.EAGER` renamed to `UNSTREAMABLE` (value
+  `"unstreamable"`).
+- `VideoEdit.run()` executes via the streaming engine: per-op in-memory
+  execution inside `VideoEdit` (`SegmentConfig.process`) is deleted, and
+  `run()` output pixels come from the decode chain. Per-op `apply()`
+  remains as the direct single-op API.
+- Plans that previously relied on the silent eager fallback now raise.
+
 ## 0.41.0
 
 **The subtitle renderer is now libass.** `add_subtitles` consumes its
@@ -94,7 +157,7 @@ streaming-first migration.
 Context-requiring effects now stream. `add_subtitles` — previously the most
 common reason a whole plan silently fell back to eager, in-memory execution —
 runs on the O(1)-memory streaming path. First step of the streaming-first
-migration (TODO.md P0.1).
+migration.
 
 - **Context threading.** `run_to_file` resolves each segment's `requires`
   context at plan-build time, re-based onto the segment-local timeline by the

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -87,18 +87,28 @@ Rules:
 `VideoEdit` runs each segment's `operations` in order, concatenates the
 results, then applies `post_operations` to the assembled output.
 
-## Streaming Mode (`run_to_file`)
+## The Streaming Engine
 
-`run_to_file()` pipes ffmpeg decode → per-frame effect chain → ffmpeg
-encode, keeping memory constant (~250 MB) regardless of video length.
+Streaming is the **only** execution engine. `run_to_file()` pipes ffmpeg
+decode → per-frame effect chain → ffmpeg encode, keeping memory constant
+(~250 MB) regardless of video length; `run()` is a view over the same
+engine that streams into memory (lossless rawvideo) instead of encoding.
 
-Each operation contributes either a ffmpeg `-vf` filter
-(`op.to_ffmpeg_filter(ctx)`) or a streaming `Effect`
-(`op.streamable == True` plus `process_frame`). If any operation is not
-streamable, `run_to_file` falls back to eager (`run()` + `save()`).
+Each operation compiles to one of: an ffmpeg filter
+(`op.to_ffmpeg_filter(ctx)`) -- the decode chain, or the encode chain when
+ordered after frame effects -- or a per-frame streaming `Effect`
+(`op.streamable == True` plus `process_frame`). Plans whose shape has no
+streaming strategy (the remaining cases: a frame effect ordered after
+encode-stage filters, time-based context after a duration-changing
+transform, a few post-op shapes) are rejected with structured
+`STREAMING_FALLBACK` errors before any decode.
 
-**Streamable transforms**: `resize`, `crop`, `resample_fps`.
-**Streamable effects**: every `Effect`, including the context-requiring
+**Filter transforms**: `resize`, `crop`, `resample_fps`, the
+duration-changing `speed_change` and `freeze_frame` (predicted metadata is
+folded through the chain so effect windows and audio follow the new
+timeline), the transcription-consuming `silence_removal`, and `face_crop`
+(ai extra; compile-time detection pass driving a per-frame crop track).
+**Streaming effects**: every `Effect`, including the context-requiring
 `add_subtitles` (pass `context=` to `run_to_file`).
 
 `add_subtitles` renders via libass: the transcription is compiled to an
@@ -107,34 +117,29 @@ filter — native speed, zero per-frame Python, classified as a `filter` in
 the streamability report. It joins the filter chain at its plan position:
 the decode chain normally (so transforms may follow it in plan order), or
 the encode chain when frame effects precede it (so `[fade, add_subtitles]`
-streams too). The eager `run()` path pipes the in-memory frames through the
-same filter — one pixel path everywhere. Requires an ffmpeg built with
+streams too). In memory, `run()` pipes the streamed-in frames through the same filter
+via a lossless rawvideo roundtrip — one pixel path everywhere. Requires an ffmpeg built with
 libass.
 
-### Streamability report and strict mode
+### Streamability report
 
 `edit.streamability()` classifies every op by streaming class without
-touching the disk — `filter` (ffmpeg `-vf`), `frame_effect`
-(`process_frame`), or `eager` (forces the whole-plan fallback, with the
-reason on the entry):
+touching the disk — `filter` (ffmpeg filter chain), `frame_effect`
+(`process_frame`), or `unstreamable` (the plan is rejected, with the
+reason and a reorder hint on the entry):
 
 ```python
 report = edit.streamability()
-report.streamable        # will run_to_file stream in O(1) memory?
+report.streamable        # will the plan run?
 report.fallbacks         # the offending ops, with reasons
 report.errors()          # the same as structured STREAMING_FALLBACK PlanErrors
 ```
 
-To make the fallback an error instead of a silent behavior change:
-
-- `edit.check(meta, strict_streaming=True)` appends one
-  `STREAMING_FALLBACK` error per offending op (location, op, and the
-  reason in `detail`) after the regular validity errors.
-- `edit.run_to_file(path, strict_streaming=True)` raises
-  `PlanValidationError` with those errors before any decode.
-
-Streamability is purely structural (op classes, order, plan shape), so a
-consumer can gate job admission on the report before downloading sources.
+`edit.check(meta)` reports the same `STREAMING_FALLBACK` errors after the
+regular validity errors, and `run()`/`run_to_file()` raise them before any
+decode. Streamability is purely structural (op classes, order, plan
+shape), so a consumer can gate job admission on the report before
+downloading sources.
 
 ## Context Data
 

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -175,10 +175,9 @@ llm_schema = cls.llm_json_schema()       # LLM-facing (llm_hidden dropped)
 | `resize` | `Resize` | transform | yes |
 | `resample_fps` | `ResampleFPS` | transform | yes |
 | `crop` | `Crop` | transform | yes |
-| `speed_change` | `SpeedChange` | transform | no |
-| `reverse` | `Reverse` | transform | no |
-| `freeze_frame` | `FreezeFrame` | transform | no |
-| `silence_removal` | `SilenceRemoval` | transform | no (requires `transcription`) |
+| `speed_change` | `SpeedChange` | transform | yes — compiles to `setpts` + CFR resample; audio time-stretched in sync |
+| `freeze_frame` | `FreezeFrame` | transform | yes — compiles to a `loop`-based chain; silence inserted in the audio |
+| `silence_removal` | `SilenceRemoval` | transform | yes — `select` keep-window cut (requires `transcription` context) |
 | `blur_effect` | `Blur` | effect | yes |
 | `zoom_effect` | `Zoom` | effect | yes |
 | `color_adjust` | `ColorGrading` | effect | yes |
@@ -209,7 +208,8 @@ and the default LLM-facing schema because they need a server-resolved
 
 | ID | Class | Category | Streamable |
 |---|---|---|---|
-| `face_crop` | `FaceTrackingCrop` | transform | no |
+| `face_crop` | `FaceTrackingCrop` | transform | yes — compile-time detection pass drives a per-frame crop track |
+| `object_detection_overlay` | `ObjectDetectionOverlay` | effect | yes — per-frame box overlay; YOLOv8 detection on a `detection_interval` cadence; bounded memory, not bounded compute |
 
 ## API Reference
 

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -43,10 +43,9 @@ plan = {
 | `resize` | `Resize` | yes | Resize, optional aspect-preserving |
 | `resample_fps` | `ResampleFPS` | yes | Change frame rate |
 | `crop` | `Crop` | yes | Pixel or normalized 0–1 fractions |
-| `speed_change` | `SpeedChange` | no | Constant or ramping speed |
-| `reverse` | `Reverse` | no | Reverse playback |
-| `freeze_frame` | `FreezeFrame` | no | Hold a frame for a duration |
-| `silence_removal` | `SilenceRemoval` | no | Requires transcription context |
+| `speed_change` | `SpeedChange` | yes | Constant or ramping speed |
+| `freeze_frame` | `FreezeFrame` | yes | Hold a frame for a duration |
+| `silence_removal` | `SilenceRemoval` | yes | Cuts silent gaps; requires transcription context |
 
 ## Crop Coordinates
 
@@ -103,10 +102,6 @@ SilenceRemoval().apply(video, transcription=my_transcription)
 ### SpeedChange
 
 ::: videopython.editing.SpeedChange
-
-### Reverse
-
-::: videopython.editing.Reverse
 
 ### FreezeFrame
 

--- a/docs/examples/large-videos.md
+++ b/docs/examples/large-videos.md
@@ -45,12 +45,13 @@ edit.run_to_file("output.mp4", crf=20, preset="medium")
 # Peak memory: ~250 MB regardless of video length
 ```
 
-When all operations are streamable, frames are never loaded into memory. If any operation
-is not streamable (e.g. `reverse`, `speed_change`), the pipeline falls back to eager
-mode automatically. To find out ahead of time, `edit.streamability()` returns a per-op
-report without touching the disk; to forbid the fallback outright, pass
-`strict_streaming=True` to `run_to_file` (raises `PlanValidationError` before any
-decode) or to `check` (reports structured `STREAMING_FALLBACK` errors).
+Streaming is the only execution engine: every op compiles to an ffmpeg
+filter or a per-frame effect, and frames are never accumulated in memory.
+A plan shape with no streaming strategy (e.g. a frame effect ordered after
+burned-in subtitles) is rejected with structured `STREAMING_FALLBACK`
+errors before any decode. `edit.streamability()` returns the per-op
+classification without touching the disk; `edit.check(meta)` reports the
+same errors alongside the validity checks.
 
 Context-requiring effects stream too: pass `context=` to `run_to_file` and
 e.g. `add_subtitles` burns word-level subtitles on the streaming path, with

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -188,13 +188,13 @@ for err in errors:
 # Re-prompt once with the full structured list instead of one-at-a-time
 ```
 
-With `check(source_metadata, strict_streaming=True)`, ops that would force
-`run_to_file`'s silent eager fallback are reported too — one
-`STREAMING_FALLBACK` error per op, with the actionable cause in
-`err.detail` (e.g. "transform follows an effect in plan order ... move the
-transform before the effect to stream"), so the refine loop can treat
-"won't stream" like any other violation. The full per-op classification
-(including the ops that do stream) is `edit.streamability()`.
+Streaming is the only execution engine, so ops that cannot stream at
+their plan position are real plan errors: `check()` reports one
+`STREAMING_FALLBACK` error per offending op, with the actionable cause in
+`err.detail` (e.g. "move the op before the duration-changing transform to
+stream"), and the refine loop treats "won't stream" like any other
+violation. The full per-op classification (including the ops that do
+stream) is `edit.streamability()`.
 
 ### Auto-repair the mechanical violations: `repair()`
 
@@ -278,7 +278,8 @@ edit.run_to_file("out.mp4", context={"transcription": transcription})
 
 Time-based context values (e.g. a `Transcription` with source-absolute
 timestamps) are re-based onto each cut segment's local timeline
-automatically, on both the eager and streaming paths.
+automatically, on the streaming engine that backs both `run()` and
+`run_to_file()`.
 
 Discover requires-aware ops via the registry:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ final.save("output.mp4")
 
 ### Core Editing
 
-Cut, resize, crop, change speed, reverse, freeze frames, silence removal. Multi-segment editing plans with automatic fps/resolution matching for concatenation.
+Cut, resize, crop, change speed, freeze frames, silence removal. Multi-segment editing plans with automatic fps/resolution matching for concatenation.
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.41.0"
+version = "0.42.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_transforms.py
+++ b/src/tests/ai/test_transforms.py
@@ -240,42 +240,25 @@ class TestFaceTrackingCrop:
         assert crop.max_speed == 0.1
         assert crop.fallback == "center"
 
-    def test_calculate_crop_region_basic(self):
-        """Test crop region calculation."""
-        crop = FaceTrackingCrop(target_aspect=(9, 16), padding=0.3, vertical_offset=0.0)
+    def test_track_positions_fixed_crop_size_and_centering(self):
+        """The crop window is the fixed aspect-fit box, centered on the face."""
+        crop = FaceTrackingCrop(target_aspect=(9, 16), framing_rule="center", smoothing=0.0)
+        frames = [np.zeros((1080, 1920, 3), dtype=np.uint8)] * 3
+        with patch("videopython.ai.transforms.FaceTracker") as tracker_cls:
+            tracker_cls.return_value.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.15)
+            positions = crop._track_crop_positions(frames, 1920, 1080)
 
-        # Face at center of 1920x1080 frame
-        x, y, w, h = crop._calculate_crop_region(
-            face_cx=0.5,
-            face_cy=0.5,
-            face_w=0.1,
-            face_h=0.15,
-            frame_w=1920,
-            frame_h=1080,
-        )
+        # For 9:16 from 1920x1080: crop = 606x1080 (even-floored), centered.
+        assert positions == [(657, 0)] * 3  # int(0.5*1920 - 606/2) = 657
 
-        # For 9:16 from 1920x1080: crop_h = 1080, crop_w = 1080 * 9/16 = 607.5
-        # Rounded down to even for H.264 compatibility
-        assert w == 606
-        assert h == 1080
+    def test_track_positions_clamped_to_bounds(self):
+        crop = FaceTrackingCrop(target_aspect=(9, 16), framing_rule="center", smoothing=0.0)
+        frames = [np.zeros((1080, 1920, 3), dtype=np.uint8)]
+        with patch("videopython.ai.transforms.FaceTracker") as tracker_cls:
+            tracker_cls.return_value.detect_and_track.return_value = (0.05, 0.5, 0.1, 0.15)
+            positions = crop._track_crop_positions(frames, 1920, 1080)
 
-    def test_calculate_crop_region_clamped_to_bounds(self):
-        """Test crop region is clamped to frame bounds."""
-        crop = FaceTrackingCrop(target_aspect=(9, 16), padding=0.3, vertical_offset=0.0)
-
-        # Face at edge of frame
-        x, y, w, h = crop._calculate_crop_region(
-            face_cx=0.05,  # Near left edge
-            face_cy=0.5,
-            face_w=0.1,
-            face_h=0.15,
-            frame_w=1920,
-            frame_h=1080,
-        )
-
-        # x should be clamped to 0
-        assert x >= 0
-        assert x + w <= 1920
+        assert positions == [(0, 0)]  # clamped at the left edge
 
     @patch("videopython.ai.transforms.FaceTracker")
     def test_apply_creates_correct_output_shape(self, mock_tracker_class):
@@ -600,3 +583,103 @@ class TestFaceCropSubtitleValidateGap:
         source = VideoMetadata(height=1080, width=1920, fps=30, frame_count=60, total_seconds=2.0)
         out = VideoEdit.from_dict(plan).validate_with_metadata(source, context={"transcription": self._transcription()})
         assert (out.width, out.height) == (606, 1080)
+
+
+class TestFaceCropStreaming:
+    """face_crop compiles to a sendcmd-driven crop track at plan build."""
+
+    @staticmethod
+    def _plan():
+        from videopython.editing import VideoEdit
+
+        return VideoEdit.model_validate(
+            {
+                "segments": [
+                    {
+                        "source": "src/tests/test_data/small_video.mp4",
+                        "start": 2.0,
+                        "end": 6.0,
+                        "operations": [
+                            {
+                                "op": "face_crop",
+                                "target_aspect": [9, 16],
+                                "framing_rule": "center",
+                                "smoothing": 0.0,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    def test_classifies_as_filter(self):
+        from videopython.editing import StreamingClass
+
+        report = self._plan().streamability()
+        assert report.entries[0].streaming_class is StreamingClass.FILTER
+        assert report.streamable
+
+    def test_streams_and_tracks_the_face(self, tmp_path):
+        import glob
+        import tempfile as _tempfile
+        from unittest.mock import patch as _patch
+
+        from videopython.base.video import Video
+
+        before = set(glob.glob(_tempfile.gettempdir() + "/*.cmd"))
+        plan = self._plan()
+        with _patch("videopython.ai.transforms.FaceTracker") as tracker_cls:
+            # Face drifts left -> right across the clip.
+            tracker_cls.return_value.detect_and_track.side_effect = lambda frame, i: (
+                0.3 + 0.4 * (i / 96),
+                0.5,
+                0.1,
+                0.15,
+            )
+            out = plan.run_to_file(tmp_path / "out.mp4")
+        assert set(glob.glob(_tempfile.gettempdir() + "/*.cmd")) == before, "sendcmd file leaked"
+
+        video = Video.from_path(str(out))
+        assert video.frames.shape == (96, 500, 280, 3)  # 9:16 of 800x500
+
+        source = Video.from_path("src/tests/test_data/small_video.mp4", start_second=2.0, end_second=6.0)
+
+        def best_x(out_frame: np.ndarray, src_frame: np.ndarray, width: int = 280) -> int:
+            errors = [
+                np.abs(out_frame.astype(np.float32) - src_frame[:, x : x + width].astype(np.float32)).mean()
+                for x in range(0, 800 - width, 20)
+            ]
+            return int(np.argmin(errors)) * 20
+
+        x_early = best_x(video.frames[5], source.frames[5])
+        x_late = best_x(video.frames[90], source.frames[90])
+        assert x_late > x_early + 100, f"crop did not follow the face: {x_early} -> {x_late}"
+
+    def test_behind_frame_effects_is_rejected(self, tmp_path):
+        """face_crop cannot reproduce post-effect frames at compile time."""
+        from unittest.mock import patch as _patch
+
+        import pytest as _pytest
+
+        from videopython.base.exceptions import PlanValidationError
+        from videopython.editing import VideoEdit
+
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [
+                    {
+                        "source": "src/tests/test_data/small_video.mp4",
+                        "start": 2.0,
+                        "end": 4.0,
+                        "operations": [
+                            {"op": "fade", "mode": "in", "duration": 0.5},
+                            {"op": "face_crop", "target_aspect": [9, 16]},
+                        ],
+                    }
+                ]
+            }
+        )
+        with _patch("videopython.ai.transforms.FaceTracker") as tracker_cls:
+            tracker_cls.return_value.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.15)
+            with _pytest.raises(PlanValidationError, match="cannot stream"):
+                plan.run_to_file(tmp_path / "out.mp4")

--- a/src/tests/editing/test_ass_subtitles.py
+++ b/src/tests/editing/test_ass_subtitles.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import glob
 import tempfile
 from typing import Any
-from unittest.mock import patch
 
 import numpy as np
 import pytest
 from PIL import ImageFont
 
 from tests.test_config import SMALL_VIDEO_PATH
+from videopython.base.exceptions import PlanValidationError
 from videopython.base.fonts import BUNDLED_FONT_FAMILIES, BUNDLED_FONTS, bundled_fonts_dir
 from videopython.base.transcription import Transcription, TranscriptionSegment, TranscriptionWord
 from videopython.base.video import Video
@@ -236,7 +236,7 @@ class TestLibassStreamability:
         ]
         assert report.streamable
 
-    def test_frame_effect_after_encode_stage_subtitles_is_eager(self):
+    def test_frame_effect_after_encode_stage_subtitles_is_unstreamable(self):
         report = _plan(
             [
                 {"op": "fade", "mode": "in", "duration": 0.5},
@@ -245,7 +245,7 @@ class TestLibassStreamability:
             ]
         ).streamability()
         trailing = report.entries[2]
-        assert trailing.streaming_class is StreamingClass.EAGER
+        assert trailing.streaming_class is StreamingClass.UNSTREAMABLE
         assert trailing.reason is not None and "encode-stage" in trailing.reason
         assert not report.streamable
 
@@ -253,9 +253,8 @@ class TestLibassStreamability:
 class TestLibassExecution:
     def test_streams_and_draws_subtitles(self, tmp_path):
         before = set(glob.glob(tempfile.gettempdir() + "/*.ass"))
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
-            out = _plan([SUBTITLES]).run_to_file(tmp_path / "subs.mp4", context={"transcription": _transcription()})
-            base = _plan([]).run_to_file(tmp_path / "base.mp4")
+        out = _plan([SUBTITLES]).run_to_file(tmp_path / "subs.mp4", context={"transcription": _transcription()})
+        base = _plan([]).run_to_file(tmp_path / "base.mp4")
         assert set(glob.glob(tempfile.gettempdir() + "/*.ass")) == before
 
         subs = Video.from_path(str(out)).frames
@@ -270,28 +269,23 @@ class TestLibassExecution:
 
     def test_transform_after_libass_subtitles_streams_end_to_end(self, tmp_path):
         plan = _plan([SUBTITLES, {"op": "crop", "width": 400, "height": 300}])
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
-            out = plan.run_to_file(tmp_path / "out.mp4", context={"transcription": _transcription()})
+        out = plan.run_to_file(tmp_path / "out.mp4", context={"transcription": _transcription()})
         meta = Video.from_path(str(out))
         assert meta.frames.shape[2] == 400 and meta.frames.shape[1] == 300
 
-    def test_abandoned_build_cleans_up_ass_file(self, tmp_path):
-        """A later non-streamable op abandons the plan; its .ass must not leak."""
+    def test_rejected_plan_leaks_no_ass_file(self, tmp_path):
+        """A plan rejected for an unstreamable op must not leak temp files."""
         before = set(glob.glob(tempfile.gettempdir() + "/*.ass"))
-        plan = _plan([SUBTITLES, {"op": "freeze_frame", "timestamp": 0.5, "duration": 0.2}])
-        with patch.object(
-            VideoEdit, "_run_to_file_eager", autospec=True, side_effect=VideoEdit._run_to_file_eager
-        ) as eager_spy:
+        plan = _plan([SUBTITLES, {"op": "cut", "start": 0.0, "end": 1.0}])
+        with pytest.raises(PlanValidationError, match="cannot stream"):
             plan.run_to_file(tmp_path / "out.mp4", context={"transcription": _transcription()})
-        assert eager_spy.call_count == 1
         assert set(glob.glob(tempfile.gettempdir() + "/*.ass")) == before
 
     def test_subtitles_after_frame_effect_stream_via_encode_stage(self, tmp_path):
         """[fade, add_subtitles] streams: the filter burns at encode time."""
         plan = _plan([{"op": "fade", "mode": "in", "duration": 1.0}, SUBTITLES])
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
-            out = plan.run_to_file(tmp_path / "out.mp4", context={"transcription": _transcription()})
-            base = _plan([{"op": "fade", "mode": "in", "duration": 1.0}]).run_to_file(tmp_path / "base.mp4")
+        out = plan.run_to_file(tmp_path / "out.mp4", context={"transcription": _transcription()})
+        base = _plan([{"op": "fade", "mode": "in", "duration": 1.0}]).run_to_file(tmp_path / "base.mp4")
 
         subs = Video.from_path(str(out)).frames
         plain = Video.from_path(str(base)).frames

--- a/src/tests/editing/test_native_transform_streaming.py
+++ b/src/tests/editing/test_native_transform_streaming.py
@@ -1,0 +1,433 @@
+"""Tests for natively compiled duration-changing transforms (P0.3).
+
+``speed_change`` and ``freeze_frame`` compile to ffmpeg filter chains
+(``setpts``/``fps``/``framerate``, ``loop``/``select``) instead of forcing
+the whole-plan eager fallback; the plan builder folds real metadata through
+the chain so frame counts, effect ranges, and the in-memory audio stay in
+sync with the filtered output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from tests.test_config import SMALL_VIDEO_PATH, TEST_AUDIO_PATH
+from videopython.base.exceptions import PlanValidationError
+from videopython.base.transcription import Transcription, TranscriptionSegment, TranscriptionWord
+from videopython.base.video import Video
+from videopython.editing import StreamingClass, VideoEdit
+
+FPS = 24
+SEGMENT = {"start": 2.0, "end": 8.0}  # 6 s cut -> 144 frames at 24 fps
+
+
+def _plan(operations: list[dict[str, Any]], source: str = SMALL_VIDEO_PATH) -> VideoEdit:
+    return VideoEdit.model_validate({"segments": [{"source": source, **SEGMENT, "operations": operations}]})
+
+
+def _stream(plan: VideoEdit, tmp_path, name: str = "out.mp4") -> Video:
+    """run_to_file (streaming is the only engine since 0.42.0)."""
+    out = plan.run_to_file(tmp_path / name)
+    return Video.from_path(str(out))
+
+
+@pytest.fixture(scope="module")
+def audio_source(tmp_path_factory) -> str:
+    """The small test video with a real audio track muxed in."""
+    video = Video.from_path(SMALL_VIDEO_PATH).add_audio_from_file(TEST_AUDIO_PATH)
+    out = tmp_path_factory.mktemp("native_transforms") / "with_audio.mp4"
+    return str(video.save(out))
+
+
+class TestSpeedChangeStreaming:
+    def test_constant_speedup_streams_with_exact_frame_count(self, tmp_path):
+        plan = _plan([{"op": "speed_change", "speed": 2.0}])
+        assert plan.streamability().entries[0].streaming_class is StreamingClass.FILTER
+
+        video = _stream(plan, tmp_path)
+        assert len(video.frames) == 72  # int(144 / 2.0), exact
+
+    def test_speedup_samples_the_right_source_frames(self, tmp_path):
+        """Output frame k must show source content from around frame 2k."""
+        video = _stream(_plan([{"op": "speed_change", "speed": 2.0}]), tmp_path)
+        source = Video.from_path(SMALL_VIDEO_PATH, start_second=2.0, end_second=8.0)
+
+        k = 30  # output frame 30 should match source frame ~60, not ~30
+        out_frame = video.frames[k].astype(np.float32)
+        right = np.abs(out_frame - source.frames[60].astype(np.float32)).mean()
+        wrong = np.abs(out_frame - source.frames[30].astype(np.float32)).mean()
+        assert right < wrong, f"speed mapping off: MAE to 2k={right:.1f}, to k={wrong:.1f}"
+
+    def test_slowdown_streams_with_interpolation(self, tmp_path):
+        plan = _plan([{"op": "speed_change", "speed": 0.5}])
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 288) <= 1  # int(144 / 0.5), +-1 EOF rounding
+
+    def test_ramp_streams_and_matches_predicted_count(self, tmp_path):
+        plan = _plan([{"op": "speed_change", "speed": 1.0, "end_speed": 3.0}])
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 72) <= 1  # int(144 / avg(1,3))
+
+    def test_ramp_accelerates(self, tmp_path):
+        """Early output advances the source slower than late output.
+
+        Uses a synthetic source whose frame i is the uniform gray level i, so
+        each output frame's mean intensity reads back the source index it
+        sampled -- the time-warp curve measured directly.
+        """
+        frames = np.zeros((144, 64, 64, 3), dtype=np.uint8)
+        for i in range(144):
+            frames[i] = i
+        src = str(Video.from_frames(frames, fps=24).save(tmp_path / "ramp_src.mp4", crf=0))
+
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [
+                    {
+                        "source": src,
+                        "start": 0.0,
+                        "end": 6.0,
+                        "operations": [{"op": "speed_change", "speed": 1.0, "end_speed": 3.0, "interpolate": False}],
+                    }
+                ]
+            }
+        )
+        video = _stream(plan, tmp_path, "ramp_idx.mp4")
+
+        sampled_index = video.frames.reshape(len(video.frames), -1).mean(axis=1)
+        early_advance = sampled_index[20] - sampled_index[10]
+        late_advance = sampled_index[65] - sampled_index[55]
+        assert late_advance > early_advance + 5, (early_advance, late_advance)
+        assert sampled_index[-1] > 130, "ramp did not span the full source"
+
+    def test_strong_slowdown_matches_predicted_exactly(self, tmp_path):
+        """Regression: a negative setpts bias dropped head frames (k<1)."""
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [
+                    {
+                        "source": SMALL_VIDEO_PATH,
+                        "start": 2.0,
+                        "end": 4.0,
+                        "operations": [{"op": "speed_change", "speed": 0.05, "interpolate": False}],
+                    }
+                ]
+            }
+        )
+        video = _stream(plan, tmp_path)
+        assert len(video.frames) == 960  # int(48 / 0.05), exact
+
+    def test_zero_frame_speed_raises_before_decode(self, tmp_path):
+        plan = _plan([{"op": "speed_change", "speed": 1000.0}])
+        with pytest.raises(ValueError, match="0 frames"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+
+class TestFreezeFrameStreaming:
+    def test_insert_freeze_extends_and_holds(self, tmp_path):
+        plan = _plan([{"op": "freeze_frame", "timestamp": 1.0, "duration": 0.5}])
+        assert plan.streamability().entries[0].streaming_class is StreamingClass.FILTER
+
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 156) <= 1  # 144 + round(0.5 * 24)
+
+        # Frames 24..36 hold frame 24's content (codec noise only).
+        held = video.frames[24:36].astype(np.float32)
+        spread = np.abs(held - held[0]).mean()
+        assert spread < 3.0, f"freeze region not held: {spread}"
+        # And the video did not stall: content after the freeze differs.
+        after = np.abs(video.frames[40].astype(np.float32) - held[0]).mean()
+        assert after > spread
+
+    def test_replace_freeze_keeps_duration(self, tmp_path):
+        plan = _plan([{"op": "freeze_frame", "timestamp": 1.0, "duration": 0.5, "position": "replace"}])
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 144) <= 1
+
+        held = video.frames[24:36].astype(np.float32)
+        assert np.abs(held - held[0]).mean() < 3.0
+        # Replace skips the covered originals: playback resumes past them.
+        source = Video.from_path(SMALL_VIDEO_PATH, start_second=2.0, end_second=8.0)
+        resumed = video.frames[40].astype(np.float32)
+        ahead = np.abs(resumed - source.frames[40].astype(np.float32)).mean()
+        behind = np.abs(resumed - source.frames[28].astype(np.float32)).mean()
+        assert ahead < behind, "replace mode did not skip the replaced originals"
+
+    def test_replace_freeze_after_resample_fps(self, tmp_path):
+        """Regression: without its own trailing resampler the replace chain
+        re-duplicated every post-freeze frame whenever an fps= filter ran
+        earlier (FrameIterator suppresses its trailing fps= append then)."""
+        plan = _plan(
+            [
+                {"op": "resample_fps", "fps": 12},
+                {"op": "freeze_frame", "timestamp": 1.0, "duration": 0.5, "position": "replace"},
+            ]
+        )
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 72) <= 1  # 6s at 12fps, duration unchanged
+
+    def test_boundary_freeze_agrees_across_paths(self, tmp_path):
+        """Regression: a timestamp in the last half-frame window rounded to
+        frame_count, where eager silently dropped the freeze while streaming
+        held the last frame -- all paths now clamp to the last frame."""
+        ops = [{"op": "freeze_frame", "timestamp": 5.99, "duration": 0.5}]
+        eager = _plan(ops).run()
+        video = _stream(_plan(ops), tmp_path)
+        assert len(eager.frames) == 156
+        assert abs(len(video.frames) - 156) <= 1
+
+    def test_sub_frame_segment_raises_structured_error(self, tmp_path):
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [
+                    {
+                        "source": SMALL_VIDEO_PATH,
+                        "start": 1.0,
+                        "end": 1.01,
+                        "operations": [{"op": "freeze_frame", "timestamp": 0.0, "duration": 0.5}],
+                    }
+                ]
+            }
+        )
+        with pytest.raises(ValueError, match="shorter than one frame"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+    def test_timestamp_out_of_range_raises_before_decode(self, tmp_path):
+        plan = _plan([{"op": "freeze_frame", "timestamp": 30.0, "duration": 0.5}])
+        with pytest.raises(ValueError, match="must be less than video duration"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+
+class TestDurationFoldIntegration:
+    def test_fade_out_after_speedup_covers_the_new_end(self, tmp_path):
+        """The fade envelope must be sized to the folded frame count."""
+        plan = _plan(
+            [
+                {"op": "speed_change", "speed": 2.0},
+                {"op": "fade", "mode": "out", "duration": 1.0},
+            ]
+        )
+        video = _stream(plan, tmp_path)
+        assert video.frames[-1].mean() < 5, "fade-out did not reach black at the sped-up end"
+
+    def test_subtitles_before_speed_streams(self, tmp_path):
+        words = [
+            TranscriptionWord(word="hello", start=3.0, end=4.0),
+            TranscriptionWord(word="world", start=4.0, end=5.0),
+        ]
+        tr = Transcription(
+            segments=[TranscriptionSegment(text="hello world", start=3.0, end=5.0, words=words)],
+            language="en",
+        )
+        plan = _plan([{"op": "add_subtitles", "font_scale": 0.1}, {"op": "speed_change", "speed": 2.0}])
+        report = plan.streamability()
+        assert [e.streaming_class for e in report.entries] == [StreamingClass.FILTER, StreamingClass.FILTER]
+
+        out = plan.run_to_file(tmp_path / "subs_speed.mp4", context={"transcription": tr})
+        assert Video.from_path(str(out)).frames.shape[0] == 72
+
+    def test_subtitles_after_speed_is_rejected(self, tmp_path):
+        plan = _plan([{"op": "speed_change", "speed": 2.0}, {"op": "add_subtitles", "font_scale": 0.1}])
+        report = plan.streamability()
+        subtitles = report.entries[1]
+        assert subtitles.streaming_class is StreamingClass.UNSTREAMABLE
+        assert subtitles.reason is not None and "duration-changing" in subtitles.reason
+        assert not report.streamable
+        with pytest.raises(PlanValidationError, match="cannot stream"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+
+class TestAudioSync:
+    def test_speedup_audio_matches_video_duration(self, tmp_path, audio_source):
+        plan = _plan([{"op": "speed_change", "speed": 2.0}], source=audio_source)
+        video = _stream(plan, tmp_path)
+        assert video.audio is not None
+        video_duration = len(video.frames) / video.fps
+        assert abs(video.audio.metadata.duration_seconds - video_duration) < 0.15
+
+    def test_freeze_audio_matches_video_duration_and_goes_silent(self, tmp_path, audio_source):
+        plan = _plan([{"op": "freeze_frame", "timestamp": 1.0, "duration": 1.0}], source=audio_source)
+        video = _stream(plan, tmp_path)
+        assert video.audio is not None
+        video_duration = len(video.frames) / video.fps
+        assert abs(video.audio.metadata.duration_seconds - video_duration) < 0.15
+
+        # The freeze window holds silence; just after it the track resumes.
+        sr = video.audio.metadata.sample_rate
+        data = np.abs(video.audio.data)
+        inside = data[int(1.3 * sr) : int(1.7 * sr)].mean()
+        outside = data[int(0.2 * sr) : int(0.8 * sr)].mean()
+        assert inside < outside * 0.2, f"freeze window not silent: {inside} vs {outside}"
+
+
+class TestSilenceRemovalStreaming:
+    @staticmethod
+    def _gapped_transcription() -> Transcription:
+        """Speech in [2.5, 4.5] and [7.0, 8.0] source time; silence between."""
+        return Transcription(
+            words=[
+                TranscriptionWord(word="a", start=2.5, end=3.5),
+                TranscriptionWord(word="b", start=3.5, end=4.5),
+                TranscriptionWord(word="c", start=7.0, end=8.0),
+            ]
+        )
+
+    def test_streams_and_cuts_the_gap(self, tmp_path):
+        plan = _plan([{"op": "silence_removal", "min_silence_duration": 1.0, "padding": 0.0}])
+        assert plan.streamability().entries[0].streaming_class is StreamingClass.FILTER
+
+        context = {"transcription": self._gapped_transcription()}
+        eager = _plan([{"op": "silence_removal", "min_silence_duration": 1.0, "padding": 0.0}]).run(context=context)
+        out = plan.run_to_file(tmp_path / "out.mp4", context=context)
+        video = Video.from_path(str(out))
+
+        # Keep [0, 2.5) + [5.0, 6.0) of the 6s cut = 3.5s = 84 frames.
+        assert len(video.frames) == 84
+        assert len(eager.frames) == 84
+
+    def test_audio_is_cut_in_sync(self, tmp_path, audio_source):
+        plan = _plan(
+            [{"op": "silence_removal", "min_silence_duration": 1.0, "padding": 0.0}],
+            source=audio_source,
+        )
+        out = plan.run_to_file(tmp_path / "out.mp4", context={"transcription": self._gapped_transcription()})
+        video = Video.from_path(str(out))
+        assert video.audio is not None
+        assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < 0.15
+
+    def test_missing_context_raises_at_compile(self, tmp_path):
+        plan = _plan([{"op": "silence_removal"}])
+        with pytest.raises(ValueError, match="requires transcription data"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+    def test_after_duration_change_is_rejected(self):
+        report = _plan([{"op": "speed_change", "speed": 2.0}, {"op": "silence_removal"}]).streamability()
+        silence = report.entries[1]
+        assert silence.streaming_class is StreamingClass.UNSTREAMABLE
+        assert silence.reason is not None and "duration-changing" in silence.reason
+
+    def test_no_silence_compiles_to_noop(self, tmp_path):
+        dense = Transcription(words=[TranscriptionWord(word=str(i), start=2.0 + i, end=3.0 + i) for i in range(6)])
+        plan = _plan([{"op": "silence_removal", "min_silence_duration": 1.0, "padding": 0.0}])
+        out = plan.run_to_file(tmp_path / "out.mp4", context={"transcription": dense})
+        assert abs(len(Video.from_path(str(out)).frames) - 144) <= 1
+
+
+class TestEncodeStageTransforms:
+    """Transforms ordered after frame effects stream via the encoder's -vf."""
+
+    def test_fade_then_crop_streams_and_matches_eager(self, tmp_path):
+        ops = [{"op": "fade", "mode": "out", "duration": 1.0}, {"op": "crop", "width": 400, "height": 300}]
+        eager = _plan(ops).run()
+        video = _stream(_plan(ops), tmp_path)
+
+        assert video.frames.shape[1:3] == (300, 400)
+        assert abs(len(video.frames) - len(eager.frames)) <= 1
+        assert video.frames[-1].mean() < 5, "fade-out lost in the encode-stage crop"
+        active = 60
+        mae = np.abs(video.frames[active].astype(np.float32) - eager.frames[active].astype(np.float32)).mean()
+        assert mae < 15, f"encode-stage crop diverged from eager: {mae}"
+
+    def test_fade_then_speed_streams_with_audio_sync(self, tmp_path, audio_source):
+        ops = [{"op": "fade", "mode": "out", "duration": 1.0}, {"op": "speed_change", "speed": 2.0}]
+        video = _stream(_plan(ops, source=audio_source), tmp_path)
+
+        assert abs(len(video.frames) - 72) <= 1
+        assert video.frames[-1].mean() < 8, "fade-out did not survive the encode-stage speed-up"
+        assert video.audio is not None
+        assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < 0.15
+
+    def test_post_ops_behind_encode_stage_are_rejected(self, tmp_path):
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [
+                    {
+                        "source": SMALL_VIDEO_PATH,
+                        "start": 2.0,
+                        "end": 8.0,
+                        "operations": [
+                            {"op": "fade", "mode": "in", "duration": 0.5},
+                            {"op": "crop", "width": 400, "height": 300},
+                        ],
+                    }
+                ],
+                "post_operations": [{"op": "color_adjust", "brightness": 0.2}],
+            }
+        )
+        report = plan.streamability()
+        post = report.entries[-1]
+        assert post.streaming_class is StreamingClass.UNSTREAMABLE
+        assert post.reason is not None and "encode-stage" in post.reason
+        with pytest.raises(PlanValidationError, match="cannot stream"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+
+class TestMultiSegmentPostOps:
+    """Post-op effects fold into per-segment schedules with global offsets."""
+
+    @staticmethod
+    def _plan(post: list[dict[str, Any]]) -> VideoEdit:
+        return VideoEdit.model_validate(
+            {
+                "segments": [
+                    {"source": SMALL_VIDEO_PATH, "start": 0.0, "end": 3.0, "operations": []},
+                    {"source": SMALL_VIDEO_PATH, "start": 6.0, "end": 9.0, "operations": []},
+                ],
+                "post_operations": post,
+            }
+        )
+
+    def test_pixel_post_op_streams_across_segments(self, tmp_path):
+        plan = self._plan([{"op": "vignette"}])
+        assert plan.streamability().streamable
+
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 144) <= 2
+        # The vignette darkens corners in BOTH segments.
+        for idx in (36, 108):
+            frame = video.frames[idx].astype(np.float32)
+            assert frame[:30, :30].mean() < frame[235:265, 385:415].mean()
+
+    def test_windowed_post_op_envelope_continues_across_boundary(self, tmp_path):
+        """A fade-to-black VIDEO envelope spanning the concat boundary must
+        not restart: brightness decreases monotonically into segment 2.
+
+        Uses zoom, not fade (audio-coupled ops are excluded); a window-spanning
+        ascending blur or zoom shows index continuity. Zoom with a window
+        crossing the boundary: the zoom level at segment 2's first frames
+        continues from segment 1's last frames.
+        """
+        plan = self._plan(
+            [{"op": "zoom_effect", "mode": "in", "zoom_factor": 2.0, "window": {"start": 2.0, "stop": 4.0}}]
+        )
+        video = _stream(plan, tmp_path)
+
+        # At the boundary (global frames 71/72, window-local 23/24 of 48) the
+        # zoom is ~halfway. If the envelope restarted, segment 2's first
+        # frame would be unzoomed (== source frame at 6.0s).
+        seg2_first = video.frames[73].astype(np.float32)
+        source2 = Video.from_path(SMALL_VIDEO_PATH, start_second=6.0, end_second=9.0)
+        unzoomed_mae = np.abs(seg2_first - source2.frames[1].astype(np.float32)).mean()
+        assert unzoomed_mae > 10, "zoom envelope restarted at the concat boundary"
+
+    def test_audio_coupled_post_op_is_rejected(self, tmp_path):
+        plan = self._plan([{"op": "fade", "mode": "out", "duration": 1.0}])
+        report = plan.streamability()
+        assert report.entries[-1].streaming_class is StreamingClass.UNSTREAMABLE
+        assert "audio-coupled" in (report.entries[-1].reason or "")
+        with pytest.raises(PlanValidationError, match="cannot stream"):
+            plan.run_to_file(tmp_path / "out.mp4")
+
+    def test_single_segment_fade_post_op_still_folds(self, tmp_path):
+        plan = VideoEdit.model_validate(
+            {
+                "segments": [{"source": SMALL_VIDEO_PATH, "start": 2.0, "end": 8.0, "operations": []}],
+                "post_operations": [{"op": "fade", "mode": "out", "duration": 1.0}],
+            }
+        )
+        assert plan.streamability().streamable
+        video = _stream(plan, tmp_path)
+        assert video.frames[-1].mean() < 5

--- a/src/tests/editing/test_streamability.py
+++ b/src/tests/editing/test_streamability.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 
@@ -18,7 +17,7 @@ from videopython.editing.video_edit import VideoEdit
 FADE = {"op": "fade", "mode": "in", "duration": 0.5}
 RESIZE = {"op": "resize", "width": 640, "height": 480}
 SUBTITLES = {"op": "add_subtitles", "font_scale": 0.1}
-FREEZE = {"op": "freeze_frame", "timestamp": 0.5, "duration": 0.2}
+CUT = {"op": "cut", "start": 0.0, "end": 1.0}
 SILENCE = {"op": "silence_removal"}
 
 
@@ -62,35 +61,52 @@ class TestStreamabilityReport:
         assert report.errors() == []
         assert all(e.reason is None for e in report.entries)
 
-    def test_transform_after_effect_is_eager(self):
+    def test_transform_after_effect_streams_via_encode_stage(self):
+        # 0.42.0: transforms following frame effects join the encode-stage
+        # filter chain instead of forcing the whole-plan eager fallback.
         report = _plan([FADE, RESIZE]).streamability()
 
         fade, resize = report.entries
-        assert fade.streams
-        assert resize.streaming_class is StreamingClass.EAGER
-        assert resize.reason is not None and "follows an effect" in resize.reason
+        assert fade.streaming_class is StreamingClass.FRAME_EFFECT
+        assert resize.streaming_class is StreamingClass.FILTER
+        assert report.streamable
+
+    def test_effect_after_encode_stage_is_unstreamable(self):
+        report = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}]).streamability()
+
+        trailing = report.entries[2]
+        assert trailing.streaming_class is StreamingClass.UNSTREAMABLE
+        assert trailing.reason is not None and "encode-stage" in trailing.reason
         assert not report.streamable
 
-    def test_context_requiring_transform_is_eager(self):
+    def test_context_requiring_transform_streams_as_filter(self):
+        # silence_removal consumes its transcription at plan compile (0.42.0).
         report = _plan([SILENCE]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.EAGER
-        assert entry.reason is not None and "transcription" in entry.reason
+        assert entry.streaming_class is StreamingClass.FILTER
 
-    def test_unfilterable_transform_is_eager(self):
-        report = _plan([FREEZE]).streamability()
+    def test_context_transform_after_duration_change_is_unstreamable(self):
+        report = _plan([{"op": "speed_change", "speed": 2.0}, SILENCE]).streamability()
+
+        speed, silence = report.entries
+        assert speed.streaming_class is StreamingClass.FILTER
+        assert silence.streaming_class is StreamingClass.UNSTREAMABLE
+        assert silence.reason is not None and "duration-changing" in silence.reason
+
+    def test_unfilterable_transform_is_unstreamable(self):
+        report = _plan([CUT]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
         assert entry.reason is not None and "no ffmpeg filter" in entry.reason
 
-    def test_non_streamable_effect_is_eager(self, monkeypatch: pytest.MonkeyPatch):
+    def test_non_streamable_effect_is_unstreamable(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(Fade, "streamable", False)
         report = _plan([FADE]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
         assert entry.reason is not None and "streamable=False" in entry.reason
 
     def test_post_op_effect_on_single_segment_streams(self):
@@ -101,35 +117,35 @@ class TestStreamabilityReport:
         assert entry.streaming_class is StreamingClass.FRAME_EFFECT
         assert report.streamable
 
-    def test_post_op_on_multi_segment_plan_is_eager(self):
+    def test_audio_coupled_post_op_on_multi_segment_plan_is_unstreamable(self):
         report = _plan([], post_operations=[FADE], n_segments=2).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
         assert entry.reason is not None and "multi-segment" in entry.reason
 
-    def test_context_requiring_post_op_is_eager(self):
+    def test_context_requiring_post_op_is_unstreamable(self):
         report = _plan([], post_operations=[SUBTITLES]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
         assert entry.reason is not None and "transcription" in entry.reason
 
-    def test_transform_post_op_is_eager(self):
+    def test_transform_post_op_is_unstreamable(self):
         report = _plan([], post_operations=[RESIZE]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.EAGER
+        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
         assert entry.reason is not None and "post-operations" in entry.reason
 
     def test_errors_carry_location_op_and_detail(self):
-        errors = _plan([FADE, RESIZE]).streamability().errors()
+        errors = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}]).streamability().errors()
 
         (err,) = errors
         assert err.code is PlanErrorCode.STREAMING_FALLBACK
-        assert err.location == "segments[0].operations[1]"
-        assert err.op == "resize"
-        assert err.detail is not None and "follows an effect" in err.detail
+        assert err.location == "segments[0].operations[2]"
+        assert err.op == "color_adjust"
+        assert err.detail is not None and "encode-stage" in err.detail
 
 
 class TestRegistryAlignment:
@@ -155,41 +171,37 @@ class TestRegistryAlignment:
 
 
 class TestCheckStrictStreaming:
-    def test_default_check_ignores_streamability(self):
-        plan = _plan([FADE, RESIZE])
-        assert plan.check(SMALL_VIDEO_METADATA) == []
-
-    def test_strict_check_reports_fallbacks(self):
-        plan = _plan([FADE, RESIZE])
-        errors = plan.check(SMALL_VIDEO_METADATA, strict_streaming=True)
+    def test_check_reports_unstreamable_ops(self):
+        # Streaming is the only engine: unstreamable shapes are plan errors.
+        plan = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
+        errors = plan.check(SMALL_VIDEO_METADATA)
 
         (err,) = errors
         assert err.code is PlanErrorCode.STREAMING_FALLBACK
-        assert err.location == "segments[0].operations[1]"
-        assert err.op == "resize"
+        assert err.location == "segments[0].operations[2]"
+        assert err.op == "color_adjust"
 
-    def test_strict_check_on_streamable_plan_is_clean(self):
+    def test_check_on_streamable_plan_is_clean(self):
         plan = _plan([RESIZE, FADE])
-        assert plan.check(SMALL_VIDEO_METADATA, strict_streaming=True) == []
+        assert plan.check(SMALL_VIDEO_METADATA) == []
 
     def test_fallback_errors_append_after_validity_errors(self):
         bad_window = {"op": "fade", "mode": "in", "duration": 0.5, "window": {"start": 50.0, "stop": 60.0}}
-        plan = _plan([bad_window, RESIZE])
-        errors = plan.check(SMALL_VIDEO_METADATA, strict_streaming=True)
+        plan = _plan([bad_window, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
+        errors = plan.check(SMALL_VIDEO_METADATA)
 
         assert len(errors) >= 2
         assert errors[0].code is not PlanErrorCode.STREAMING_FALLBACK
         assert errors[-1].code is PlanErrorCode.STREAMING_FALLBACK
 
 
-class TestRunToFileStrict:
-    def test_streamable_plan_streams_under_strict(self, tmp_path):
+class TestRunToFileRejection:
+    def test_streamable_plan_streams(self, tmp_path):
         plan = _plan([RESIZE, FADE])
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
-            out = plan.run_to_file(tmp_path / "out.mp4", strict_streaming=True)
+        out = plan.run_to_file(tmp_path / "out.mp4")
         assert out.exists()
 
-    def test_multi_segment_streamable_plan_streams_under_strict(self, tmp_path):
+    def test_multi_segment_streamable_plan_streams(self, tmp_path):
         plan = VideoEdit.model_validate(
             {
                 "segments": [
@@ -198,54 +210,42 @@ class TestRunToFileStrict:
                 ],
             }
         )
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("eager fallback used")):
-            out = plan.run_to_file(tmp_path / "out.mp4", strict_streaming=True)
+        out = plan.run_to_file(tmp_path / "out.mp4")
         assert out.exists()
 
-    def test_fallback_plan_raises_under_strict(self, tmp_path):
-        plan = _plan([FADE, RESIZE])
+    def test_unstreamable_plan_raises(self, tmp_path):
+        plan = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
         out_path = tmp_path / "out.mp4"
 
-        with pytest.raises(PlanValidationError, match="strict_streaming=True rejects this plan") as exc_info:
-            plan.run_to_file(out_path, strict_streaming=True)
+        with pytest.raises(PlanValidationError, match="cannot stream") as exc_info:
+            plan.run_to_file(out_path)
 
         assert not out_path.exists()
         (err,) = exc_info.value.errors
         assert err.code is PlanErrorCode.STREAMING_FALLBACK
-        assert err.op == "resize"
+        assert err.op == "color_adjust"
 
-    def test_fallback_plan_still_falls_back_without_strict(self, tmp_path):
-        plan = _plan([FADE, RESIZE])
-        with patch.object(
-            VideoEdit, "_run_to_file_eager", autospec=True, side_effect=VideoEdit._run_to_file_eager
-        ) as eager_spy:
-            out = plan.run_to_file(tmp_path / "out.mp4")
-        assert eager_spy.call_count == 1
-        assert out.exists()
+    def test_run_raises_the_same_errors(self, tmp_path):
+        plan = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
+        with pytest.raises(PlanValidationError, match="cannot stream"):
+            plan.run()
 
     def test_builder_drift_raises_instead_of_silent_eager(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
-        """A streamable-flagged transform that fails to compile must not eager-load."""
+        """A streamable-flagged transform that fails to compile must not slip through."""
         monkeypatch.setattr(Resize, "to_ffmpeg_filter", lambda self, ctx: None)
         plan = _plan([RESIZE])
 
         with pytest.raises(PlanValidationError, match="despite a clean streamability report"):
-            plan.run_to_file(tmp_path / "out.mp4", strict_streaming=True)
+            plan.run_to_file(tmp_path / "out.mp4")
 
-    def test_flag_false_transform_goes_eager_even_with_working_filter(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
-        """The ``streamable`` flag is authoritative in both directions.
-
-        A transform declaring ``streamable=False`` must take the eager path
-        even if its ``to_ffmpeg_filter`` compiles -- otherwise the runtime
-        would stream while the report (which classifies by the flag) says
-        eager, and strict mode would reject a plan that actually streams.
-        """
+    def test_flag_false_transform_is_rejected_even_with_working_filter(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        """The ``streamable`` flag is authoritative in both directions: a
+        transform declaring ``streamable=False`` is rejected even if its
+        ``to_ffmpeg_filter`` compiles, so the report and the runtime can
+        never disagree."""
         monkeypatch.setattr(Resize, "streamable", False)
         plan = _plan([RESIZE])
 
         assert not plan.streamability().streamable
-        with patch.object(
-            VideoEdit, "_run_to_file_eager", autospec=True, side_effect=VideoEdit._run_to_file_eager
-        ) as eager_spy:
-            out = plan.run_to_file(tmp_path / "out.mp4")
-        assert eager_spy.call_count == 1
-        assert out.exists()
+        with pytest.raises(PlanValidationError, match="cannot stream"):
+            plan.run_to_file(tmp_path / "out.mp4")

--- a/src/tests/editing/test_streaming.py
+++ b/src/tests/editing/test_streaming.py
@@ -3,7 +3,6 @@
 import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -358,7 +357,7 @@ class TestStreamableTransforms:
         )
         assert abs(meta.fps - 12) < 1
 
-    def test_speed_change_falls_back_to_eager(self):
+    def test_speed_change_streams_natively(self):
         """speed_change is not streamable -- should fall back to eager and still work."""
         meta = self._run_plan(
             {
@@ -372,7 +371,7 @@ class TestStreamableTransforms:
                 ]
             }
         )
-        # 4s at 2x speed = ~2s output (via eager fallback)
+        # 4s at 2x speed = ~2s output, compiled to setpts+fps (0.42.0)
         assert meta.total_seconds < 3.0
 
     def test_transforms_plus_effects(self):
@@ -609,8 +608,7 @@ class TestContextStreaming:
         eager_video = VideoEdit.from_dict(self._PLAN).run(context=context)
 
         out_path = tmp_path / "subtitled.mp4"
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("fell back to eager")):
-            VideoEdit.from_dict(self._PLAN).run_to_file(out_path, context=context)
+        VideoEdit.from_dict(self._PLAN).run_to_file(out_path, context=context)
         streamed_video = Video.from_path(str(out_path))
 
         assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
@@ -678,8 +676,7 @@ class TestContextStreaming:
         eager_video = VideoEdit.from_dict(plan).run(context=context)
 
         out_path = tmp_path / "out.mp4"
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("fell back to eager")):
-            VideoEdit.from_dict(plan).run_to_file(out_path, context=context)
+        VideoEdit.from_dict(plan).run_to_file(out_path, context=context)
         streamed_video = Video.from_path(str(out_path))
 
         assert streamed_video.frames.shape[1:3] == (300, 400)
@@ -715,7 +712,6 @@ class TestTrailingFrameSchedule:
             ],
         }
         out_path = tmp_path / "faded.mp4"
-        with patch.object(VideoEdit, "_run_to_file_eager", side_effect=AssertionError("fell back to eager")):
-            VideoEdit.from_dict(plan).run_to_file(out_path)
+        VideoEdit.from_dict(plan).run_to_file(out_path)
         result = Video.from_path(str(out_path))
         assert result.frames[-1].mean() < 5, f"Last frame escaped the fade: {result.frames[-1].mean()}"

--- a/src/tests/editing/test_transforms.py
+++ b/src/tests/editing/test_transforms.py
@@ -15,7 +15,6 @@ from videopython.editing.transforms import (
     FreezeFrame,
     ResampleFPS,
     Resize,
-    Reverse,
     SilenceRemoval,
     SpeedChange,
 )
@@ -350,32 +349,6 @@ def _make_transcription(words_data: list[tuple[float, float, str]]) -> Transcrip
     return Transcription(segments=[segment])
 
 
-class TestReverse:
-    def test_reverses_frame_order(self, video_1s):
-        video_1s.frames[0] = 0
-        video_1s.frames[-1] = 255
-        result = Reverse().apply(video_1s)
-        assert result.frames[0].mean() == 255
-        assert result.frames[-1].mean() == 0
-
-    def test_preserves_shape(self, video_1s):
-        original_shape = video_1s.video_shape
-        result = Reverse().apply(video_1s)
-        assert result.video_shape == original_shape
-
-    def test_reverse_audio(self, video_with_audio_1s):
-        original_first_sample = video_with_audio_1s.audio.data[0].copy()
-        original_last_sample = video_with_audio_1s.audio.data[-1].copy()
-        result = Reverse(reverse_audio=True).apply(video_with_audio_1s)
-        assert np.isclose(result.audio.data[0], original_last_sample)
-        assert np.isclose(result.audio.data[-1], original_first_sample)
-
-    def test_reverse_audio_false(self, video_with_audio_1s):
-        original_audio = video_with_audio_1s.audio.data.copy()
-        result = Reverse(reverse_audio=False).apply(video_with_audio_1s)
-        assert np.array_equal(result.audio.data, original_audio)
-
-
 class TestFreezeFrame:
     def test_freeze_after_increases_duration(self, video_1s):
         original_frames = len(video_1s.frames)
@@ -440,22 +413,10 @@ class TestSilenceRemoval:
 
     def test_cut_removes_silence(self, video_5s, transcription_with_gap):
         original_frames = len(video_5s.frames)
-        result = SilenceRemoval(min_silence_duration=1.0, padding=0.0, mode="cut").apply(
+        result = SilenceRemoval(min_silence_duration=1.0, padding=0.0).apply(
             video_5s, transcription=transcription_with_gap
         )
         assert len(result.frames) < original_frames
-
-    def test_speed_up_reduces_duration(self, video_5s, transcription_with_gap):
-        original_frames = len(video_5s.frames)
-        result = SilenceRemoval(min_silence_duration=1.0, padding=0.0, mode="speed_up", speed_factor=3.0).apply(
-            video_5s, transcription=transcription_with_gap
-        )
-        assert len(result.frames) < original_frames
-        cut_result = SilenceRemoval(min_silence_duration=1.0, padding=0.0, mode="cut").apply(
-            Video.from_frames(np.full((50, 32, 32, 3), 128, dtype=np.uint8), fps=10),
-            transcription=transcription_with_gap,
-        )
-        assert len(result.frames) > len(cut_result.frames)
 
     def test_no_silence_returns_unchanged(self, video_5s):
         transcription = _make_transcription(
@@ -471,10 +432,10 @@ class TestSilenceRemoval:
         assert len(result.frames) == len(video_5s.frames)
 
     def test_padding_preserves_context(self, video_5s, transcription_with_gap):
-        result = SilenceRemoval(min_silence_duration=1.0, padding=0.5, mode="cut").apply(
+        result = SilenceRemoval(min_silence_duration=1.0, padding=0.5).apply(
             video_5s, transcription=transcription_with_gap
         )
-        result_no_pad = SilenceRemoval(min_silence_duration=1.0, padding=0.0, mode="cut").apply(
+        result_no_pad = SilenceRemoval(min_silence_duration=1.0, padding=0.0).apply(
             Video.from_frames(np.full((50, 32, 32, 3), 128, dtype=np.uint8), fps=10),
             transcription=transcription_with_gap,
         )
@@ -489,8 +450,6 @@ class TestSilenceRemoval:
             SilenceRemoval(min_silence_duration=0)
         with pytest.raises(ValueError, match="padding"):
             SilenceRemoval(padding=-1)
-        with pytest.raises(ValueError, match="speed_factor"):
-            SilenceRemoval(speed_factor=0.5)
 
 
 class TestCutDurationErrors:

--- a/src/tests/editing/test_video_edit.py
+++ b/src/tests/editing/test_video_edit.py
@@ -128,11 +128,11 @@ class TestParsingAndSerialization:
     def test_post_operations_round_trip(self):
         plan = {
             "segments": [_segment()],
-            "post_operations": [{"op": "reverse"}, {"op": "fade", "mode": "out", "duration": 0.5}],
+            "post_operations": [{"op": "vignette"}, {"op": "fade", "mode": "out", "duration": 0.5}],
         }
         edit = VideoEdit.from_dict(plan)
         out = edit.to_dict()
-        assert [op["op"] for op in out["post_operations"]] == ["reverse", "fade"]
+        assert [op["op"] for op in out["post_operations"]] == ["vignette", "fade"]
 
     def test_window_round_trip(self):
         plan = {
@@ -197,7 +197,7 @@ class TestJsonSchema:
         # the exact shape comes from Operation.json_schema(), so just check the
         # union mentions a known op_id.
         as_json = json.dumps(op_schema)
-        for op_id in ("resize", "blur_effect", "fade", "reverse"):
+        for op_id in ("resize", "blur_effect", "fade", "speed_change"):
             assert op_id in as_json, f"Operation {op_id!r} missing from schema"
 
     def test_schema_has_descriptions_for_every_top_level_field(self):
@@ -270,11 +270,19 @@ class TestExecution:
     def test_run_with_post_operations(self):
         plan = {
             "segments": [_segment(start=0.0, end=2.0)],
-            "post_operations": [{"op": "resize", "width": 200, "height": 100}],
+            "post_operations": [{"op": "fade", "mode": "out", "duration": 0.5}],
         }
         result = VideoEdit.from_dict(plan).run()
-        assert result.frames.shape[2] == 200
-        assert result.frames.shape[1] == 100
+        assert result.frames[-1].mean() < 5
+
+    def test_transform_post_op_is_rejected(self):
+        # Streaming is the only engine; transforms cannot stream as post-ops.
+        plan = {
+            "segments": [_segment(start=0.0, end=2.0)],
+            "post_operations": [{"op": "resize", "width": 200, "height": 100}],
+        }
+        with pytest.raises(PlanValidationError, match="move the transform into the segment"):
+            VideoEdit.from_dict(plan).run()
 
     def test_run_with_image_overlay(self, tmp_path):
         logo = tmp_path / "logo.png"
@@ -827,25 +835,6 @@ class TestSegmentContextHelper:
 class TestSegmentContextWiring:
     """``run()`` and ``validate()`` re-base per segment but not post_operations."""
 
-    def test_process_rebases_context_for_segment_ops(self):
-        seg = SegmentConfig.model_validate(
-            {"source": "fake.mp4", "start": 10.0, "end": 20.0, "operations": [{"op": "reverse"}]}
-        )
-        abs_tx = _make_transcription([(12.0, 13.0, "a"), (18.0, 19.0, "b")])
-        video = _make_synthetic_video(32, 32, 24, 0.5)
-        captured: dict[str, Any] = {}
-
-        def fake_apply(op: Any, vid: Video, ctx: dict[str, Any] | None) -> Video:
-            captured["ctx"] = ctx
-            return vid
-
-        with patch("videopython.editing.video_edit._apply_with_context", side_effect=fake_apply):
-            out = seg.process(video, {"transcription": abs_tx, "other": 123})
-
-        assert out is video
-        assert captured["ctx"]["other"] == 123
-        assert _word_spans(captured["ctx"]["transcription"]) == [(2.0, 3.0, "a"), (8.0, 9.0, "b")]
-
     def test_validate_rebases_segment_but_not_post_operations(self):
         plan = {
             "segments": [_segment(source="fake.mp4", start=10.0, end=20.0, operations=[{"op": "silence_removal"}])],
@@ -929,7 +918,7 @@ class TestStreamingRequiresGuard:
     context.
     """
 
-    def test_build_streaming_plan_returns_none_for_requires_transform(self, monkeypatch):
+    def test_build_streaming_plan_returns_none_for_non_streamable_requires_transform(self, monkeypatch):
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -943,10 +932,12 @@ class TestStreamingRequiresGuard:
             }
         )
         seg = plan.segments[0]
-        # resize is streamable, so without the guard a plan is built.
         assert plan._build_streaming_plan(seg, None, None, None) is not None
-        # Same streamable transform, now declaring a context requirement -> eager.
+        # A context-requiring transform streams when its compile can consume
+        # the context (silence_removal); without a streaming strategy it
+        # still defers to eager.
         monkeypatch.setattr(Resize, "requires", ("transcription",))
+        monkeypatch.setattr(Resize, "streamable", False)
         assert plan._build_streaming_plan(seg, None, None, None) is None
 
     def test_requires_effect_builds_plan_with_rebased_context(self):
@@ -1037,12 +1028,12 @@ class TestStreamingRequiresGuard:
 
 
 class TestStreamingOpOrderGuard:
-    """A transform after a scheduled effect forces the eager fallback.
+    """Plan-order scheduling across the decode and encode filter stages.
 
-    vf filters run at decode time, before every scheduled effect's
-    process_frame, so an effect-then-transform plan cannot stream in plan
-    order: the effect's frame range and streaming_init dims/fps would be
-    computed against a timeline the later filter changes.
+    Transforms before effects join the decode chain; transforms after
+    effects join the encode chain (FrameEncoder -vf). The one unstreamable
+    order is a frame effect AFTER encode-stage content -- process_frame
+    runs before the encoder, so plan order cannot be preserved.
     """
 
     @staticmethod
@@ -1051,11 +1042,25 @@ class TestStreamingOpOrderGuard:
             {"segments": [_segment(source=SMALL_VIDEO_PATH, start=0.0, end=2.0, operations=operations)]}
         )
 
-    def test_transform_after_effect_returns_none(self):
+    def test_transform_after_effect_joins_encode_stage(self):
         plan = self._plan(
             [
                 {"op": "fade", "mode": "in", "duration": 0.5},
                 {"op": "resize", "width": 64, "height": 64},
+            ]
+        )
+        built = plan._build_streaming_plan(plan.segments[0], None, None, None)
+        assert built is not None
+        assert built.post_vf_filters == ["scale=64:64"]
+        # The pipe (encoder rawvideo input) keeps the pre-transform dims.
+        assert (built.output_width, built.output_height) == (800, 500)
+
+    def test_effect_after_encode_stage_returns_none(self):
+        plan = self._plan(
+            [
+                {"op": "fade", "mode": "in", "duration": 0.5},
+                {"op": "resize", "width": 64, "height": 64},
+                {"op": "color_adjust", "brightness": 0.2},
             ]
         )
         assert plan._build_streaming_plan(plan.segments[0], None, None, None) is None
@@ -1067,7 +1072,9 @@ class TestStreamingOpOrderGuard:
                 {"op": "fade", "mode": "in", "duration": 0.5},
             ]
         )
-        assert plan._build_streaming_plan(plan.segments[0], None, None, None) is not None
+        built = plan._build_streaming_plan(plan.segments[0], None, None, None)
+        assert built is not None
+        assert built.post_vf_filters == []
 
 
 class TestPostOpsGuard:
@@ -1094,9 +1101,9 @@ class TestPostOpsGuard:
             plan.run(context={"transcription": tx})
 
     def test_multi_segment_post_op_without_requires_is_allowed(self):
-        plan = self._plan(2, [{"op": "reverse"}])
+        plan = self._plan(2, [{"op": "vignette"}])
         tx = _make_transcription([(1.0, 2.0, "hello")])
-        # reverse has no `requires`; the transcription is irrelevant to it.
+        # vignette has no `requires`; the transcription is irrelevant to it.
         plan.validate_with_metadata(self._META, context={"transcription": tx})
 
     def test_single_segment_post_op_requiring_context_is_allowed(self):
@@ -1110,10 +1117,10 @@ class TestPostOpsGuard:
 
 
 class TestMetadataChain:
-    def test_reverse_preserves_metadata(self):
+    def test_shape_preserving_chain_preserves_metadata(self):
         plan = {
-            "segments": [_segment(start=0.0, end=3.0, operations=[{"op": "reverse"}])],
-            "post_operations": [{"op": "reverse"}],
+            "segments": [_segment(start=0.0, end=3.0, operations=[{"op": "vignette"}])],
+            "post_operations": [{"op": "vignette"}],
         }
         source_meta = VideoMetadata(height=500, width=800, fps=24, frame_count=240, total_seconds=10.0)
         meta = VideoEdit.from_dict(plan).validate_with_metadata(source_meta)

--- a/src/videopython/ai/transforms.py
+++ b/src/videopython/ai/transforms.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import logging
+import tempfile
+import uuid
+from collections.abc import Iterable
+from pathlib import Path
 from typing import ClassVar, Literal
 
-import cv2
 import numpy as np
 from pydantic import Field
 from tqdm import tqdm
 
 from videopython.ai.understanding.faces import FaceTracker
 from videopython.base._dimensions import floor_to_even
-from videopython.base.video import Video, VideoMetadata
-from videopython.editing.operation import OpCategory, Operation
+from videopython.base.video import FrameIterator, Video, VideoMetadata
+from videopython.editing._ass import escape_filter_value
+from videopython.editing.operation import FilterCtx, OpCategory, Operation
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +33,19 @@ class FaceTrackingCrop(Operation):
     Useful for creating vertical (9:16) content from horizontal (16:9) video
     by tracking the speaker's face and keeping it framed.
 
-    Supports GPU acceleration for faster processing with optional frame sampling
-    and simple cinematographic framing rules (headroom / thirds) plus optional
-    movement speed clamping.
+    The crop window has a fixed size -- the largest ``target_aspect`` box
+    that fits the frame (also the output size, so no resampling happens) --
+    and its position follows the smoothed face track. On the streaming path
+    the detection pass runs at plan-compile time over a bounded decode of
+    exactly the frames the filter will see, and the track compiles to a
+    per-frame ``crop`` position command file (ffmpeg ``sendcmd``): zero
+    per-frame Python at render time.
     """
 
     op: Literal["face_crop"] = "face_crop"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
+    streamable: ClassVar[bool] = True
+    compiles_from_source: ClassVar[bool] = True
 
     target_aspect: tuple[int, int] = Field((9, 16), description="Output aspect ratio as (width, height).")
     face_selection: Literal["largest", "centered", "index"] = Field(
@@ -58,7 +68,11 @@ class FaceTrackingCrop(Operation):
     smoothing: float = Field(0.8, ge=0, le=1, description="Position smoothing factor (0-1, higher = smoother).")
     max_speed: float | None = Field(None, gt=0, description="Optional max camera movement per frame (normalized).")
     fallback: Literal["center", "last_position", "full_frame"] = Field(
-        "last_position", description="Behavior when no face detected."
+        "last_position",
+        description=(
+            'Behavior when no face detected. "center" and "full_frame" both center the crop '
+            '("full_frame" kept for plan compatibility); "last_position" holds the last tracked crop.'
+        ),
     )
     detection_interval: int = Field(3, ge=1, description="Frames between face detections.")
     backend: Literal["cpu", "gpu", "auto"] = Field("auto", description='Detection backend - "cpu", "gpu", or "auto".')
@@ -77,13 +91,12 @@ class FaceTrackingCrop(Operation):
         return (face_cx, face_cy - self.headroom)
 
     def _resolved_output_dims(self, w: int, h: int) -> tuple[int, int]:
-        """Output ``(width, height)`` after the crop + resize.
+        """Output ``(width, height)`` -- the fixed crop-window size.
 
-        Every frame is resized to this size regardless of the per-frame face
-        position, so it is a pure function of the input dimensions and
-        ``target_aspect``. Single source of truth shared by :meth:`apply` and
-        :meth:`predict_metadata` (mirrors ``Resize._resolve_dims`` /
-        ``Crop._resolve_box``), so the dry-run cannot disagree with the render.
+        The largest ``target_aspect`` box that fits the frame, even-floored.
+        A pure function of the input dimensions, shared by :meth:`apply`,
+        :meth:`predict_metadata`, and :meth:`to_ffmpeg_filter`, so the
+        dry-run cannot disagree with the render.
         """
         target_ratio = self.target_aspect[0] / self.target_aspect[1]
         if target_ratio < w / h:
@@ -109,44 +122,20 @@ class FaceTrackingCrop(Operation):
         scale = self.max_speed / distance
         return (current[0] + dx * scale, current[1] + dy * scale)
 
-    def _calculate_crop_region(
+    def _track_crop_positions(
         self,
-        face_cx: float,
-        face_cy: float,
-        face_w: float,
-        face_h: float,
+        frames: Iterable[np.ndarray],
         frame_w: int,
         frame_h: int,
-        center_position: tuple[float, float] | None = None,
-    ) -> tuple[int, int, int, int]:
-        target_ratio = self.target_aspect[0] / self.target_aspect[1]
-        frame_ratio = frame_w / frame_h
+    ) -> list[tuple[int, int]]:
+        """Per-frame crop top-left positions for a fixed-size crop window.
 
-        if target_ratio < frame_ratio:
-            crop_h = floor_to_even(frame_h)
-            crop_w = floor_to_even(int(crop_h * target_ratio))
-        else:
-            crop_w = floor_to_even(frame_w)
-            crop_h = floor_to_even(int(crop_w / target_ratio))
-
-        min_face_dim = max(face_w * frame_w, face_h * frame_h)
-        min_crop_dim = min_face_dim * (1 + 2 * self.padding)
-        if crop_w < min_crop_dim * target_ratio:
-            crop_w = floor_to_even(min(int(min_crop_dim * target_ratio), frame_w))
-            crop_h = floor_to_even(min(int(crop_w / target_ratio), frame_h))
-
-        if center_position is None:
-            center_position = self._apply_framing_offset(face_cx, face_cy, face_h)
-
-        center_x = center_position[0] * frame_w
-        center_y = center_position[1] * frame_h
-        x = int(center_x - crop_w / 2)
-        y = int(center_y - crop_h / 2)
-        x = max(0, min(x, frame_w - crop_w))
-        y = max(0, min(y, frame_h - crop_h))
-        return (x, y, crop_w, crop_h)
-
-    def apply(self, video: Video) -> Video:
+        The single source of the tracking math (detection cadence, EMA
+        smoothing, framing offset, speed clamp, frame clamping), shared by
+        the eager :meth:`apply` and the compile-time detection pass so the
+        two paths cannot drift.
+        """
+        out_w, out_h = self._resolved_output_dims(frame_w, frame_h)
         tracker = FaceTracker(
             selection_strategy=self.face_selection,
             face_index=self.face_index,
@@ -155,16 +144,31 @@ class FaceTrackingCrop(Operation):
             backend=self.backend,
             sample_rate=self.sample_rate,
         )
+        default = ((frame_w - out_w) // 2, (frame_h - out_h) // 2)
+        last = default
+        current_position = (0.5, 0.5)
+        positions: list[tuple[int, int]] = []
+        for i, frame in enumerate(frames):
+            face_info = tracker.detect_and_track(frame, i)
+            if face_info:
+                cx, cy, _fw, fh = face_info
+                target = self._apply_framing_offset(cx, cy, fh)
+                current_position = self._clamp_speed(current_position, target)
+                x = int(current_position[0] * frame_w - out_w / 2)
+                y = int(current_position[1] * frame_h - out_h / 2)
+                x = max(0, min(x, frame_w - out_w))
+                y = max(0, min(y, frame_h - out_h))
+                last = (x, y)
+                positions.append((x, y))
+            elif self.fallback == "last_position":
+                positions.append(last)
+            else:  # "center" / "full_frame" (the latter kept for plan compat)
+                positions.append(default)
+        return positions
 
+    def apply(self, video: Video) -> Video:
         h, w = video.frame_shape[:2]
         out_w, out_h = self._resolved_output_dims(w, h)
-
-        default_x = (w - out_w) // 2
-        default_y = (h - out_h) // 2
-        last_crop = (default_x, default_y, out_w, out_h)
-        current_position = (0.5, 0.5)
-
-        framing_label = self.framing_rule if self.framing_rule != "offset" else "legacy-offset"
         logger.info(
             "Face tracking crop: %dx%d -> %dx%d (%d:%d, framing=%s)",
             w,
@@ -173,33 +177,55 @@ class FaceTrackingCrop(Operation):
             out_h,
             self.target_aspect[0],
             self.target_aspect[1],
-            framing_label,
+            self.framing_rule,
         )
-
-        new_frames = []
-        for i in tqdm(range(len(video.frames)), desc="Face tracking crop"):
-            frame = video.frames[i]
-            face_info = tracker.detect_and_track(frame, i)
-
-            if face_info:
-                cx, cy, fw, fh = face_info
-                target_position = self._apply_framing_offset(cx, cy, fh)
-                current_position = self._clamp_speed(current_position, target_position)
-                crop = self._calculate_crop_region(cx, cy, fw, fh, w, h, center_position=current_position)
-                last_crop = crop
-            else:
-                if self.fallback == "center":
-                    crop = (default_x, default_y, out_w, out_h)
-                elif self.fallback == "last_position":
-                    crop = last_crop
-                else:  # full_frame
-                    crop = (0, 0, w, h)
-
-            x, y, cw, ch = crop
-            cropped = frame[y : y + ch, x : x + cw]
-            if cropped.shape[1] != out_w or cropped.shape[0] != out_h:
-                cropped = cv2.resize(cropped, (out_w, out_h), interpolation=cv2.INTER_AREA)
-            new_frames.append(cropped)
-
-        video.frames = np.array(new_frames, dtype=np.uint8)
+        positions = self._track_crop_positions(tqdm(video.frames, desc="Face tracking crop"), w, h)
+        video.frames = np.stack([video.frames[i][y : y + out_h, x : x + out_w] for i, (x, y) in enumerate(positions)])
         return video
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the face track to a per-frame ``crop`` position command file.
+
+        Runs the detection pass at plan-compile time over a bounded decode of
+        the segment (through the same decode-stage filter prefix the render
+        will use, so the detector sees identical frames), then emits one
+        ``sendcmd`` interval per frame driving a fixed-size ``crop``. Returns
+        ``None`` when the input frames are not reproducible at compile time
+        (``decode_filters is None`` -- the op sits behind per-frame Python
+        effects) or the source is unknown.
+        """
+        if ctx.source_path is None or ctx.decode_filters is None or ctx.frame_count <= 0:
+            return None
+        out_w, out_h = self._resolved_output_dims(ctx.width, ctx.height)
+
+        with FrameIterator(
+            ctx.source_path,
+            start_second=ctx.start_second,
+            end_second=ctx.end_second,
+            vf_filters=list(ctx.decode_filters),
+            output_width=ctx.width,
+            output_height=ctx.height,
+        ) as decoder:
+            frames = (frame for _, frame in decoder)
+            positions = self._track_crop_positions(
+                tqdm(frames, desc="Face tracking (compile)", total=ctx.frame_count), ctx.width, ctx.height
+            )
+        if not positions:
+            return None
+
+        label = f"fc{uuid.uuid4().hex[:8]}"
+        lines = []
+        for i, (x, y) in enumerate(positions):
+            t0 = i / ctx.fps
+            t1 = (i + 1) / ctx.fps
+            lines.append(f"{t0:.6f}-{t1:.6f} crop@{label} x {x}, crop@{label} y {y};")
+        tmp = tempfile.NamedTemporaryFile("w", suffix=".cmd", delete=False, encoding="utf-8")
+        try:
+            tmp.write("\n".join(lines) + "\n")
+        finally:
+            tmp.close()
+        cmd_path = Path(tmp.name)
+        ctx.owned_files.append(cmd_path)
+
+        x0, y0 = positions[0]
+        return f"sendcmd=f={escape_filter_value(str(cmd_path))},crop@{label}=w={out_w}:h={out_h}:x={x0}:y={y0}"

--- a/src/videopython/base/exceptions.py
+++ b/src/videopython/base/exceptions.py
@@ -92,7 +92,7 @@ class PlanErrorCode(str, Enum):
     UNKNOWN_OP = "unknown_op"
     CONCAT_MISMATCH = "concat_mismatch"
     POST_OP_REQUIRES_CONTEXT = "post_op_requires_context"
-    # Streaming strictness (opt-in via strict_streaming).
+    # Streaming: unstreamable op at its plan position (always reported).
     STREAMING_FALLBACK = "streaming_fallback"
 
 
@@ -103,7 +103,7 @@ class PlanError:
     ``location`` is a path into the plan (e.g. ``'segments[1].operations[0]'``);
     the remaining fields are populated when meaningful for the ``code``.
     ``detail`` carries a short human-readable cause when the code alone is not
-    actionable (e.g. *why* an op forces the eager fallback) -- prose meant for
+    actionable (e.g. *why* an op cannot stream at its plan position) -- prose meant for
     LLM refine-loop feedback, not for branching.
     """
 

--- a/src/videopython/base/video.py
+++ b/src/videopython/base/video.py
@@ -234,11 +234,15 @@ class FrameIterator:
         if self.start_second > 0:
             cmd.extend(["-ss", str(self.start_second)])
 
-        cmd.extend(["-i", str(self.path)])
-
+        # Input-side -t: trim the SOURCE segment before the filter chain. As
+        # an output option it would instead cap the post-filter duration,
+        # silently truncating duration-extending filters (slow-motion setpts,
+        # freeze-frame loop).
         if self.end_second is not None:
             duration = self.end_second - self.start_second
             cmd.extend(["-t", str(duration)])
+
+        cmd.extend(["-i", str(self.path)])
 
         if self._vf_filters:
             cmd.extend(["-vf", ",".join(self._vf_filters)])

--- a/src/videopython/editing/__init__.py
+++ b/src/videopython/editing/__init__.py
@@ -33,7 +33,6 @@ from .transforms import (
     FreezeFrame,
     ResampleFPS,
     Resize,
-    Reverse,
     SilenceRemoval,
     SpeedChange,
 )
@@ -54,7 +53,6 @@ __all__ = [
     "Crop",
     "CropMode",
     "SpeedChange",
-    "Reverse",
     "FreezeFrame",
     "SilenceRemoval",
     # Effects

--- a/src/videopython/editing/effects.py
+++ b/src/videopython/editing/effects.py
@@ -429,6 +429,7 @@ class Fade(Effect):
 
     op: Literal["fade"] = "fade"
     streamable: ClassVar[bool] = True
+    audio_coupled: ClassVar[bool] = True
 
     mode: Literal["in", "out", "in_out"] = Field(
         description=('"in" fades from black at the start, "out" fades to black at the end, "in_out" does both.'),
@@ -513,6 +514,7 @@ class VolumeAdjust(Effect):
 
     op: Literal["volume_adjust"] = "volume_adjust"
     streamable: ClassVar[bool] = True
+    audio_coupled: ClassVar[bool] = True
 
     volume: float = Field(
         1.0,

--- a/src/videopython/editing/operation.py
+++ b/src/videopython/editing/operation.py
@@ -41,6 +41,7 @@ from pydantic import BaseModel, ConfigDict, Discriminator, Field, TypeAdapter
 from tqdm import tqdm
 
 if TYPE_CHECKING:
+    from videopython.audio import Audio
     from videopython.base.video import Video, VideoMetadata
 
 __all__ = [
@@ -102,6 +103,12 @@ class BoundedTimeField(NamedTuple):
 class FilterCtx:
     """Current pipeline state (post-prior-ops) when compiling to ffmpeg.
 
+    ``frame_count`` is the number of frames entering the filter at this chain
+    position (the plan builder folds ``predict_metadata`` through the chain),
+    so duration-aware compilations (a speed ramp's time-warp expression, a
+    freeze's frame indices) can be exact. ``0`` when unknown -- compilations
+    that need it must return ``None`` (no filter compilation) in that case.
+
     ``context`` carries the resolved, segment-local runtime context (the same
     re-based values ``streaming_init`` receives) so a context-consuming op can
     compile itself into the filter chain (e.g. ``add_subtitles`` consuming the
@@ -110,13 +117,26 @@ class FilterCtx:
     ``owned_files`` collects temp files a compilation creates (the ``.ass``
     file a ``subtitles=`` entry references); the plan runner deletes them once
     streaming finishes or the plan is abandoned.
+
+    ``source_path``/``start_second``/``end_second`` locate the segment on
+    disk, and ``decode_filters`` is the decode-stage filter prefix ahead of
+    this op -- together they let a compilation run its own bounded decode
+    pass over exactly the frames the filter will see (``face_crop``'s
+    detection). ``decode_filters`` is ``None`` when those frames are not
+    reproducible at compile time (the op sits at the encode stage, behind
+    per-frame Python effects); such compilations must return ``None``.
     """
 
     width: int
     height: int
     fps: float
+    frame_count: int = 0
     context: dict[str, Any] = field(default_factory=dict)
     owned_files: list[Path] = field(default_factory=list)
+    source_path: Path | None = None
+    start_second: float = 0.0
+    end_second: float | None = None
+    decode_filters: tuple[str, ...] | None = ()
 
 
 LLM_HIDDEN_KEY = "llm_hidden"
@@ -213,7 +233,7 @@ class Operation(BaseModel):
     ``streamable``, and ``requires`` ClassVars.
 
     The default ``apply`` raises ``NotImplementedError``; ``predict_metadata``
-    defaults to identity; ``to_ffmpeg_filter`` defaults to ``None`` (eager).
+    defaults to identity; ``to_ffmpeg_filter`` defaults to ``None`` (no filter compilation).
     """
 
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
@@ -223,6 +243,22 @@ class Operation(BaseModel):
     category: ClassVar[OpCategory] = OpCategory.SPECIAL
     streamable: ClassVar[bool] = False
     requires: ClassVar[tuple[str, ...]] = ()
+    compiles_from_source: ClassVar[bool] = False
+    """Whether the op's filter compile decodes the source itself (face_crop's
+    detection pass). Such ops cannot sit at the encode stage -- the frames
+    behind per-frame Python effects are not reproducible at compile time --
+    so both the plan builder and the streamability report reject them as
+    UNSTREAMABLE there."""
+    changes_duration: ClassVar[bool] = False
+    """Whether the op's output duration differs from its input (speed, freeze).
+
+    The streaming plan builder folds ``predict_metadata`` through the chain
+    either way; this flag additionally gates time-based *context*: a
+    context-consuming op scheduled after a duration-changing transform would
+    receive timestamps on the wrong timeline, so such plans are rejected as
+    UNSTREAMABLE until context re-mapping exists. The streamability report
+    mirrors the same rule.
+    """
     llm_exposed: ClassVar[bool] = True
     time_fields: ClassVar[tuple[BoundedTimeField, ...]] = ()
     """Time-valued (seconds) fields :meth:`VideoEdit.repair` may clamp into range.
@@ -370,12 +406,28 @@ class Operation(BaseModel):
         return meta
 
     def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile to an ffmpeg ``-vf`` filter expression, or ``None`` for eager.
+        """Compile to an ffmpeg ``-vf`` filter expression, or ``None`` for no filter compilation.
 
         Streamable transforms override this. Effects use ``process_frame``
         instead -- they do not go through ffmpeg filters.
         """
         return None
+
+    def transform_audio(self, audio: Audio, output_duration: float, fps: float, **context: Any) -> Audio:
+        """The op's audio-domain twin for the streaming path.
+
+        Video streams through the ffmpeg filter chain, but segment audio is
+        processed in memory (``_load_segment_audio``); a duration-changing
+        transform must therefore transform the audio to match
+        (``speed_change`` time-stretches, ``freeze_frame`` inserts silence,
+        ``silence_removal`` cuts the same windows). ``output_duration`` is
+        the predicted post-op duration the result must fit; ``context``
+        carries the op's resolved ``requires`` values (segment-local), for
+        twins that need them. Identity by default -- the runner only replays
+        ops that override this. The eager ``apply`` should delegate its audio
+        handling here so the two paths cannot drift.
+        """
+        return audio
 
 
 class Effect(Operation):
@@ -398,6 +450,14 @@ class Effect(Operation):
     """
 
     category: ClassVar[OpCategory] = OpCategory.EFFECT
+    audio_coupled: ClassVar[bool] = False
+    """Whether the effect mutates audio alongside pixels (``_apply_audio``).
+
+    Audio-coupled effects cannot fold as post-operations across segment
+    boundaries: each segment's audio is processed independently, so a gain
+    envelope spanning a concat boundary would restart mid-ramp. The plan
+    builder and the streamability report both consult this.
+    """
 
     window: TimeRange | None = Field(
         None,

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -33,21 +33,21 @@ logger = logging.getLogger(__name__)
 
 
 class StreamingClass(str, Enum):
-    """How an op executes on the streaming path -- its memory class.
+    """How an op executes on the streaming engine -- its memory class.
 
-    ``FILTER`` and ``FRAME_EFFECT`` stream in O(1) memory w.r.t. video length;
-    ``EAGER`` means the op has no streaming strategy (yet), which forces the
-    *whole plan* onto the eager in-memory path. Future classes from the
-    streaming-first contract (frame mapper, cut list, bounded buffer) will be
-    added here as they are implemented.
+    ``FILTER`` and ``FRAME_EFFECT`` stream in O(1) memory w.r.t. video
+    length. ``UNSTREAMABLE`` means the op (or its plan position) has no
+    streaming strategy; since streaming is the only engine, such plans are
+    rejected with structured ``STREAMING_FALLBACK`` errors instead of run.
     """
 
     FILTER = "filter"
-    """Compiles to an ffmpeg ``-vf`` filter applied at decode time."""
+    """Compiles to an ffmpeg filter -- the decode chain, or the encode chain
+    when ordered after frame effects."""
     FRAME_EFFECT = "frame_effect"
     """Shape-preserving per-frame Python (``streaming_init`` + ``process_frame``)."""
-    EAGER = "eager"
-    """No streaming strategy; forces the whole-plan eager fallback."""
+    UNSTREAMABLE = "unstreamable"
+    """No streaming strategy at this plan position; the plan is rejected."""
 
 
 @dataclass(frozen=True)
@@ -60,11 +60,11 @@ class OpStreamability:
     """The op discriminator, e.g. ``'add_subtitles'``."""
     streaming_class: StreamingClass
     reason: str | None = None
-    """Why the op forces the eager fallback; ``None`` unless ``EAGER``."""
+    """Why the op cannot stream; ``None`` unless ``UNSTREAMABLE``."""
 
     @property
     def streams(self) -> bool:
-        return self.streaming_class is not StreamingClass.EAGER
+        return self.streaming_class is not StreamingClass.UNSTREAMABLE
 
 
 @dataclass(frozen=True)
@@ -74,20 +74,20 @@ class StreamabilityReport:
     Built by :meth:`VideoEdit.streamability` from the plan structure alone --
     no source files, metadata, or runtime context needed -- so a consumer can
     gate job admission on it before downloading anything. ``streamable`` is
-    the plan-level verdict: one ``EAGER`` op forces the *entire*
-    ``run_to_file`` onto the eager in-memory path.
+    the plan-level verdict: one ``UNSTREAMABLE`` op rejects the entire plan
+    (streaming is the only engine).
     """
 
     entries: tuple[OpStreamability, ...]
 
     @property
     def streamable(self) -> bool:
-        """True when ``run_to_file`` will stream (no op forces the fallback)."""
+        """True when the plan runs (no op is unstreamable at its position)."""
         return all(e.streams for e in self.entries)
 
     @property
     def fallbacks(self) -> tuple[OpStreamability, ...]:
-        """The ops that force the eager fallback, in plan order."""
+        """The unstreamable ops, in plan order."""
         return tuple(e for e in self.entries if not e.streams)
 
     def errors(self) -> list[PlanError]:
@@ -120,12 +120,31 @@ def analyze_streamability(
     runtime context.
     """
     entries: list[OpStreamability] = []
+    segment_has_encode_stage: list[bool] = []
     for i, ops in enumerate(segment_operations):
         seen_effect = False
-        seen_encode_filter = False
+        seen_encode_stage = False
+        seen_duration_change = False
         for j, op in enumerate(ops):
             location = f"segments[{i}].operations[{j}]"
             if isinstance(op, Effect):
+                if op.streamable and op.requires and seen_duration_change:
+                    # The builder rejects context-consuming ops behind a
+                    # duration-changing transform: segment-local context is
+                    # not re-mapped through the time warp yet.
+                    entries.append(
+                        OpStreamability(
+                            location,
+                            op.op,
+                            StreamingClass.UNSTREAMABLE,
+                            reason=(
+                                "context-requiring op follows a duration-changing transform "
+                                "(speed_change/freeze_frame); time-based context is not re-mapped "
+                                "through the warp yet -- move the op before it to stream"
+                            ),
+                        )
+                    )
+                    continue
                 if op.streamable and op.compiles_to_filter:
                     # Filter-class effect (add_subtitles): joins the decode
                     # filter chain at this plan position -- or the encode
@@ -135,88 +154,101 @@ def analyze_streamability(
                     # builder mirrors this exactly.
                     entries.append(OpStreamability(location, op.op, StreamingClass.FILTER))
                     if seen_effect:
-                        seen_encode_filter = True
+                        seen_encode_stage = True
                     continue
                 if not op.streamable:
                     entries.append(
                         OpStreamability(
                             location,
                             op.op,
-                            StreamingClass.EAGER,
+                            StreamingClass.UNSTREAMABLE,
                             reason="effect has no streaming implementation (streamable=False)",
                         )
                     )
-                elif seen_encode_filter:
+                elif seen_encode_stage:
                     entries.append(
                         OpStreamability(
                             location,
                             op.op,
-                            StreamingClass.EAGER,
+                            StreamingClass.UNSTREAMABLE,
                             reason=(
-                                "frame effect follows burned-in subtitles (an encode-stage filter) in "
-                                "plan order; the filter runs after every frame effect, so plan order "
-                                "cannot be preserved -- move the effect before the subtitles to stream"
+                                "frame effect follows encode-stage filters (subtitles or transforms "
+                                "ordered after effects) in plan order; those filters run after every "
+                                "frame effect, so plan order cannot be preserved -- move the effect "
+                                "earlier to stream"
                             ),
                         )
                     )
                 else:
                     entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
                 seen_effect = True
-            elif op.requires:
+            elif op.requires and seen_duration_change:
                 entries.append(
                     OpStreamability(
                         location,
                         op.op,
-                        StreamingClass.EAGER,
+                        StreamingClass.UNSTREAMABLE,
                         reason=(
-                            f"transform requires runtime context {sorted(op.requires)} and has no "
-                            "streaming strategy yet -- an ffmpeg filter cannot consume runtime context"
+                            "context-requiring transform follows a duration-changing transform; "
+                            "time-based context is not re-mapped through the warp yet -- move it "
+                            "before the duration change to stream"
                         ),
                     )
                 )
-            elif seen_effect:
+            elif op.requires and not op.streamable:
                 entries.append(
                     OpStreamability(
                         location,
                         op.op,
-                        StreamingClass.EAGER,
+                        StreamingClass.UNSTREAMABLE,
                         reason=(
-                            "transform follows an effect in plan order; ffmpeg filters run at decode "
-                            "time, before every scheduled effect, so plan order cannot be preserved -- "
-                            "move the transform before the effect to stream"
+                            f"transform requires runtime context {sorted(op.requires)} and has no streaming strategy"
+                        ),
+                    )
+                )
+            elif op.streamable and op.compiles_from_source and (seen_effect or seen_encode_stage):
+                entries.append(
+                    OpStreamability(
+                        location,
+                        op.op,
+                        StreamingClass.UNSTREAMABLE,
+                        reason=(
+                            "the op's compile-time detection pass cannot reproduce frames behind "
+                            "per-frame Python effects -- move it before the effects to stream"
                         ),
                     )
                 )
             elif op.streamable:
+                # Transforms compile to filters at any plan position: the
+                # decode chain normally, the encode chain (after every
+                # process_frame) when frame effects precede them.
                 entries.append(OpStreamability(location, op.op, StreamingClass.FILTER))
+                if seen_effect or seen_encode_stage:
+                    seen_encode_stage = True
+                if op.changes_duration:
+                    seen_duration_change = True
             else:
                 entries.append(
                     OpStreamability(
                         location,
                         op.op,
-                        StreamingClass.EAGER,
+                        StreamingClass.UNSTREAMABLE,
                         reason="transform has no ffmpeg filter compilation",
                     )
                 )
 
+        segment_has_encode_stage.append(seen_encode_stage)
+
     multi_segment = len(segment_operations) > 1
+    any_encode_stage = any(segment_has_encode_stage)
     for j, op in enumerate(post_operations):
         location = f"post_operations[{j}]"
-        if multi_segment:
+        if op.requires:
             entries.append(
                 OpStreamability(
                     location,
                     op.op,
-                    StreamingClass.EAGER,
-                    reason="post-operations on a multi-segment plan cannot stream yet (no cross-segment schedule)",
-                )
-            )
-        elif op.requires:
-            entries.append(
-                OpStreamability(
-                    location,
-                    op.op,
-                    StreamingClass.EAGER,
+                    StreamingClass.UNSTREAMABLE,
                     reason=(
                         f"post-operation requires runtime context {sorted(op.requires)}, which is not "
                         "re-based onto the assembled timeline -- move it into the segment to stream"
@@ -228,21 +260,50 @@ def analyze_streamability(
                 OpStreamability(
                     location,
                     op.op,
-                    StreamingClass.EAGER,
+                    StreamingClass.UNSTREAMABLE,
                     reason=(
                         "filter-class post-operations cannot fold into the segment schedule -- "
                         "move the op into the segment to stream"
                     ),
                 )
             )
+        elif isinstance(op, Effect) and op.streamable and any_encode_stage:
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.UNSTREAMABLE,
+                    reason=(
+                        "post-operations fold into the per-segment frame-effect schedules, which run "
+                        "before a segment's encode-stage filters -- move the op into the segments "
+                        "(before the encode-stage ops) to stream"
+                    ),
+                )
+            )
+        elif isinstance(op, Effect) and op.streamable and op.audio_coupled and multi_segment:
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.UNSTREAMABLE,
+                    reason=(
+                        "audio-coupled post-operations (fade/volume_adjust) cannot fold across a "
+                        "multi-segment concat: each segment's audio is processed independently, so "
+                        "the gain envelope would restart at every boundary -- apply it per segment "
+                        "or use a single-segment plan"
+                    ),
+                )
+            )
         elif isinstance(op, Effect) and op.streamable:
+            # Folds into the per-segment schedules with globally-rebased
+            # frame offsets (multi-segment included since 0.42.0).
             entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
         elif isinstance(op, Effect):
             entries.append(
                 OpStreamability(
                     location,
                     op.op,
-                    StreamingClass.EAGER,
+                    StreamingClass.UNSTREAMABLE,
                     reason="effect has no streaming implementation (streamable=False)",
                 )
             )
@@ -251,7 +312,7 @@ def analyze_streamability(
                 OpStreamability(
                     location,
                     op.op,
-                    StreamingClass.EAGER,
+                    StreamingClass.UNSTREAMABLE,
                     reason="transforms cannot stream as post-operations -- move the transform into the segment",
                 )
             )
@@ -267,12 +328,22 @@ class EffectScheduleEntry:
     re-based onto the segment-local timeline by the plan builder), forwarded
     as keyword arguments to ``streaming_init``. Empty for context-free
     effects.
+
+    For a post-operation folded across a multi-segment plan, the effect's
+    window lives on the assembled (concatenated) timeline: ``index_offset``
+    is the number of window frames consumed by previous segments (so
+    ``process_frame`` indices continue across the concat boundary) and
+    ``total_effect_frames`` is the global window length ``streaming_init``
+    must size envelopes to. Defaults describe the ordinary segment-local
+    case.
     """
 
     effect: Effect
     start_frame: int
     end_frame: int  # exclusive
     context: dict[str, Any] = field(default_factory=dict)
+    index_offset: int = 0
+    total_effect_frames: int | None = None
 
 
 @dataclass
@@ -299,6 +370,28 @@ class StreamingSegmentPlan:
     effect_schedule: list[EffectScheduleEntry] = field(default_factory=list)
     post_vf_filters: list[str] = field(default_factory=list)
     owned_temp_files: list[Path] = field(default_factory=list)
+    final_fps: float = 0.0
+    """Frame rate after the encode-stage filters (== ``output_fps`` unless a
+    ``post_vf`` transform resamples). ``0`` means "same as output_fps"."""
+    final_width: int = 0
+    final_height: int = 0
+    """Dimensions after the encode-stage filters; ``0`` means "same as
+    output_width/output_height"."""
+    output_total_frames: int = 0
+    """Predicted output frame count, folded through every compiled transform.
+
+    Authoritative for effect scheduling, envelope sizing, and progress --
+    duration-changing filters (speed, freeze) make ``(end_second -
+    start_second) * output_fps`` wrong. ``0`` means "no transform changed
+    duration; derive from the cut".
+    """
+    audio_ops: list[tuple[Operation, float, float, dict[str, Any]]] = field(default_factory=list)
+    """Transforms with an audio-domain twin: ``(op, predicted post-op
+    duration, fps at the op's chain position, resolved requires-context)``;
+    ``_load_segment_audio`` replays them in plan order."""
+    post_audio_ops: list[tuple[Operation, float, float, dict[str, Any]]] = field(default_factory=list)
+    """Encode-stage audio twins (transforms ordered after the frame
+    effects), replayed after the effect envelopes."""
 
 
 class FrameEncoder:
@@ -441,15 +534,22 @@ def stream_segment(
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Estimate total frames for progress and streaming_init
-    duration = plan.end_second - plan.start_second
-    total_frames = round(duration * plan.output_fps)
+    # Total output frames for progress, streaming_init sizing, and the
+    # open-ended schedule logic. The plan's folded prediction is
+    # authoritative (duration-changing filters break the cut-length
+    # derivation); the derivation remains as a fallback for hand-built plans.
+    total_frames = plan.output_total_frames
+    if total_frames <= 0:
+        duration = plan.end_second - plan.start_second
+        total_frames = round(duration * plan.output_fps)
 
     # Initialize effects for streaming. Runs before this segment's decode,
     # so a context-requiring effect with missing context fails before any
     # frame work on this segment.
     for entry in plan.effect_schedule:
-        n_effect_frames = entry.end_frame - entry.start_frame
+        n_effect_frames = (
+            entry.total_effect_frames if entry.total_effect_frames is not None else entry.end_frame - entry.start_frame
+        )
         entry.effect.streaming_init(
             n_effect_frames, plan.output_fps, plan.output_width, plan.output_height, **entry.context
         )
@@ -496,7 +596,7 @@ def stream_segment(
                         # sized to the estimate stay in bounds.
                         open_ended = entry.end_frame >= total_frames
                         if entry.start_frame <= frame_count and (frame_count < entry.end_frame or open_ended):
-                            local_index = min(frame_count, entry.end_frame - 1) - entry.start_frame
+                            local_index = entry.index_offset + min(frame_count, entry.end_frame - 1) - entry.start_frame
                             frame = entry.effect.process_frame(frame, local_index)
 
                     encoder.write_frame(frame)
@@ -510,6 +610,94 @@ def stream_segment(
     finally:
         if temp_audio_file is not None:
             Path(temp_audio_file.name).unlink(missing_ok=True)
+
+
+def stream_segment_to_frames(plan: StreamingSegmentPlan) -> np.ndarray:
+    """Run a segment's streaming pipeline into memory instead of a file.
+
+    The same scheduler ``stream_segment`` uses -- decode through the plan's
+    vf chain, per-frame effects in plan order, encode-stage filters via a
+    lossless rawvideo pass -- collecting RGB frames instead of encoding.
+    This is what makes ``VideoEdit.run`` a view over the streaming engine
+    rather than a second execution path.
+    """
+    total_frames = plan.output_total_frames
+    if total_frames <= 0:
+        total_frames = round((plan.end_second - plan.start_second) * plan.output_fps)
+
+    for entry in plan.effect_schedule:
+        n_effect_frames = (
+            entry.total_effect_frames if entry.total_effect_frames is not None else entry.end_frame - entry.start_frame
+        )
+        entry.effect.streaming_init(
+            n_effect_frames, plan.output_fps, plan.output_width, plan.output_height, **entry.context
+        )
+
+    frames: list[np.ndarray] = []
+    with FrameIterator(
+        plan.source_path,
+        start_second=plan.start_second,
+        end_second=plan.end_second,
+        vf_filters=plan.vf_filters,
+        output_fps=plan.output_fps,
+        output_width=plan.output_width,
+        output_height=plan.output_height,
+    ) as decoder:
+        frame_count = 0
+        for _, frame in tqdm(decoder, desc="Streaming (in-memory)", total=total_frames):
+            for entry in plan.effect_schedule:
+                open_ended = entry.end_frame >= total_frames
+                if entry.start_frame <= frame_count and (frame_count < entry.end_frame or open_ended):
+                    local_index = entry.index_offset + min(frame_count, entry.end_frame - 1) - entry.start_frame
+                    frame = entry.effect.process_frame(frame, local_index)
+            frames.append(frame)
+            frame_count += 1
+
+    stacked = np.stack(frames) if frames else np.empty((0, plan.output_height, plan.output_width, 3), dtype=np.uint8)
+    if not plan.post_vf_filters:
+        return stacked
+
+    # Encode-stage filters: a lossless rawvideo->rawvideo pass, the in-memory
+    # twin of FrameEncoder's -vf.
+    n, height, width = stacked.shape[:3]
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pixel_format",
+        "rgb24",
+        "-video_size",
+        f"{width}x{height}",
+        "-framerate",
+        str(plan.output_fps),
+        "-i",
+        "pipe:0",
+        "-vf",
+        ",".join(plan.post_vf_filters),
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "pipe:1",
+    ]
+    out = _ffmpeg.run(cmd, stdin=stacked.tobytes())
+    return out_frames_reshape(out, plan, n)
+
+
+def out_frames_reshape(raw: bytes, plan: StreamingSegmentPlan, n_in: int) -> np.ndarray:
+    """Reshape a rawvideo byte stream using the plan's final geometry.
+
+    Encode-stage transforms may change dims/fps; the builder records the
+    folded final geometry on the plan (``final_width``/``final_height``).
+    """
+    final_w = plan.final_width or plan.output_width
+    final_h = plan.final_height or plan.output_height
+    frame_size = final_w * final_h * 3
+    n_frames = len(raw) // frame_size
+    return np.frombuffer(raw, dtype=np.uint8)[: n_frames * frame_size].reshape(n_frames, final_h, final_w, 3).copy()
 
 
 def concat_files(segment_files: list[Path], output_path: Path) -> Path:

--- a/src/videopython/editing/transcription_overlay.py
+++ b/src/videopython/editing/transcription_overlay.py
@@ -8,8 +8,9 @@ and the resolved look are baked into an ASS document, and ffmpeg's
 * the streaming path emits one ``-vf`` entry -- decode-stage normally, or
   encode-stage when the op follows frame effects in plan order, so
   ``[fade, add_subtitles]`` keeps streaming in plan order;
-* the eager path (:meth:`TranscriptionOverlay.apply`, used by
-  ``VideoEdit.run``) pipes the in-memory frames through the same filter.
+* the direct per-op path (:meth:`TranscriptionOverlay.apply`) pipes its
+  in-memory frames through the same filter (``VideoEdit.run`` streams them
+  in through the same compiled ``-vf`` entry).
 
 Geometry is resolution-relative (``font_scale``/``region``) and libass wraps
 long cues within the box instead of failing, so there is no fit validation:
@@ -108,8 +109,8 @@ class TranscriptionOverlay(Effect):
     local timeline and delivered at plan-compile time through
     :class:`FilterCtx`; the op compiles to a libass ``subtitles=`` filter
     (:attr:`compiles_to_filter`), so subtitled edits run on the O(1)-memory
-    streaming path at native speed. The eager path pipes frames through the
-    same filter, so both paths share one pixel implementation.
+    streaming path at native speed. The direct per-op ``apply`` pipes frames
+    through the same filter, so both paths share one pixel implementation.
     """
 
     op: Literal["add_subtitles"] = "add_subtitles"

--- a/src/videopython/editing/transforms.py
+++ b/src/videopython/editing/transforms.py
@@ -7,7 +7,9 @@ See ``editing/operation.py`` for the ``Operation`` base.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
+import math
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
@@ -16,6 +18,7 @@ import numpy as np
 from pydantic import Field, model_validator
 from tqdm import tqdm
 
+from videopython.audio import Audio
 from videopython.base._dimensions import floor_to_even, round_to_even
 from videopython.base.exceptions import PlanError, PlanErrorCode, PlanValidationError
 from videopython.base.video import Video
@@ -40,7 +43,6 @@ __all__ = [
     "Crop",
     "CropMode",
     "SpeedChange",
-    "Reverse",
     "FreezeFrame",
     "SilenceRemoval",
 ]
@@ -311,6 +313,8 @@ class SpeedChange(Operation):
 
     op: Literal["speed_change"] = "speed_change"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
+    streamable: ClassVar[bool] = True
+    changes_duration: ClassVar[bool] = True
 
     speed: float = Field(gt=0, description="Playback speed multiplier. 2.0 = twice as fast, 0.5 = half speed.")
     end_speed: float | None = Field(
@@ -326,6 +330,65 @@ class SpeedChange(Operation):
             return int(n_frames / self.speed)
         avg = (self.speed + self.end_speed) / 2
         return int(n_frames / avg)
+
+    @property
+    def _is_slow(self) -> bool:
+        return self.speed < 1.0 or (self.end_speed is not None and self.end_speed < 1.0)
+
+    def _eff_speed(self) -> float:
+        return self.speed if self.end_speed is None else (self.speed + self.end_speed) / 2
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile to a ``setpts`` retime plus a CFR resampler.
+
+        Constant speed: ``setpts=(PTS-STARTPTS)/k`` with a ``(k-1)/(2k)``-frame
+        forward-bias correction so the ``fps`` filter's tick rounding selects
+        the same nearest source frame a per-frame sampler would.
+
+        Ramp: the eager sampler varies speed linearly across the *source*
+        timeline and renormalizes so the output spans ``frame_count / avg``
+        frames; the closed form of that curve is
+        ``out(T) = D_out * ln(1 + (b-a)*T/(a*D_in)) / ln(b/a)``, evaluated
+        per frame by ``setpts`` in double precision.
+
+        With ``interpolate`` on a slowdown, the CFR resampler is the
+        ``framerate`` filter (blends adjacent frames) instead of ``fps``
+        (nearest), matching the eager path's frame blending in spirit -- the
+        blend weighting is libavfilter's, not pixel-identical.
+        """
+        k = self.speed
+        if self.end_speed is None or self.end_speed == self.speed:
+            # Forward-bias so the fps filter's tick rounding picks the same
+            # nearest source frame a per-frame sampler would. Speedups only:
+            # for slowdowns the slot rounding already centers, and a negative
+            # bias would retime head frames to negative PTS (dropped by the
+            # resampler, shorting the predicted count by ~1/(2k) frames).
+            bias = max(0.0, (k - 1) / (2 * k))
+            retime = f"setpts=(PTS-STARTPTS)/{k:.10g}+{bias:.10g}/(FR*TB)"
+        else:
+            if ctx.frame_count <= 0:
+                return None  # ramp needs the input duration; unknown -> not streamable
+            a, b = self.speed, self.end_speed
+            d_in = ctx.frame_count / ctx.fps
+            d_out = self._new_frame_count(ctx.frame_count) / ctx.fps
+            c_warp = (b - a) / (a * d_in)
+            c_norm = d_out / math.log(b / a)
+            retime = f"setpts='{c_norm:.10g}*log(1+{c_warp:.10g}*T)/TB'"
+        if self.interpolate and self._is_slow:
+            resample = f"framerate=fps={ctx.fps:.10g}"
+        else:
+            resample = f"fps={ctx.fps:.10g}"
+        return f"{retime},{resample}"
+
+    def transform_audio(self, audio: Audio, output_duration: float, fps: float, **_context: Any) -> Audio:
+        """Time-stretch by the (average) speed, then fit the predicted duration.
+
+        Ramps are approximated with a single constant stretch -- the same
+        approximation the eager path has always used, so the two paths agree.
+        """
+        if not audio.is_silent and self.adjust_audio:
+            audio = audio.time_stretch(self._eff_speed())
+        return audio.fit_to_duration(output_duration)
 
     def apply(self, video: Video) -> Video:
         n_frames = len(video.frames)
@@ -350,8 +413,7 @@ class SpeedChange(Operation):
             source_positions = np.interp(output_positions, cumulative_time, np.linspace(0, 1, num_samples))
             source_indices = source_positions * (n_frames - 1)
 
-        slow = self.speed < 1.0 or (self.end_speed is not None and self.end_speed < 1.0)
-        if self.interpolate and slow:
+        if self.interpolate and self._is_slow:
             new_frames = []
             for idx in tqdm(source_indices, desc="Interpolating frames"):
                 idx_low = int(idx)
@@ -368,13 +430,8 @@ class SpeedChange(Operation):
             video.frames = video.frames[indices]
 
         target_duration = len(video.frames) / video.fps
-        if video.audio is not None and not video.audio.is_silent:
-            if self.adjust_audio:
-                eff_speed = self.speed if self.end_speed is None else (self.speed + self.end_speed) / 2
-                video.audio = video.audio.time_stretch(eff_speed)
-            video.audio = video.audio.fit_to_duration(target_duration)
-        elif video.audio is not None:
-            video.audio = video.audio.fit_to_duration(target_duration)
+        if video.audio is not None:
+            video.audio = self.transform_audio(video.audio, target_duration, video.fps)
         return video
 
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
@@ -403,26 +460,13 @@ class SpeedChange(Operation):
         )
 
 
-class Reverse(Operation):
-    """Plays the video backwards, with optional audio reversal."""
-
-    op: Literal["reverse"] = "reverse"
-    category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-
-    reverse_audio: bool = Field(True, description="If true, reverse the audio track along with the video.")
-
-    def apply(self, video: Video) -> Video:
-        video.frames = video.frames[::-1].copy()
-        if self.reverse_audio and video.audio is not None:
-            video.audio.data = np.flip(video.audio.data, axis=0).copy()
-        return video
-
-
 class FreezeFrame(Operation):
     """Pauses video at a specific moment by holding a single frame."""
 
     op: Literal["freeze_frame"] = "freeze_frame"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
+    streamable: ClassVar[bool] = True
+    changes_duration: ClassVar[bool] = True
     # `timestamp` indexes a frame, so it must be strictly < the clip duration;
     # repair clamps an out-of-range value to the last frame.
     time_fields: ClassVar[tuple[BoundedTimeField, ...]] = (BoundedTimeField("timestamp", exclusive_end=True),)
@@ -438,7 +482,7 @@ class FreezeFrame(Operation):
         if self.timestamp >= video.total_seconds:
             raise ValueError(f"timestamp ({self.timestamp}) must be less than video duration ({video.total_seconds})")
 
-        frame_idx = round(self.timestamp * video.fps)
+        frame_idx = min(round(self.timestamp * video.fps), len(video.frames) - 1)
         freeze_count = round(self.duration * video.fps)
         frozen = np.tile(video.frames[frame_idx : frame_idx + 1], (freeze_count, 1, 1, 1))
 
@@ -453,29 +497,76 @@ class FreezeFrame(Operation):
 
         if video.audio is not None:
             target_duration = len(video.frames) / video.fps
-            sample_rate = video.audio.metadata.sample_rate
-            channels = video.audio.metadata.channels
-            silence_samples = round(self.duration * sample_rate)
-            silence_shape = (silence_samples, channels) if channels > 1 else (silence_samples,)
-            silence = np.zeros(silence_shape, dtype=np.float32)
-            timestamp_sample = round(self.timestamp * sample_rate)
-
-            if self.position == "after":
-                insert_sample = min(timestamp_sample + round(sample_rate / video.fps), len(video.audio.data))
-                video.audio.data = np.concatenate(
-                    [video.audio.data[:insert_sample], silence, video.audio.data[insert_sample:]], axis=0
-                )
-            elif self.position == "before":
-                video.audio.data = np.concatenate(
-                    [video.audio.data[:timestamp_sample], silence, video.audio.data[timestamp_sample:]], axis=0
-                )
-            else:
-                replace_end_sample = min(timestamp_sample + silence_samples, len(video.audio.data))
-                video.audio.data = np.concatenate(
-                    [video.audio.data[:timestamp_sample], silence, video.audio.data[replace_end_sample:]], axis=0
-                )
-            video.audio = video.audio.fit_to_duration(target_duration)
+            video.audio = self.transform_audio(video.audio, target_duration, video.fps)
         return video
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile to a linear ``loop``-based freeze chain.
+
+        Insert modes (``after``/``before``): ``loop`` duplicates the held
+        frame in place with continuous PTS -- the inserted copies are
+        identical to the boundary frame, so both modes compile to the same
+        chain. Replace mode stays linear too: ``loop`` adds the copies, a
+        ``select`` drops the originals they replace (shifted behind the loop
+        region), and ``setpts`` regenerates CFR timing. Needs the input
+        frame count (``ctx.frame_count``); unknown -> not streamable.
+
+        Raises the same out-of-range error as the eager path when
+        ``timestamp`` lies past the clip end -- at compile, before decode.
+        """
+        if ctx.frame_count <= 0:
+            return None
+        input_duration = ctx.frame_count / ctx.fps
+        if self.timestamp >= input_duration:
+            raise ValueError(f"timestamp ({self.timestamp}) must be less than video duration ({input_duration})")
+        frame_idx = min(round(self.timestamp * ctx.fps), ctx.frame_count - 1)
+        freeze_count = round(self.duration * ctx.fps)
+        if freeze_count == 0:
+            return "null"
+        # Every chain ends in its own CFR resampler: FrameIterator suppresses
+        # its trailing fps= whenever any element starts with "fps=" (e.g. a
+        # resample_fps op earlier in the plan), and without a resampler the
+        # select/loop output re-duplicates frames at the rawvideo pipe.
+        resample = f"fps={ctx.fps:.10g}"
+        if self.position in ("after", "before"):
+            return f"loop=loop={freeze_count}:size=1:start={frame_idx},setpts=N/FRAME_RATE/TB,{resample}"
+        # replace: hold N frames of frame_idx while dropping the originals
+        # they cover. `loop` adds N-1 copies (original + copies = N held);
+        # the replaced originals sit right behind the loop region.
+        replaced = min(freeze_count, ctx.frame_count - frame_idx)
+        chain = f"loop=loop={freeze_count - 1}:size=1:start={frame_idx}"
+        if replaced >= 2:
+            drop_from = frame_idx + freeze_count
+            drop_to = drop_from + replaced - 2
+            chain += f",select='not(between(n,{drop_from},{drop_to}))'"
+        return chain + f",setpts=N/FRAME_RATE/TB,{resample}"
+
+    def transform_audio(self, audio: Audio, output_duration: float, fps: float, **_context: Any) -> Audio:
+        """Insert the freeze's silence at the held position, then fit the duration."""
+        sample_rate = audio.metadata.sample_rate
+        channels = audio.metadata.channels
+        silence_samples = round(self.duration * sample_rate)
+        silence_shape = (silence_samples, channels) if channels > 1 else (silence_samples,)
+        silence = np.zeros(silence_shape, dtype=np.float32)
+        timestamp_sample = round(self.timestamp * sample_rate)
+
+        if self.position == "after":
+            insert_sample = min(timestamp_sample + round(sample_rate / fps), len(audio.data))
+            data = np.concatenate([audio.data[:insert_sample], silence, audio.data[insert_sample:]], axis=0)
+        elif self.position == "before":
+            data = np.concatenate([audio.data[:timestamp_sample], silence, audio.data[timestamp_sample:]], axis=0)
+        else:
+            replace_end_sample = min(timestamp_sample + silence_samples, len(audio.data))
+            data = np.concatenate([audio.data[:timestamp_sample], silence, audio.data[replace_end_sample:]], axis=0)
+        # Rebuild metadata from the new sample count: fit_to_duration trusts
+        # metadata.duration_seconds, so a raw .data mutation would leave it
+        # stale and make the fit pad the insertion a second time.
+        metadata = dataclasses.replace(
+            audio.metadata,
+            duration_seconds=data.shape[0] / sample_rate,
+            frame_count=data.shape[0],
+        )
+        return Audio(data, metadata).fit_to_duration(output_duration)
 
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         if self.timestamp >= meta.total_seconds:
@@ -497,7 +588,7 @@ class FreezeFrame(Operation):
         if self.position in ("after", "before"):
             new_count = meta.frame_count + freeze_count
         else:  # replace
-            frame_idx = round(self.timestamp * meta.fps)
+            frame_idx = min(round(self.timestamp * meta.fps), meta.frame_count - 1)
             replace_end = min(frame_idx + freeze_count, meta.frame_count)
             new_count = meta.frame_count - (replace_end - frame_idx) + freeze_count
         from videopython.base.video import VideoMetadata as _Meta
@@ -512,23 +603,26 @@ class FreezeFrame(Operation):
 
 
 class SilenceRemoval(Operation):
-    """Cuts or fast-forwards through silent gaps between speech.
+    """Cuts silent gaps between speech, using word-level transcription timestamps.
 
-    Uses word-level transcription timestamps to identify silent sections and
-    either removes them entirely or speeds them up.
+    Compiles to a ``select``/``aselect``-style keep-window cut on the
+    streaming path: the transcription is consumed at plan-compile time and
+    the silent frame ranges are dropped by the decoder's filter chain.
     """
 
     op: Literal["silence_removal"] = "silence_removal"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
+    streamable: ClassVar[bool] = True
+    changes_duration: ClassVar[bool] = True
     requires: ClassVar[tuple[str, ...]] = ("transcription",)
 
     min_silence_duration: float = Field(1.0, gt=0, description="Ignore silences shorter than this many seconds.")
     padding: float = Field(0.15, ge=0, description="Seconds of breathing room around each speech boundary.")
-    mode: Literal["cut", "speed_up"] = Field(
-        "cut",
-        description="'cut' removes silent sections entirely; 'speed_up' speeds them up.",
+
+    _MISSING_CONTEXT = (
+        "SilenceRemoval requires transcription data. "
+        "Pass it via VideoEdit.run(context={'transcription': ...}) or directly to apply()."
     )
-    speed_factor: float = Field(3.0, gt=1.0, description="Speed multiplier for silent sections when mode='speed_up'.")
 
     def _silence_ranges(self, words: list[Any], total_seconds: float) -> list[tuple[float, float]]:
         speech: list[tuple[float, float]] = []
@@ -549,131 +643,96 @@ class SilenceRemoval(Operation):
             silences.append((prev_end, total_seconds))
         return silences
 
-    def apply(self, video: Video, transcription: Transcription | None = None) -> Video:
-        if transcription is None:
-            raise ValueError(
-                "SilenceRemoval requires transcription data. "
-                "Pass it via VideoEdit.run(context={'transcription': ...}) or directly to apply()."
-            )
+    def _keep_frame_ranges(
+        self, transcription: Transcription, total_seconds: float, fps: float, n_frames: int
+    ) -> list[tuple[int, int]] | None:
+        """Frame ranges to keep, or ``None`` for "nothing to cut" (identity).
+
+        The single source of the cut math, shared by the eager apply, the
+        filter compile, the audio twin, and ``predict_metadata`` -- all four
+        must agree on the output timeline.
+        """
         words = transcription.words
         if not words:
-            return video
-        silences = self._silence_ranges(words, video.total_seconds)
+            return None
+        silences = self._silence_ranges(words, total_seconds)
         if not silences:
-            return video
-        if self.mode == "cut":
-            return self._apply_cut(video, silences)
-        return self._apply_speed_up(video, silences)
-
-    def _apply_cut(self, video: Video, silence_ranges: list[tuple[float, float]]) -> Video:
+            return None
         keep: list[tuple[int, int]] = []
         prev_frame = 0
-        for s_start, s_end in silence_ranges:
-            cut_start = round(s_start * video.fps)
-            cut_end = round(s_end * video.fps)
+        for s_start, s_end in silences:
+            cut_start = round(s_start * fps)
+            cut_end = round(s_end * fps)
             if cut_start > prev_frame:
                 keep.append((prev_frame, cut_start))
             prev_frame = cut_end
-        if prev_frame < len(video.frames):
-            keep.append((prev_frame, len(video.frames)))
-        if not keep:
+        if prev_frame < n_frames:
+            keep.append((prev_frame, n_frames))
+        return keep or None
+
+    def apply(self, video: Video, transcription: Transcription | None = None) -> Video:
+        if transcription is None:
+            raise ValueError(self._MISSING_CONTEXT)
+        keep = self._keep_frame_ranges(transcription, video.total_seconds, video.fps, len(video.frames))
+        if keep is None:
             return video
         video.frames = np.concatenate([video.frames[s:e] for s, e in keep], axis=0)
         if video.audio is not None:
-            sample_rate = video.audio.metadata.sample_rate
-            chunks = []
-            for start_f, end_f in keep:
-                a_start = round((start_f / video.fps) * sample_rate)
-                a_end = round((end_f / video.fps) * sample_rate)
-                chunks.append(video.audio.data[a_start:a_end])
-            video.audio.data = np.concatenate(chunks, axis=0)
-            video.audio = video.audio.fit_to_duration(len(video.frames) / video.fps)
+            video.audio = self.transform_audio(
+                video.audio, len(video.frames) / video.fps, video.fps, transcription=transcription
+            )
         return video
 
-    def _apply_speed_up(self, video: Video, silence_ranges: list[tuple[float, float]]) -> Video:
-        segments: list[tuple[int, int, float]] = []
-        prev_frame = 0
-        for s_start, s_end in silence_ranges:
-            silence_start = round(s_start * video.fps)
-            silence_end = round(s_end * video.fps)
-            if silence_start > prev_frame:
-                segments.append((prev_frame, silence_start, 1.0))
-            segments.append((silence_start, silence_end, self.speed_factor))
-            prev_frame = silence_end
-        if prev_frame < len(video.frames):
-            segments.append((prev_frame, len(video.frames), 1.0))
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the cut to a ``select`` keep-window filter.
 
-        frame_parts: list[np.ndarray] = []
-        for start_f, end_f, speed in segments:
-            n = end_f - start_f
-            if n <= 0:
-                continue
-            if speed == 1.0:
-                frame_parts.append(video.frames[start_f:end_f])
-            else:
-                target = max(1, round(n / speed))
-                idx = np.linspace(start_f, end_f - 1, target).astype(int)
-                frame_parts.append(video.frames[idx])
-        if not frame_parts:
-            return video
-        video.frames = np.concatenate(frame_parts, axis=0)
+        Consumes the segment-local transcription from ``ctx.context``;
+        missing context raises the op's clear error at plan compile, before
+        any decode. No silences -> ``null`` (identity).
+        """
+        from videopython.base.transcription import Transcription as _Transcription
 
-        if video.audio is not None and not video.audio.is_silent:
-            sample_rate = video.audio.metadata.sample_rate
-            audio_parts: list[np.ndarray] = []
-            for start_f, end_f, speed in segments:
-                a_start = round((start_f / video.fps) * sample_rate)
-                a_end = round((end_f / video.fps) * sample_rate)
-                chunk = video.audio.data[a_start:a_end]
-                if speed == 1.0 or len(chunk) == 0:
-                    audio_parts.append(chunk)
-                else:
-                    target = max(1, round(len(chunk) / speed))
-                    idx = np.linspace(0, len(chunk) - 1, target).astype(int)
-                    audio_parts.append(chunk[idx])
-            video.audio.data = np.concatenate(audio_parts, axis=0)
-            video.audio = video.audio.fit_to_duration(len(video.frames) / video.fps)
-        return video
+        transcription = ctx.context.get("transcription")
+        if not isinstance(transcription, _Transcription):
+            raise ValueError(self._MISSING_CONTEXT)
+        if ctx.frame_count <= 0:
+            return None
+        keep = self._keep_frame_ranges(transcription, ctx.frame_count / ctx.fps, ctx.fps, ctx.frame_count)
+        if keep is None:
+            return "null"
+        terms = "+".join(f"between(n,{s},{e - 1})" for s, e in keep)
+        # Trailing resampler: see FreezeFrame.to_ffmpeg_filter.
+        return f"select='{terms}',setpts=N/FRAME_RATE/TB,fps={ctx.fps:.10g}"
 
-    def predict_metadata(
-        self,
-        meta: VideoMetadata,
-        transcription: Transcription | None = None,
-    ) -> VideoMetadata:
-        from videopython.base.video import VideoMetadata as _Meta
-
-        identity = _Meta(
-            height=meta.height,
-            width=meta.width,
-            fps=meta.fps,
-            frame_count=meta.frame_count,
-            total_seconds=meta.total_seconds,
+    def transform_audio(self, audio: Audio, output_duration: float, fps: float, **context: Any) -> Audio:
+        """Cut the same keep windows out of the audio, then fit the duration."""
+        transcription = context.get("transcription")
+        if transcription is None:
+            raise ValueError(self._MISSING_CONTEXT)
+        total_seconds = audio.metadata.duration_seconds
+        keep = self._keep_frame_ranges(transcription, total_seconds, fps, round(total_seconds * fps))
+        if keep is None:
+            return audio
+        sample_rate = audio.metadata.sample_rate
+        chunks = [audio.data[round(s / fps * sample_rate) : round(e / fps * sample_rate)] for s, e in keep]
+        data = np.concatenate(chunks, axis=0)
+        metadata = dataclasses.replace(
+            audio.metadata,
+            duration_seconds=data.shape[0] / sample_rate,
+            frame_count=data.shape[0],
         )
-        if transcription is None or not getattr(transcription, "words", None):
-            return identity
-        silences = self._silence_ranges(transcription.words, meta.total_seconds)
-        if not silences:
-            return identity
+        return Audio(data, metadata).fit_to_duration(output_duration)
 
-        if self.mode == "cut":
-            keep = 0
-            prev_frame = 0
-            for s_start, s_end in silences:
-                cut_start = round(s_start * meta.fps)
-                cut_end = round(s_end * meta.fps)
-                if cut_start > prev_frame:
-                    keep += cut_start - prev_frame
-                prev_frame = cut_end
-            if prev_frame < meta.frame_count:
-                keep += meta.frame_count - prev_frame
-            new_count = max(1, keep)
-        else:
-            saved = 0
-            for s_start, s_end in silences:
-                gap = round((s_end - s_start) * meta.fps)
-                sped = max(1, round(gap / self.speed_factor))
-                saved += gap - sped
-            new_count = max(1, meta.frame_count - saved)
+    def predict_metadata(self, meta: VideoMetadata, transcription: Transcription | None = None) -> VideoMetadata:
+        """Predict the cut duration; identity when no transcription is in the
+        validate context (the same conditional guarantee as time re-basing)."""
+        if transcription is None:
+            return meta
+        keep = self._keep_frame_ranges(transcription, meta.total_seconds, meta.fps, meta.frame_count)
+        if keep is None:
+            return meta
+        new_count = sum(e - s for s, e in keep)
+        from videopython.base.video import VideoMetadata as _Meta
 
         return _Meta(
             height=meta.height,

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -40,6 +40,7 @@ from videopython.editing.streaming import (
     analyze_streamability,
     concat_files,
     stream_segment,
+    stream_segment_to_frames,
 )
 from videopython.editing.transforms import DURATION_EPS, CutSeconds, Resize
 
@@ -147,14 +148,6 @@ def _segment_context(
         else:
             rebased[key] = sliced.offset(-start)
     return rebased
-
-
-def _apply_with_context(op: Operation, video: Video, context: dict[str, Any] | None) -> Video:
-    """Apply ``op`` to ``video``, threading ``op.requires`` keys from ``context``."""
-    if op.requires and context:
-        kwargs = {k: context[k] for k in op.requires if k in context}
-        return op.apply(video, **kwargs)
-    return op.apply(video)
 
 
 def _predict_with_context(
@@ -539,17 +532,6 @@ class SegmentConfig(BaseModel):
             height=height,
         )
 
-    def process(self, video: Video, context: dict[str, Any] | None = None) -> Video:
-        """Apply every operation in this segment to ``video`` in order.
-
-        Time-based context (e.g. ``transcription``) is re-based onto this
-        segment's 0-based local timeline before any operation sees it.
-        """
-        seg_context = _segment_context(context, self.start, self.end)
-        for op in self.operations:
-            video = _apply_with_context(op, video, seg_context)
-        return video
-
 
 class VideoEdit(BaseModel):
     """A multi-segment editing plan.
@@ -744,7 +726,6 @@ class VideoEdit(BaseModel):
         context: dict[str, Any] | None = None,
         *,
         clamp_windows: bool = False,
-        strict_streaming: bool = False,
     ) -> list[PlanError]:
         """Collect **every** plan error in one pass; ``[]`` means valid.
 
@@ -763,18 +744,16 @@ class VideoEdit(BaseModel):
         ``code`` rather than substring-matching prose. ``clamp_windows`` matches
         :meth:`validate`: a clampable ``window.stop`` overrun is not reported.
 
-        With ``strict_streaming=True``, ops that would force
-        :meth:`run_to_file`'s silent eager fallback are additionally reported as
-        ``STREAMING_FALLBACK`` errors (appended after the validity errors, in
-        plan order), with the cause in :attr:`PlanError.detail` -- the gating
-        twin of ``run_to_file(strict_streaming=True)``. See
-        :meth:`streamability` for the full per-op report including the ops that
-        *do* stream.
+        Streaming is the only engine, so ops that cannot stream at their
+        plan position are real plan errors: one ``STREAMING_FALLBACK`` per
+        offending op is appended after the validity errors, in plan order,
+        with the actionable cause in :attr:`PlanError.detail`. See
+        :meth:`streamability` for the full per-op report including the ops
+        that *do* stream.
         """
         metas = self._resolve_source_metas(source_metadata)
         _, errors = self._collect(metas, context, clamp_windows=clamp_windows, stop_first=False)
-        if strict_streaming:
-            errors.extend(self.streamability().errors())
+        errors.extend(self.streamability().errors())
         return errors
 
     def streamability(self) -> StreamabilityReport:
@@ -784,8 +763,9 @@ class VideoEdit(BaseModel):
         order, and the plan shape, never on source metadata or runtime context
         -- so this needs no source files and is safe to call before a job is
         admitted. ``report.streamable`` answers "will :meth:`run_to_file`
-        stream in O(1) memory, or eager-load the whole video?"; each entry
-        carries the op's memory class and, for fallbacks, the reason.
+        stream this plan in O(1) memory, or is an op unstreamable at its
+        plan position?"; each entry carries the op's memory class and, for
+        fallbacks, the reason.
         """
         return analyze_streamability(
             [list(seg.operations) for seg in self.segments],
@@ -1200,19 +1180,32 @@ class VideoEdit(BaseModel):
     # -------------------------------------------------------------------- run
 
     def run(self, context: dict[str, Any] | None = None) -> Video:
-        """Execute the plan in memory and return the final ``Video``."""
-        self._assert_post_ops_supported(context)
-        target_fps, target_w, target_h = self._matching_targets_from_disk()
-        videos = [
-            segment.process(segment.load(fps=target_fps, width=target_w, height=target_h), context)
-            for segment in self.segments
-        ]
-        result = videos[0]
-        for video in videos[1:]:
-            result = result + video
-        for op in self.post_operations:
-            result = _apply_with_context(op, result, context)
-        return result
+        """Execute the plan and return the final ``Video`` in memory.
+
+        A view over the streaming engine -- the same compiled plans
+        ``run_to_file`` streams to disk are streamed into memory (lossless
+        rawvideo, no encode round-trip), so the two entry points cannot
+        diverge. Plans with unstreamable shapes raise the same structured
+        ``STREAMING_FALLBACK`` errors as :meth:`run_to_file`.
+        """
+        plans = self._compile_streaming_plans(context)
+        try:
+            videos: list[Video] = []
+            for segment, plan in zip(self.segments, plans):
+                frames = stream_segment_to_frames(plan)
+                video = Video.from_frames(frames, fps=plan.final_fps or plan.output_fps)
+                audio = self._load_segment_audio(segment, plan)
+                if audio is not None:
+                    video.audio = audio
+                videos.append(video)
+            result = videos[0]
+            for video in videos[1:]:
+                result = result + video
+            return result
+        finally:
+            for plan in plans:
+                for f in plan.owned_temp_files:
+                    f.unlink(missing_ok=True)
 
     def run_to_file(
         self,
@@ -1221,104 +1214,22 @@ class VideoEdit(BaseModel):
         preset: ALLOWED_VIDEO_PRESETS = "medium",
         crf: int = 23,
         context: dict[str, Any] | None = None,
-        *,
-        strict_streaming: bool = False,
     ) -> Path:
-        """Execute the plan, streaming directly to a file when possible.
+        """Execute the plan, streaming directly to a file.
 
-        Falls back to eager (``self.run().save(...)``) for any operation that
-        isn't streamable. Memory usage is O(1) w.r.t. video length for fully
-        streamable pipelines.
-
-        With ``strict_streaming=True`` the silent fallback becomes a
-        :class:`PlanValidationError` carrying one ``STREAMING_FALLBACK``
-        :class:`PlanError` per offending op -- raised before any decode, so a
-        consumer that priced a job as O(1) memory never eager-loads the whole
-        video instead. Gate plans early with ``check(strict_streaming=True)``
-        or :meth:`streamability`, which report the same fallbacks without
-        running anything.
+        Memory usage is O(1) w.r.t. video length (video; segment audio is
+        in-memory). Streaming is the only engine: a plan with an unstreamable
+        shape raises :class:`PlanValidationError` carrying one
+        ``STREAMING_FALLBACK`` :class:`PlanError` per offending op -- before
+        any decode. Gate plans early with :meth:`check` or
+        :meth:`streamability`, which report the same errors without running
+        anything.
         """
-        self._assert_post_ops_supported(context)
-        if strict_streaming:
-            report = self.streamability()
-            if not report.streamable:
-                causes = "; ".join(f"{e.location} '{e.op}': {e.reason}" for e in report.fallbacks)
-                message = (
-                    f"strict_streaming=True rejects this plan: {len(report.fallbacks)} op(s) "
-                    f"would force the eager in-memory fallback -- {causes}"
-                )
-                raise PlanValidationError(message, report.errors())
         output_path = Path(output_path).with_suffix(f".{format}")
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        target_fps, target_w, target_h = self._matching_targets_from_disk()
-        plans: list[StreamingSegmentPlan] = []
-        # Built plans may own compile-time temp files (e.g. the .ass behind a
-        # subtitles= filter); delete them on every exit -- success, eager
-        # fallback (eager re-renders from scratch), or error.
+        plans = self._compile_streaming_plans(context)
         try:
-            for i, segment in enumerate(self.segments):
-                plan = self._build_streaming_plan(segment, target_fps, target_w, target_h, context)
-                if plan is None:
-                    return self._eager_fallback(
-                        strict_streaming,
-                        f"segments[{i}] did not compile to a streaming plan",
-                        output_path,
-                        format,
-                        preset,
-                        crf,
-                        context,
-                    )
-                plans.append(plan)
-
-            # Post-ops only fold cleanly into a single segment plan; multi-segment
-            # post-ops would need a second pass we don't bother with.
-            if self.post_operations and len(plans) != 1:
-                return self._eager_fallback(
-                    strict_streaming,
-                    "post-operations on a multi-segment plan",
-                    output_path,
-                    format,
-                    preset,
-                    crf,
-                    context,
-                )
-            if self.post_operations:
-                plan = plans[0]
-                total_frames = round((plan.end_second - plan.start_second) * plan.output_fps)
-                for op in self.post_operations:
-                    if op.requires:
-                        # Segment ops get re-based context on their schedule entry,
-                        # but post-ops run on the assembled timeline where the eager
-                        # path passes context *raw* -- folding that into the segment
-                        # schedule is the P0.4 scheduling work. Defer to eager.
-                        # (Multi-segment + requires already raised by
-                        # _assert_post_ops_supported.)
-                        return self._eager_fallback(
-                            strict_streaming,
-                            f"post-operation '{op.op}' requires runtime context",
-                            output_path,
-                            format,
-                            preset,
-                            crf,
-                            context,
-                        )
-                    if not isinstance(op, Effect) or not op.streamable or op.compiles_to_filter:
-                        # compiles_to_filter post-ops are excluded too: folding
-                        # appends a frame-effect schedule entry, which a
-                        # filter-class op cannot serve (no process_frame).
-                        return self._eager_fallback(
-                            strict_streaming,
-                            f"post-operation '{op.op}' cannot fold into the segment schedule",
-                            output_path,
-                            format,
-                            preset,
-                            crf,
-                            context,
-                        )
-                    start_f, end_f = _effect_frame_range(op, plan.output_fps, total_frames)
-                    plan.effect_schedule.append(EffectScheduleEntry(op, start_f, end_f))
-
             if len(plans) == 1:
                 plan = plans[0]
                 audio = self._load_segment_audio(self.segments[0], plan)
@@ -1341,41 +1252,88 @@ class VideoEdit(BaseModel):
                 for f in plan.owned_temp_files:
                     f.unlink(missing_ok=True)
 
-    def _eager_fallback(
-        self,
-        strict_streaming: bool,
-        detail: str,
-        output_path: Path,
-        format: ALLOWED_VIDEO_FORMATS,
-        preset: ALLOWED_VIDEO_PRESETS,
-        crf: int,
-        context: dict[str, Any] | None,
-    ) -> Path:
-        """Take the eager path -- or refuse to, under ``strict_streaming``.
+    def _compile_streaming_plans(self, context: dict[str, Any] | None) -> list[StreamingSegmentPlan]:
+        """Compile every segment plan and fold the post-ops, or raise.
 
-        When the :meth:`streamability` report is in sync with the plan builder
-        the strict branch is unreachable: the upfront gate in
-        :meth:`run_to_file` already raised. Reaching it means the two drifted
-        (e.g. a third-party transform whose ``streamable`` flag does not match
-        its ``to_ffmpeg_filter``) -- refuse to silently eager-load anyway.
+        The single admission point for both :meth:`run` and
+        :meth:`run_to_file`. Unstreamable shapes raise
+        :class:`PlanValidationError` with the streamability report's
+        structured errors; a builder/report drift (e.g. a third-party
+        transform whose ``streamable`` flag does not match its
+        ``to_ffmpeg_filter``) raises with a generic ``STREAMING_FALLBACK``.
+        On raise, any compile-time temp files already created are deleted;
+        on success the caller owns ``plan.owned_temp_files``.
         """
-        if strict_streaming:
-            raise PlanValidationError(
-                f"strict_streaming=True: plan stopped streaming despite a clean streamability report ({detail})",
+        self._assert_post_ops_supported(context)
+        report = self.streamability()
+        if not report.streamable:
+            causes = "; ".join(f"{e.location} '{e.op}': {e.reason}" for e in report.fallbacks)
+            message = (
+                f"Plan cannot stream: {len(report.fallbacks)} op(s) have no streaming "
+                f"strategy at their plan position -- {causes}"
+            )
+            raise PlanValidationError(message, report.errors())
+
+        def drift(detail: str) -> PlanValidationError:
+            return PlanValidationError(
+                f"plan stopped streaming despite a clean streamability report ({detail})",
                 [PlanError(code=PlanErrorCode.STREAMING_FALLBACK, detail=detail)],
             )
-        return self._run_to_file_eager(output_path, format, preset, crf, context)
 
-    def _run_to_file_eager(
-        self,
-        output_path: Path,
-        format: ALLOWED_VIDEO_FORMATS,
-        preset: ALLOWED_VIDEO_PRESETS,
-        crf: int,
-        context: dict[str, Any] | None,
-    ) -> Path:
-        video = self.run(context=context)
-        return video.save(output_path, format=format, preset=preset, crf=crf)
+        target_fps, target_w, target_h = self._matching_targets_from_disk()
+        plans: list[StreamingSegmentPlan] = []
+        try:
+            for i, segment in enumerate(self.segments):
+                plan = self._build_streaming_plan(segment, target_fps, target_w, target_h, context)
+                if plan is None:
+                    raise drift(f"segments[{i}] did not compile to a streaming plan")
+                plans.append(plan)
+
+            if self.post_operations:
+                # Post-op effects fold into the per-segment schedules with
+                # globally-rebased frame offsets: each segment's entries get
+                # the window slice that falls inside it, with index_offset /
+                # total_effect_frames carrying the assembled-timeline window
+                # so envelopes continue across the concat boundary. The
+                # unsupported shapes were rejected by the report gate above;
+                # reaching one here is drift.
+                if any(p.post_vf_filters for p in plans):
+                    raise drift("post-operations behind encode-stage filters")
+                seg_counts = [p.output_total_frames for p in plans]
+                offsets = [0]
+                for count in seg_counts[:-1]:
+                    offsets.append(offsets[-1] + count)
+                total_frames = sum(seg_counts)
+                post_fps = plans[0].output_fps
+                for op in self.post_operations:
+                    if op.requires:
+                        raise drift(f"post-operation '{op.op}' requires runtime context")
+                    if not isinstance(op, Effect) or not op.streamable or op.compiles_to_filter:
+                        raise drift(f"post-operation '{op.op}' cannot fold into the segment schedule")
+                    if op.audio_coupled and len(plans) > 1:
+                        raise drift(f"audio-coupled post-operation '{op.op}' cannot fold across segments")
+                    g_start, g_end = _effect_frame_range(op, post_fps, total_frames)
+                    g_open = g_end >= total_frames
+                    for offset, count, plan in zip(offsets, seg_counts, plans):
+                        local_start = max(g_start, offset)
+                        local_end = count + offset if g_open else min(g_end, offset + count)
+                        if local_start >= local_end:
+                            continue
+                        plan.effect_schedule.append(
+                            EffectScheduleEntry(
+                                op,
+                                local_start - offset,
+                                local_end - offset,
+                                index_offset=max(0, offset - g_start),
+                                total_effect_frames=g_end - g_start,
+                            )
+                        )
+        except BaseException:
+            for plan in plans:
+                for f in plan.owned_temp_files:
+                    f.unlink(missing_ok=True)
+            raise
+        return plans
 
     # ----------------------------------------------------------------- helpers
 
@@ -1397,15 +1355,27 @@ class VideoEdit(BaseModel):
         context: dict[str, Any] | None = None,
     ) -> StreamingSegmentPlan | None:
         source_meta = VideoMetadata.from_path(str(segment.source))
-        out_fps = target_fps or source_meta.fps
-        out_w = target_w or source_meta.width
-        out_h = target_h or source_meta.height
+        # Fold real metadata through the chain -- the same walk validation
+        # does -- so duration-changing transforms (speed, freeze) keep frame
+        # counts, effect ranges, and audio in sync with the actual output.
+        running = CutSeconds(start=segment.start, end=segment.end).predict_metadata(source_meta)
+        if running.frame_count <= 0:
+            message = (
+                f"Segment [{segment.start}, {segment.end}) is shorter than one frame "
+                f"at {running.fps} fps and cannot be rendered"
+            )
+            raise PlanValidationError(
+                message,
+                [PlanError(code=PlanErrorCode.DEGENERATE_DURATION, op=None, field="end", value=segment.end)],
+            )
 
         vf_filters: list[str] = []
         if target_w and target_h and (target_w != source_meta.width or target_h != source_meta.height):
             vf_filters.append(f"scale={target_w}:{target_h}")
+            running = running.with_dimensions(target_w, target_h)
         if target_fps and target_fps != source_meta.fps:
             vf_filters.append(f"fps={target_fps}")
+            running = running.with_fps(target_fps)
 
         # Resolve requires-context onto the segment's local timeline once; each
         # context-requiring effect gets its keys on the schedule entry, which
@@ -1424,10 +1394,27 @@ class VideoEdit(BaseModel):
 
         effect_schedule: list[EffectScheduleEntry] = []
         post_vf_filters: list[str] = []
+        audio_ops: list[tuple[Operation, float, float, dict[str, Any]]] = []
+        post_audio_ops: list[tuple[Operation, float, float, dict[str, Any]]] = []
+        duration_changed = False
+        # The pipe stage: dims/fps/frame-count of the frames flowing through
+        # process_frame and into the encoder's rawvideo stdin. Frozen the
+        # moment encode-stage content appears (a scheduled effect or any
+        # post_vf entry); transforms after that fold `running` further (for
+        # audio durations and the final output), but the pipe stays put.
+        pipe_meta: VideoMetadata | None = None
         try:
             for op in segment.operations:
                 if isinstance(op, Effect):
                     if not op.streamable:
+                        abandon()
+                        return None
+                    if op.requires and duration_changed:
+                        # A duration-changing transform earlier in the chain
+                        # moved the timeline; segment-local context (e.g. the
+                        # transcription) is not re-mapped through the warp
+                        # yet. Not streamable here -- rejected as
+                        # UNSTREAMABLE by the streamability report.
                         abandon()
                         return None
                     if op.compiles_to_filter:
@@ -1438,11 +1425,23 @@ class VideoEdit(BaseModel):
                         # (FrameEncoder -vf), which runs after every
                         # process_frame. Either way plan order is preserved. A
                         # None compile falls through to the frame-effect path.
-                        ctx = FilterCtx(width=out_w, height=out_h, fps=out_fps, context=seg_context or {})
+                        encode_stage_effect = bool(effect_schedule or post_vf_filters)
+                        ctx = FilterCtx(
+                            width=running.width,
+                            height=running.height,
+                            fps=running.fps,
+                            frame_count=running.frame_count,
+                            context=seg_context or {},
+                            source_path=segment.source,
+                            start_second=segment.start,
+                            end_second=segment.end,
+                            decode_filters=None if encode_stage_effect else tuple(vf_filters),
+                        )
                         filter_expr = op.to_ffmpeg_filter(ctx)
                         owned_files.extend(ctx.owned_files)
                         if filter_expr is not None:
-                            if effect_schedule or post_vf_filters:
+                            if encode_stage_effect:
+                                pipe_meta = pipe_meta or running
                                 post_vf_filters.append(filter_expr)
                             else:
                                 vf_filters.append(filter_expr)
@@ -1450,68 +1449,109 @@ class VideoEdit(BaseModel):
                     if post_vf_filters:
                         # A frame effect after an encode-stage filter would run
                         # before it (process_frame precedes the encoder), so
-                        # plan order cannot be preserved. Defer to eager.
+                        # plan order cannot be preserved -- not streamable
+                        # (rejected as UNSTREAMABLE by the streamability report).
                         abandon()
                         return None
                     op_context: dict[str, Any] = {}
                     if op.requires and seg_context:
                         op_context = {k: seg_context[k] for k in op.requires if k in seg_context}
-                    total_frames = round(segment.duration * out_fps)
-                    start_f, end_f = _effect_frame_range(op, out_fps, total_frames)
+                    pipe_meta = pipe_meta or running
+                    start_f, end_f = _effect_frame_range(op, running.fps, running.frame_count)
                     effect_schedule.append(EffectScheduleEntry(op, start_f, end_f, op_context))
                     continue
-                if op.requires:
-                    # Context-requiring transforms (e.g. silence_removal) have no
-                    # streaming strategy yet -- an ffmpeg filter string can't
-                    # consume runtime context. Defer the plan to the eager path.
-                    abandon()
-                    return None
-                if effect_schedule:
-                    # vf_filters run at decode time, BEFORE every scheduled
-                    # effect's process_frame, so a transform that follows an
-                    # effect in plan order cannot be expressed without reordering:
-                    # the effect's frame range and streaming_init dims/fps were
-                    # computed against a timeline this filter would change. Defer
-                    # to the eager path, which executes ops strictly in plan order.
+                if op.requires and (duration_changed or not op.streamable):
+                    # A context-requiring transform can stream only when its
+                    # filter compile can consume the context (silence_removal
+                    # does, via FilterCtx.context) -- but not after a
+                    # duration-changing transform (no time-warp re-mapping
+                    # yet), and not without a streaming strategy. Not
+                    # streamable here -- rejected as UNSTREAMABLE by the
+                    # streamability report.
                     abandon()
                     return None
                 # Non-effect transform: compile to ffmpeg filter if streamable.
                 # The `streamable` flag is the authoritative declaration -- checked
                 # first so the streamability report (which classifies by the flag)
                 # can never disagree with the builder in this direction: a
-                # flag-False transform goes eager even if it has a working
-                # to_ffmpeg_filter. The remaining drift class (flag True, filter
-                # compiles to None) is caught by _eager_fallback under strict mode.
+                # flag-False transform is classified UNSTREAMABLE even if it has
+                # a working to_ffmpeg_filter. The remaining drift class (flag
+                # True, filter compiles to None) is caught by the
+                # STREAMING_FALLBACK raise in _compile_streaming_plans.
                 if not op.streamable:
                     abandon()
                     return None
-                ctx = FilterCtx(width=out_w, height=out_h, fps=out_fps)
+                encode_stage = bool(effect_schedule or post_vf_filters)
+                if encode_stage and op.compiles_from_source:
+                    # The op's compile decodes the source to see its input
+                    # frames (face_crop's detection pass); frames behind
+                    # per-frame Python effects are not reproducible at
+                    # compile time -- not streamable (rejected as UNSTREAMABLE).
+                    abandon()
+                    return None
+                ctx = FilterCtx(
+                    width=running.width,
+                    height=running.height,
+                    fps=running.fps,
+                    frame_count=running.frame_count,
+                    context=seg_context or {},
+                    source_path=segment.source,
+                    start_second=segment.start,
+                    end_second=segment.end,
+                    decode_filters=None if encode_stage else tuple(vf_filters),
+                )
                 filter_expr = op.to_ffmpeg_filter(ctx)
+                owned_files.extend(ctx.owned_files)
                 if filter_expr is None:
                     abandon()
                     return None
-                vf_filters.append(filter_expr)
-                new_meta = op.predict_metadata(
-                    VideoMetadata(height=out_h, width=out_w, fps=out_fps, frame_count=1, total_seconds=1.0)
-                )
-                out_w, out_h, out_fps = new_meta.width, new_meta.height, new_meta.fps
+                if encode_stage:
+                    # A transform following frame effects joins the encode
+                    # chain (FrameEncoder -vf), which runs after every
+                    # process_frame -- plan order is preserved without the
+                    # whole-plan fallback this shape used to force.
+                    pipe_meta = pipe_meta or running
+                    post_vf_filters.append(filter_expr)
+                else:
+                    vf_filters.append(filter_expr)
+                running = _predict_with_context(op, running, seg_context)
+                if op.changes_duration:
+                    duration_changed = True
+                if type(op).transform_audio is not Operation.transform_audio:
+                    # The op has an audio-domain twin; _load_segment_audio
+                    # replays it (with the predicted post-op duration and the
+                    # op's resolved context) so the in-memory audio follows
+                    # the video's filter chain. Encode-stage twins replay
+                    # after the effect envelopes, matching plan order.
+                    twin_context: dict[str, Any] = {}
+                    if op.requires and seg_context:
+                        twin_context = {k: seg_context[k] for k in op.requires if k in seg_context}
+                    entry = (op, running.total_seconds, running.fps, twin_context)
+                    (post_audio_ops if encode_stage else audio_ops).append(entry)
         except BaseException:
             # A raising compile or prediction (e.g. missing subtitle context,
             # crop exceeding source) must not leak earlier ops' temp files.
             abandon()
             raise
 
+        pipe = pipe_meta or running
         return StreamingSegmentPlan(
             source_path=segment.source,
             start_second=segment.start,
             end_second=segment.end,
-            output_fps=out_fps,
-            output_width=out_w,
-            output_height=out_h,
+            output_fps=pipe.fps,
+            output_width=pipe.width,
+            output_height=pipe.height,
             vf_filters=vf_filters,
             effect_schedule=effect_schedule,
             post_vf_filters=post_vf_filters,
             owned_temp_files=owned_files,
+            output_total_frames=pipe.frame_count,
+            audio_ops=audio_ops,
+            post_audio_ops=post_audio_ops,
+            final_fps=running.fps,
+            final_width=running.width,
+            final_height=running.height,
         )
 
     def _load_segment_audio(
@@ -1526,12 +1566,25 @@ class VideoEdit(BaseModel):
             warnings.warn(f"No audio found for `{segment.source}`, using silent track.")
             audio = Audio.create_silent(duration_seconds=round(segment.duration, 2), stereo=True, sample_rate=44100)
 
+        # Replay duration-changing transforms' audio twins in plan order
+        # (speed_change stretches, freeze_frame inserts silence), each fit to
+        # its predicted post-op duration -- the audio mirror of the video
+        # filter chain. Runs before the effect envelopes, whose frame ranges
+        # already live on the post-transform output timeline.
+        for op, out_duration, op_fps, op_context in plan.audio_ops:
+            audio = op.transform_audio(audio, out_duration, op_fps, **op_context)
+
         for entry in plan.effect_schedule:
             effect = entry.effect
             if isinstance(effect, (Fade, VolumeAdjust)) and not audio.is_silent:
                 start_s = entry.start_frame / plan.output_fps
                 stop_s = entry.end_frame / plan.output_fps
                 effect._apply_audio(audio, start_s, stop_s)
+
+        # Encode-stage twins (transforms that follow the effects in plan
+        # order) replay after the envelopes, mirroring the video chain.
+        for op, out_duration, op_fps, op_context in plan.post_audio_ops:
+            audio = op.transform_audio(audio, out_duration, op_fps, **op_context)
 
         return audio
 

--- a/uv.lock
+++ b/uv.lock
@@ -4536,7 +4536,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.41.0"
+version = "0.42.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
…forms (0.42.0)

Completes the streaming-first migration: streaming becomes the only execution engine for VideoEdit. Every op compiles to an ffmpeg filter chain or streams as a per-frame effect; the silent whole-plan eager fallback is deleted. run() is redefined as a view over the same engine that streams compiled plans into memory (decode -> per-frame effects -> lossless rawvideo pass for encode-stage filters), so run() and run_to_file() cannot diverge. The eager runner (_run_to_file_eager, SegmentConfig.process, _apply_with_context) is gone. Plan shapes with no streaming strategy are structured STREAMING_FALLBACK errors raised before any decode, with reorder hints.

Every remaining op streams natively:
- speed_change: setpts retime (bias-corrected nearest for speedups, closed-form log-curve ramps) + fps/framerate resample
- freeze_frame: linear loop/select chains for all three modes
- silence_removal: transcription consumed at compile -> select keep-window cut; gains a real predict_metadata
- face_crop (ai): compile-time detection pass over the exact decode prefix drives a per-frame sendcmd crop track -- zero per-frame Python

Engine:
- the plan builder folds real metadata through the chain (pipe stage vs final stage), the plan carries authoritative frame counts, and effect envelopes size to the post-transform timeline
- segment audio follows via Operation.transform_audio twins (time-stretch / silence insert / gap cut), replayed in chain order
- transforms after frame effects join the encoder -vf chain (post_vf_filters): [fade, crop], [fade, speed_change] stream in order
- post-op effects fold across multi-segment plans with globally-rebased offsets (EffectScheduleEntry.index_offset / total_effect_frames) -- envelopes continue across concat boundaries, closing the brand-logo overlay fallback
- FrameIterator's segment trim moved input-side so duration-extending filters are not truncated

BREAKING (no deprecation):
- the reverse op is removed (whole-video buffering has no place here)
- strict_streaming kwargs removed from run_to_file() and check(): strictness is the only behavior; check() always reports unstreamable ops as plan errors
- StreamingClass.EAGER renamed to UNSTREAMABLE (value "unstreamable")
- silence_removal loses mode="speed_up" and speed_factor
- face_crop: fixed crop-window size (the size-expansion clause and its per-frame cv2 resize are gone -- crops are pure slices); fallback="full_frame" behaves as "center"
- run() output pixels come from the decode chain, not the old per-op in-memory pipeline (per-op apply() remains the direct single-op API)
- transform post-ops and audio-coupled post-ops (fade/volume_adjust) on multi-segment plans are rejected; plans relying on the silent eager fallback now raise

The remaining unstreamable shapes (frame effect after encode-stage filters, time-context after a duration warp, face_crop behind effects, in-plan cut ops) are explicit errors, not fallbacks.

Docs/tests: README, the docs/ tree, and RELEASE_NOTES refreshed for the single-engine contract; source docstrings/comments scrubbed of the removed eager engine; new test_native_transform_streaming.py and reworked streamability/video_edit/ai suites.