### PR TITLE
feat(editing)!: remove eager in-memory execution; streaming-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ edit.validate()                  # dry-run via metadata, no frames loaded
 edit.run_to_file("output.mp4")   # streams ffmpeg decode → effects → encode
 ```
 
-`run_to_file()` streams ffmpeg decode → per-frame effects → encode, so memory stays bounded even for hour-long sources. Use `edit.run()` to get a `Video` back in memory instead.
+`run_to_file()` streams ffmpeg decode → per-frame effects → encode, so memory stays bounded even for hour-long sources. If you need the frames back in memory, load the rendered file: `Video.from_path(str(edit.run_to_file("output.mp4")))`.
 
 ### AI generation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,56 @@
 # Release Notes
 
+## 0.44.0
+
+Breaking: the eager/in-memory editing path is gone. Streaming-to-file
+(`run_to_file`) is now the only execution engine -- nothing runs in memory.
+
+### Removed `VideoEdit.run()`
+
+`VideoEdit.run()` (execute the plan into an in-memory `Video`) is gone, along with
+its in-memory machinery (`stream_segment_to_frames`, `stream_segment_audio_to_array`,
+`stream_transition_frames`, `out_frames_reshape`). It was a hand-synced twin of
+`run_to_file` that defeated the engine's O(1)-memory guarantee for the sake of a
+convenience return value.
+
+Use `run_to_file` and read the result back when you need a `Video`:
+
+```python
+from videopython.base.video import Video
+
+out = edit.run_to_file("output.mp4")
+video = Video.from_path(str(out))   # only when you actually need frames in memory
+```
+
+`run_to_file` is unchanged: same signature, same structured `STREAMING_FALLBACK`
+errors raised before any decode.
+
+### Removed `Operation.apply()` and the eager twins
+
+`Operation.apply(video) -> Video` and its machinery are removed: `Effect.apply`,
+`Effect._apply`, `Effect._resolved_window`, every `Transform.apply` /
+`_audio_apply` numpy implementation, the effect `apply` / `_audio_apply` overrides
+(`Fade`, `VolumeAdjust`, `FullImageOverlay`, `Vignette`), and
+`TranscriptionOverlay.apply`. An Operation is now defined purely by its streaming
+contract: `to_ffmpeg_filter` / `to_ffmpeg_audio_filter`, `streaming_init` +
+`process_frame`, and `predict_metadata`.
+
+To apply an operation, build a `VideoEdit` and stream it:
+
+```python
+edit = VideoEdit.from_dict(
+    {"segments": [{"source": "in.mp4", "start": 0, "end": 5,
+                   "operations": [{"op": "resize", "width": 1280, "height": 720}]}]}
+)
+edit.run_to_file("out.mp4")
+```
+
+`FullImageOverlay`'s shape / fade-time validation moved to `predict_metadata`, so
+it still fails fast at `validate()`. The AI pipeline no longer loads video into
+memory to edit it: `ai/dubbing` and `ai/video_analysis` slice `Video` directly
+(frames + audio) instead of `CutSeconds(...).apply(video)`. `Video.from_frames`,
+`Video` slicing, and the per-frame `process_frame` streaming hook are unchanged.
+
 ## 0.43.1
 
 Four low-risk consumer wins (P2.14 + P3), all additive or bugfix -- no breaking

--- a/docs/api/ai/effects.md
+++ b/docs/api/ai/effects.md
@@ -14,21 +14,23 @@ internally; the box/label drawing is done by the AI-free renderer
 
 ```python
 from videopython.ai import ObjectDetectionOverlay
-from videopython.base import Video
-
-video = Video.from_path("street.mp4")
+from videopython.editing import VideoEdit, SegmentConfig
 
 # Default: per-class colours, confidence shown, detect every 2nd frame.
-annotated = ObjectDetectionOverlay().apply(video)
+edit = VideoEdit(segments=[SegmentConfig(source="street.mp4", start=0, end=5, operations=[
+    ObjectDetectionOverlay(),
+])])
+edit.run_to_file("annotated.mp4")
 
 # Only people and cars, detect every frame, larger model for accuracy.
-annotated = ObjectDetectionOverlay(
-    class_filter=["person", "car"],
-    detection_interval=1,
-    model_size="s",
-).apply(video)
-
-annotated.save("annotated.mp4")
+edit = VideoEdit(segments=[SegmentConfig(source="street.mp4", start=0, end=5, operations=[
+    ObjectDetectionOverlay(
+        class_filter=["person", "car"],
+        detection_interval=1,
+        model_size="s",
+    ),
+])])
+edit.run_to_file("annotated.mp4")
 ```
 
 In a JSON editing plan (it is exposed in the LLM-facing schema):

--- a/docs/api/ai/transforms.md
+++ b/docs/api/ai/transforms.md
@@ -11,15 +11,19 @@ The underlying `FaceTracker` lives in
 
 ```python
 from videopython.ai import FaceTrackingCrop
-from videopython.base import Video
-
-video = Video.from_path("input.mp4")
+from videopython.editing import VideoEdit, SegmentConfig
 
 # Create vertical content from horizontal by tracking faces
-vertical = FaceTrackingCrop(target_aspect=(9, 16)).apply(video)
+edit = VideoEdit(segments=[SegmentConfig(source="input.mp4", start=0, end=5, operations=[
+    FaceTrackingCrop(target_aspect=(9, 16)),
+])])
+edit.run_to_file("vertical.mp4")
 
 # Headroom framing + bounded camera speed
-framed = FaceTrackingCrop(framing_rule="headroom", max_speed=0.1).apply(video)
+edit = VideoEdit(segments=[SegmentConfig(source="input.mp4", start=0, end=5, operations=[
+    FaceTrackingCrop(framing_rule="headroom", max_speed=0.1),
+])])
+edit.run_to_file("framed.mp4")
 ```
 
 ## FaceTrackingCrop

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -9,7 +9,7 @@ carries an ordered list of `Operation` instances to run against it.
 - One `operations` list per segment — transforms and effects are sequenced together.
 - `post_operations` runs against the concatenated result.
 - `validate()` is a dry-run via metadata; no frames are loaded.
-- `run()` returns a `Video` in memory; `run_to_file()` streams directly to disk.
+- `run_to_file()` streams directly to disk — the only execution engine.
 
 ## Quick Start
 
@@ -42,11 +42,7 @@ plan = {
 
 edit = VideoEdit.from_dict(plan)
 predicted = edit.validate()        # dry-run via VideoMetadata
-video = edit.run()                  # in-memory
-video.save("output.mp4")
-
-# Or stream directly to file (constant memory, any video length):
-edit.run_to_file("output.mp4", crf=20, preset="medium")
+edit.run_to_file("output.mp4", crf=20, preset="medium")  # streams to disk (constant memory, any video length)
 ```
 
 ## JSON Plan Format
@@ -146,17 +142,18 @@ downloading sources.
 Operations that need side-channel data (e.g. `silence_removal` and
 `add_subtitles` need a transcription) declare it via
 `requires: ClassVar[tuple[str, ...]]`. The runner picks matching keys out
-of the `context` dict and threads them into `apply` / `predict_metadata`:
+of the `context` dict and threads them into the streaming compile —
+`predict_metadata` and either the effect's `streaming_init` or the
+filter-compiled op's `FilterCtx.context`:
 
 ```python
 edit = VideoEdit.from_dict(plan)
-video = edit.run(context={"transcription": my_transcription})
 edit.run_to_file("out.mp4", context={"transcription": my_transcription})
 ```
 
-On both paths, time-based context values are re-based onto each cut
-segment's local timeline; on the streaming path the resolved values are
-delivered to the effect's `streaming_init`.
+Time-based context values are re-based onto each cut segment's local
+timeline, and the resolved values are delivered to the effect's
+`streaming_init`.
 
 ## Validation
 

--- a/docs/api/effects.md
+++ b/docs/api/effects.md
@@ -7,39 +7,47 @@ limits the effect to a sub-range of the video. See
 
 ## Usage
 
+Effects are not applied to a `Video` directly. They run only through the
+streaming engine: add the operation(s) to a `VideoEdit` and render with
+`run_to_file`. Each effect carries an optional `window` that limits it to
+a sub-range of the segment.
+
 ```python
-from videopython.base import Video, BoundingBox
+from videopython.base import BoundingBox
 from videopython.editing import (
+    VideoEdit, SegmentConfig,
     Blur, Zoom, ColorGrading, Vignette, KenBurns,
     Fade, VolumeAdjust, TextOverlay, TimeRange,
 )
 
-video = Video.from_path("input.mp4")
+edit = VideoEdit(segments=[SegmentConfig(source="input.mp4", start=0, end=5, operations=[
+    # Effect across the full segment:
+    Blur(mode="constant", iterations=50),
+    # Effect on a sub-range via the `window` field:
+    Blur(mode="constant", iterations=50, window=TimeRange(start=0.0, stop=2.0)),
+])])
+edit.run_to_file("output.mp4")
+```
 
-# Effect across the full duration:
-video = Blur(mode="constant", iterations=50).apply(video)
+The constructors below produce the operation objects to drop into a
+segment's `operations` list (as above) and render with `run_to_file`:
 
-# Effect on a sub-range via the `window` field:
-video = Blur(
-    mode="constant",
-    iterations=50,
-    window=TimeRange(start=0.0, stop=2.0),
-).apply(video)
-
-video = Zoom(zoom_factor=1.5, mode="in").apply(video)
-video = ColorGrading(brightness=0.1, contrast=1.2, saturation=1.1).apply(video)
-video = Vignette(strength=0.5, radius=0.8).apply(video)
+```python
+video_op = Blur(mode="constant", iterations=50)
+video_op = Blur(mode="constant", iterations=50, window=TimeRange(start=0.0, stop=2.0))
+video_op = Zoom(zoom_factor=1.5, mode="in")
+video_op = ColorGrading(brightness=0.1, contrast=1.2, saturation=1.1)
+video_op = Vignette(strength=0.5, radius=0.8)
 
 start_region = BoundingBox(x=0.0, y=0.0, width=0.5, height=0.5)
 end_region = BoundingBox(x=0.5, y=0.5, width=0.5, height=0.5)
-video = KenBurns(start_region=start_region, end_region=end_region,
-                 easing="ease_in_out").apply(video)
+video_op = KenBurns(start_region=start_region, end_region=end_region,
+                    easing="ease_in_out")
 
-video = Fade(mode="in", duration=1.0).apply(video)
-video = Fade(mode="out", duration=0.5).apply(video)
-video = VolumeAdjust(volume=0.0, window=TimeRange(stop=2.0)).apply(video)  # mute first 2s
-video = TextOverlay(text="Hello World", position=(0.5, 0.9),
-                    font_size=48).apply(video)
+video_op = Fade(mode="in", duration=1.0)
+video_op = Fade(mode="out", duration=0.5)
+video_op = VolumeAdjust(volume=0.0, window=TimeRange(stop=2.0))  # mute first 2s
+video_op = TextOverlay(text="Hello World", position=(0.5, 0.9), font_size=48)
 
 # YouTube / experimental effects:
 from videopython.editing import (
@@ -47,28 +55,31 @@ from videopython.editing import (
     FilmGrain, Sharpen, Pixelate, MirrorFlip, Kaleidoscope,
 )
 
-video = Shake(intensity_px=6, mode="rhythmic", frequency_hz=4).apply(video)
-video = PunchIn(zoom_factor=1.5, attack_frames=3, release_frames=0).apply(video)
-video = Flash(color=(255, 255, 255), peak_alpha=1.0,
-              attack_frames=2, decay_frames=4,
-              window=TimeRange(start=1.0, stop=1.3)).apply(video)
-video = ChromaticAberration(shift_px=4, mode="radial").apply(video)
-video = Glitch(intensity=0.4, slice_count=12, seed=42).apply(video)
-video = FilmGrain(intensity=0.08, monochrome=True).apply(video)
-video = Sharpen(amount=1.0, kernel_size=5).apply(video)
-video = Pixelate(block_size=24,
-                 region=BoundingBox(x=0.4, y=0.2, width=0.2, height=0.2)).apply(video)
-video = MirrorFlip(mode="mirror_left").apply(video)
-video = Kaleidoscope(segments=6).apply(video)
+video_op = Shake(intensity_px=6, mode="rhythmic", frequency_hz=4)
+video_op = PunchIn(zoom_factor=1.5, attack_frames=3, release_frames=0)
+video_op = Flash(color=(255, 255, 255), peak_alpha=1.0,
+                 attack_frames=2, decay_frames=4,
+                 window=TimeRange(start=1.0, stop=1.3))
+video_op = ChromaticAberration(shift_px=4, mode="radial")
+video_op = Glitch(intensity=0.4, slice_count=12, seed=42)
+video_op = FilmGrain(intensity=0.08, monochrome=True)
+video_op = Sharpen(amount=1.0, kernel_size=5)
+video_op = Pixelate(block_size=24,
+                    region=BoundingBox(x=0.4, y=0.2, width=0.2, height=0.2))
+video_op = MirrorFlip(mode="mirror_left")
+video_op = Kaleidoscope(segments=6)
 ```
 
-Inside a `VideoEdit` plan, effects go in the segment's `operations`
-list. The `window` field travels inline as a nested object:
+A `SegmentConfig`'s `operations` list also accepts the inline dict form;
+the `window` field travels as a nested object:
 
 ```python
 {"op": "blur_effect", "mode": "constant", "iterations": 50,
  "window": {"start": 0.0, "stop": 2.0}}
 ```
+
+The subtitles effect (`add_subtitles`) requires a `transcription`
+context, passed to the runner: `run_to_file(..., context={"transcription": ...})`.
 
 ## Available Effects
 

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -11,10 +11,12 @@ discriminated-union schema for LLM-driven plan generation.
 
 ```python
 from typing import ClassVar, Literal
+
+import numpy as np
 from pydantic import Field
 
-from videopython.editing import Operation, OpCategory
-from videopython.base.video import Video, VideoMetadata
+from videopython.editing import Operation, OpCategory, FilterCtx
+from videopython.base.video import VideoMetadata
 
 
 class Resize(Operation):
@@ -32,10 +34,23 @@ class Resize(Operation):
     width: int | None = Field(None, gt=0)
     height: int | None = Field(None, gt=0)
 
-    def apply(self, video: Video) -> Video: ...
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata: ...
-    def to_ffmpeg_filter(self, ctx) -> str | None: ...   # streamable transforms only
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None: ...   # filter-compiled transforms
 ```
+
+There is **no** `apply()`. Operations execute only through `VideoEdit`'s
+streaming engine (`run_to_file`); they never run against a
+`Video` directly. A subclass implements:
+
+- `predict_metadata(self, meta) -> VideoMetadata` — predict the output
+  `VideoMetadata` and fail fast on plans that would crash at run time.
+  Defaults to identity (override on the base `Operation`; on `Effect` it
+  is identity, since effects preserve shape and frame count).
+- **either** `to_ffmpeg_filter(self, ctx)` (and `to_ffmpeg_audio_filter`
+  for a duration-changing transform's audio twin) — for ops compiled into
+  the ffmpeg filter chain — **or** `streaming_init(self, total_frames,
+  fps, width, height, **context)` + `process_frame(self, frame,
+  frame_index)` — for per-frame Python effects.
 
 Notes:
 
@@ -48,17 +63,20 @@ Notes:
   implementing `to_ffmpeg_filter`; for effects that means implementing
   `process_frame` and `streaming_init`.
 - Context-dependent ops declare
-  `requires: ClassVar[tuple[str, ...]] = ("transcription",)` and use a
-  wider `apply` signature (`def apply(self, video, transcription=None)`)
-  with `# type: ignore[override]`.
+  `requires: ClassVar[tuple[str, ...]] = ("transcription",)`. The runner
+  picks the matching keys out of the `context` dict passed to
+  `run_to_file(..., context=...)`, re-bases any time-based values onto the
+  segment's local timeline, and threads them into the effect's
+  `streaming_init` (and `predict_metadata`) as keyword arguments — or onto
+  the `FilterCtx.context` for a filter-compiled op.
 
 ## Effects
 
-`Effect(Operation)` adds a `window: TimeRange | None` field and a
-shape-and-frame-count-preserving invariant. Subclasses override
-`_apply(self, video)`; the base `Effect.apply` resolves the window,
-slices the video, runs `_apply`, splices the result back, and asserts
-the invariant.
+`Effect(Operation)` adds a `window: TimeRange | None` field and preserves
+shape and frame count (so its `predict_metadata` is identity). The
+streaming engine resolves `window` against the segment timeline, leaving
+frames outside the window untouched. A frame effect implements the
+`streaming_init` / `process_frame` pair:
 
 ```python
 class ColorGrading(Effect):
@@ -68,7 +86,7 @@ class ColorGrading(Effect):
     brightness: float = Field(0.0, ge=-1, le=1)
     # ... more fields ...
 
-    def _apply(self, video: Video) -> Video: ...
+    def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray: ...
 ```
 
 The `window` field on the wire:
@@ -77,9 +95,12 @@ The `window` field on the wire:
 {"op": "color_adjust", "brightness": 0.1, "window": {"start": 1.0, "stop": 3.0}}
 ```
 
-Audio-mutating effects (`Fade`, `VolumeAdjust`) override `apply` directly;
-`TranscriptionOverlay` overrides it to pipe frames through its libass
-filter.
+An effect can instead compile to a native ffmpeg filter by setting the
+`compiles_to_filter` property and implementing `to_ffmpeg_filter` (and,
+for audio-coupled effects like `Fade`/`VolumeAdjust`,
+`to_ffmpeg_audio_filter`). `TranscriptionOverlay` (`add_subtitles`) takes
+this path: it compiles its transcription to an ASS document and emits one
+libass `subtitles=` filter entry.
 
 ## Registry API
 

--- a/docs/api/text.md
+++ b/docs/api/text.md
@@ -20,24 +20,38 @@ Classes for handling transcriptions and burning subtitles onto video.
 
 ### TranscriptionOverlay
 
-Render transcriptions as subtitles with word-level highlighting:
+Render transcriptions as subtitles with word-level highlighting. The
+`add_subtitles` op (class `TranscriptionOverlay`) runs through the
+streaming engine, so it executes inside a `VideoEdit` rather than against
+a `Video` directly. It declares `requires=("transcription",)`; pass the
+transcription via the `context` argument to `run_to_file`:
 
 ```python
-from videopython.base import Video
-from videopython.editing import TranscriptionOverlay
+from videopython.editing import VideoEdit
 
-video = Video.from_path("input.mp4")
 # transcription = ... (from AudioToText or manually created)
 
-overlay = TranscriptionOverlay(
-    style="boxed",       # boxed | outline | clean | karaoke
-    region="bottom",     # top | center | bottom
-    font_scale=0.055,    # font height as a fraction of frame height
-    # font_filename is optional; omit it (or pass None) to use the
-    # bundled default font. Pass a path to use your own .ttf/.otf.
-    font_filename=None,
+edit = VideoEdit.from_dict(
+    {
+        "segments": [
+            {
+                "source": "input.mp4",
+                "start": 0.0,
+                "end": 5.0,
+                "operations": [
+                    {
+                        "op": "add_subtitles",
+                        "style": "boxed",   # boxed | outline | clean | karaoke
+                        "region": "bottom", # top | center | bottom
+                        "font_scale": 0.055,  # font height as a fraction of frame height
+                        # "font": "poppins-bold",  # optional bundled font; omit for default
+                    }
+                ],
+            }
+        ]
+    }
 )
-video = overlay.apply(video, transcription)
+edit.run_to_file("output.mp4", context={"transcription": transcription})
 ```
 
 Geometry is **resolution-independent** by default: `font_scale`/`region` are

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -6,19 +6,22 @@ count. See [Operations](operations.md) for the base contract.
 
 ## Usage
 
-```python
-from videopython.base import Video
-from videopython.editing import Resize, Crop, CutSeconds
+Transforms are not applied to a `Video` directly. They run only through
+the streaming engine: add the operation(s) to a `VideoEdit` and render
+with `run_to_file`.
 
-video = Video.from_path("input.mp4")
-video = CutSeconds(start=0.0, end=10.0).apply(video)
-video = Crop(width=0.5, height=0.5).apply(video)        # 50% center crop
-video = Resize(width=1280, height=720).apply(video)
-video.save("output.mp4")
+```python
+from videopython.editing import VideoEdit, SegmentConfig, Resize, Crop, CutSeconds
+
+edit = VideoEdit(segments=[SegmentConfig(source="input.mp4", start=0, end=10, operations=[
+    CutSeconds(start=0.0, end=10.0),
+    Crop(width=0.5, height=0.5),        # 50% center crop
+    Resize(width=1280, height=720),
+])])
+edit.run_to_file("output.mp4")
 ```
 
-Inside a `VideoEdit` plan, transforms go in the `operations` list with
-their fields inline:
+A `SegmentConfig`'s `operations` list also accepts the inline dict form:
 
 ```python
 plan = {
@@ -53,24 +56,27 @@ plan = {
 are treated as fractions of source dimensions; everything else is
 interpreted as a pixel count.
 
+Add any of these to a `VideoEdit` and render with `run_to_file`:
+
 ```python
 from videopython.editing import Crop, CropMode
 
-Crop(width=640, height=480).apply(video)                              # pixels
-Crop(width=0.5, height=0.5).apply(video)                              # 50% center crop
-Crop(width=0.5, height=1.0, x=0.5, y=0.0, mode=CropMode.CUSTOM).apply(video)
+video_op = Crop(width=640, height=480)                              # pixels
+video_op = Crop(width=0.5, height=0.5)                              # 50% center crop
+video_op = Crop(width=0.5, height=1.0, x=0.5, y=0.0, mode=CropMode.CUSTOM)
 ```
 
 ## Context-Dependent Transforms
 
-`SilenceRemoval` declares `requires = ("transcription",)`. Inside a
-`VideoEdit`, pass it via `context`; standalone, pass it directly to
-`apply`:
+`SilenceRemoval` declares `requires = ("transcription",)`. Add it to a
+segment's `operations` and pass the transcription to the runner via
+`context`:
 
 ```python
-edit.run(context={"transcription": my_transcription})
-# or
-SilenceRemoval().apply(video, transcription=my_transcription)
+edit = VideoEdit(segments=[SegmentConfig(source="input.mp4", start=0, end=10, operations=[
+    SilenceRemoval(),
+])])
+edit.run_to_file("out.mp4", context={"transcription": my_transcription})
 ```
 
 ## API Reference

--- a/docs/examples/ai-video.md
+++ b/docs/examples/ai-video.md
@@ -8,13 +8,23 @@ Generate images from text prompts, animate them into video segments, add AI-gene
 
 ## Full Example
 
+AI generation produces in-memory `Video` objects; narration is attached with
+`Video.add_audio`. Editing operations run only through the streaming engine, so
+each generated scene is saved to disk, then all scenes are assembled in a single
+`VideoEdit` plan (one `SegmentConfig` per scene) executed with `run_to_file`.
+The per-scene `operations` standardize resolution, and a `transition_in`
+crossfades each follow-on scene into the previous one:
+
 ```python
-from videopython.editing import Resize, Fade
-from videopython.editing.operation import TimeRange
+from pathlib import Path
+
+from videopython.editing import VideoEdit, SegmentConfig, TransitionSpec
+from videopython.editing.transforms import Resize
 from videopython.ai import TextToImage, ImageToVideo, TextToSpeech
+from videopython.base.video import VideoMetadata
 
 
-def create_ai_video():
+def create_ai_video(output_path: str, workdir: str = "scenes"):
     scenes = [
         {"image_prompt": "A serene mountain landscape at sunrise, photorealistic",
          "narration": "In the mountains, every sunrise brings new possibilities."},
@@ -28,25 +38,36 @@ def create_ai_video():
     video_gen = ImageToVideo()
     speech_gen = TextToSpeech()
 
-    videos = []
-    for scene in scenes:
+    # Generate each scene with narration and save it to disk.
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+    scene_paths = []
+    for i, scene in enumerate(scenes):
         image = image_gen.generate_image(scene["image_prompt"])
         video = video_gen.generate_video(image=image)
-        video = Resize(width=1920, height=1080).apply(video)
         audio = speech_gen.generate_audio(scene["narration"])
-        videos.append(video.add_audio(audio))
+        path = f"{workdir}/scene_{i}.mp4"
+        video.add_audio(audio).save(path)
+        scene_paths.append(path)
 
-    # Concatenate, with a 1s fade-in on each follow-on segment
-    final = videos[0]
-    for next_video in videos[1:]:
-        next_video = Fade(mode="in", duration=1.0,
-                          window=TimeRange(stop=1.0)).apply(next_video)
-        final = final + next_video
-    return final
+    # Assemble every scene into one streaming plan. Resize standardizes each
+    # scene to 1080p; a 1s dissolve crossfades each follow-on scene in (the
+    # first scene has no predecessor, so it carries no transition_in).
+    segments = []
+    for i, path in enumerate(scene_paths):
+        meta = VideoMetadata.from_path(path)
+        segments.append(SegmentConfig(
+            source=path,
+            start=0,
+            end=meta.total_seconds,
+            operations=[Resize(width=1920, height=1080)],
+            transition_in=None if i == 0 else TransitionSpec(type="dissolve", duration=1.0),
+        ))
+
+    edit = VideoEdit(segments=segments)
+    edit.run_to_file(output_path)
 
 
-video = create_ai_video()
-video.save("ai_generated.mp4")
+create_ai_video("ai_generated.mp4")
 ```
 
 ## Step-by-Step Breakdown
@@ -77,12 +98,44 @@ audio = speech_gen.generate_audio("Your narration text here")
 
 ### 4. Combine Segments
 
-```python
-from videopython.editing import Fade
-from videopython.editing.operation import TimeRange
+Saved scenes are assembled in a single streaming plan. Each scene is one
+`SegmentConfig`; a `transition_in` crossfades it into the previous scene (so the
+first scene carries none):
 
-next_video = Fade(mode="in", duration=1.0, window=TimeRange(stop=1.0)).apply(next_video)
-final = final + next_video
+```python
+from videopython.editing import VideoEdit, SegmentConfig, TransitionSpec
+from videopython.base.video import VideoMetadata
+
+segments = []
+for i, path in enumerate(scene_paths):
+    meta = VideoMetadata.from_path(path)
+    segments.append(SegmentConfig(
+        source=path,
+        start=0,
+        end=meta.total_seconds,
+        transition_in=None if i == 0 else TransitionSpec(type="dissolve", duration=1.0),
+    ))
+
+VideoEdit(segments=segments).run_to_file("ai_generated.mp4")
+```
+
+### 5. Reframe for Vertical (optional)
+
+To turn a horizontal scene into a vertical 9:16 clip, add the AI `face_crop`
+operation (the `FaceTrackingCrop` transform), which tracks the speaker's face
+and crops around it. It is just another entry in a segment's `operations` list:
+
+```python
+from videopython.editing import VideoEdit, SegmentConfig
+from videopython.ai.transforms import FaceTrackingCrop
+
+edit = VideoEdit(segments=[SegmentConfig(
+    source="scenes/scene_0.mp4",
+    start=0,
+    end=5,
+    operations=[FaceTrackingCrop(target_aspect=(9, 16), framing_rule="center")],
+)])
+edit.run_to_file("scene_0_vertical.mp4")
 ```
 
 ## Tips

--- a/docs/examples/auto-subtitles.md
+++ b/docs/examples/auto-subtitles.md
@@ -11,27 +11,34 @@ Take a video with speech, transcribe the audio using AI, and overlay synchronize
 ```python
 from videopython import Video
 from videopython.ai import AudioToText
-from videopython.editing import TranscriptionOverlay
+from videopython.editing import VideoEdit, SegmentConfig
+from videopython.editing.transcription_overlay import TranscriptionOverlay
 
 def add_subtitles(input_path: str, output_path: str):
-    # Load video
+    # Load the video and transcribe its audio.
     video = Video.from_path(input_path)
-
-    # Transcribe audio
     transcriber = AudioToText()
     transcription = transcriber.transcribe(video)
 
-    # Apply subtitle overlay. Geometry is resolution-independent by
-    # default, so the same overlay works at any output resolution.
-    overlay = TranscriptionOverlay(
-        style="boxed",      # color/border/background/highlight preset
-        region="bottom",    # top | center | bottom
-        font_scale=0.055,   # fraction of frame height (auto-scales)
-    )
-    video = overlay.apply(video, transcription)
+    # Build a streaming plan with the add_subtitles op (TranscriptionOverlay).
+    # Geometry is resolution-independent by default, so the same overlay works
+    # at any output resolution. A single segment covers the whole source.
+    edit = VideoEdit(segments=[SegmentConfig(
+        source=input_path,
+        start=0,
+        end=video.total_seconds,
+        operations=[
+            TranscriptionOverlay(
+                style="boxed",      # color/border/background/highlight preset
+                region="bottom",    # top | center | bottom
+                font_scale=0.055,   # fraction of frame height (auto-scales)
+            ),
+        ],
+    )])
 
-    # Save with burned-in subtitles
-    video.save(output_path)
+    # The op consumes the transcription via run_to_file's context; the runner
+    # re-bases it onto the segment's local timeline.
+    edit.run_to_file(output_path, context={"transcription": transcription})
 
 add_subtitles("interview.mp4", "interview_subtitled.mp4")
 ```
@@ -91,10 +98,21 @@ Key parameters (the recommended, resolution-independent surface):
     time. With the relative surface, `VideoEdit.validate()` also rejects an
     un-fittable plan up front instead of crashing mid-render.
 
-### 3. Apply Overlay
+### 3. Run the Plan
+
+The `TranscriptionOverlay` op (`add_subtitles`) declares `requires=("transcription",)`,
+so the transcription is passed through `run_to_file`'s `context` rather than to
+a constructor. The runner re-bases it onto each segment's local timeline before
+the op compiles it to a libass `subtitles=` filter:
 
 ```python
-video = overlay.apply(video, transcription)
+edit = VideoEdit(segments=[SegmentConfig(
+    source="interview.mp4",
+    start=0,
+    end=video.total_seconds,
+    operations=[overlay],
+)])
+edit.run_to_file("interview_subtitled.mp4", context={"transcription": transcription})
 ```
 
 The overlay renders each word at its exact timestamp, highlighting the current word being spoken.

--- a/docs/examples/social-clip.md
+++ b/docs/examples/social-clip.md
@@ -8,37 +8,43 @@ Take a landscape video, extract a segment, convert to vertical 9:16 format, add 
 
 ## Full Example
 
+Operations run only through the streaming engine, so the whole edit is a
+single `VideoEdit` plan executed with `run_to_file`. The 15s cut is the
+segment's `start`/`end`; standardizing, the landscape-to-vertical conversion,
+and the fade-in are the segment's `operations`:
+
 ```python
-from videopython.base import Video
-from videopython.editing import CutSeconds, Resize, Crop, ResampleFPS, Fade
-from videopython.editing.operation import TimeRange
-import numpy as np
+from videopython.editing import VideoEdit, SegmentConfig
+from videopython.editing.transforms import Resize, Crop, ResampleFPS
+from videopython.editing.effects import Fade
 
-# Load source video, then extract and standardize a 15s segment
-video = Video.from_path("raw_footage.mp4")
-video = CutSeconds(start=30, end=45).apply(video)
-video = ResampleFPS(fps=30).apply(video)
+# Extract a 15s segment (cut via start/end) and turn it into a vertical 9:16
+# clip: standardize fps, scale to the target height, center-crop the width,
+# then fade in over the first 0.5s.
+edit = VideoEdit(segments=[SegmentConfig(
+    source="raw_footage.mp4",
+    start=30.0,
+    end=45.0,
+    operations=[
+        ResampleFPS(fps=30),
+        Resize(height=1920),                      # scale to height, keep aspect
+        Crop(width=1080, height=1920, mode="center"),
+        Fade(mode="in", duration=0.5),
+    ],
+)])
 
-# Convert landscape to vertical (9:16):
-# scale to target height, then center-crop width
-height, width = video.frame_shape[:2]
-target_height = 1920
-target_width = 1080
-new_width = int(width * (target_height / height))
-video = Resize(width=new_width, height=target_height).apply(video)
-video = Crop(width=target_width, height=target_height).apply(video)  # center mode
+edit.validate()                       # dry run using VideoMetadata
+edit.run_to_file("social_clip.mp4")   # streams to disk
 
-# Fade in over the first 0.5s
-video = Fade(mode="in", duration=0.5, window=TimeRange(stop=0.5)).apply(video)
-
-# Mix background music
-video = video.add_audio_from_file("upbeat_music.mp3")
-video.save("social_clip.mp4")
+# To lay a music bed over the rendered clip, load it back and mix audio:
+# from videopython.base import Video
+# Video.from_path("social_clip.mp4").add_audio_from_file("upbeat_music.mp3").save("social_clip.mp4")
 ```
 
-## Same Plan via `VideoEdit`
+## Same Plan as a Dict
 
-For LLM-generated or UI-generated edits, use `VideoEdit`:
+For LLM-generated or UI-generated edits, build the same plan from a dict (the
+JSON wire format) instead of operation objects:
 
 ```python
 from videopython.editing import VideoEdit
@@ -52,16 +58,14 @@ plan = {
             {"op": "resample_fps", "fps": 30},
             {"op": "resize", "height": 1920},
             {"op": "crop", "width": 1080, "height": 1920, "mode": "center"},
-            {"op": "fade", "mode": "in", "duration": 0.5,
-             "window": {"stop": 0.5}},
+            {"op": "fade", "mode": "in", "duration": 0.5},
         ],
     }],
 }
 
 edit = VideoEdit.from_dict(plan)
 edit.validate()      # dry run using VideoMetadata
-final = edit.run().add_audio_from_file("upbeat_music.mp3")
-final.save("social_clip.mp4")
+edit.run_to_file("social_clip.mp4")   # streams to disk
 ```
 
 If you need a JSON Schema for plan generation/validation:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -29,23 +29,33 @@ print(video.frame_shape)  # (height, width, channels)
 
 ## Basic Transformations
 
-Every editing primitive is an `Operation`. Apply one to a `Video`:
+Every editing primitive is an `Operation`. Operations run only through the
+streaming engine, so you assemble them into a `VideoEdit` plan and execute it
+with `run_to_file`. A time cut is expressed as the segment's `start`/`end`,
+while resizing, fps resampling, and effects go in the segment's `operations`
+list:
 
 ```python
-from videopython.base import Video
-from videopython.editing import CutSeconds, Resize, ResampleFPS
+from videopython.editing import VideoEdit, SegmentConfig
+from videopython.editing.transforms import Resize, ResampleFPS
 
-video = Video.from_path("input.mp4")
-video = CutSeconds(start=0, end=10).apply(video)
-video = Resize(width=1280, height=720).apply(video)
-video = ResampleFPS(fps=30).apply(video)
-
-# Resize preserves aspect ratio when only one dimension is set:
-video = Resize(width=1280).apply(video)
+edit = VideoEdit(segments=[SegmentConfig(
+    source="input.mp4",
+    start=0,    # cut the first 10 seconds...
+    end=10,     # ...via the segment range, not a cut operation
+    operations=[
+        Resize(width=1280, height=720),
+        ResampleFPS(fps=30),
+    ],
+)])
+edit.run_to_file("output.mp4")
 ```
 
-For multi-step plans use `VideoEdit`, which also gives you a dry-run
-via `.validate()`:
+`Resize` preserves aspect ratio when only one dimension is set
+(e.g. `Resize(width=1280)`).
+
+`VideoEdit` also gives you a dry-run via `.validate()`, and accepts a plain
+dict (the JSON wire format) instead of operation objects:
 
 ```python
 from videopython.editing import VideoEdit
@@ -62,7 +72,7 @@ edit = VideoEdit.from_dict({
     }]
 })
 print(edit.validate())   # predicted VideoMetadata, no frames loaded
-video = edit.run()
+edit.run_to_file("output.mp4")
 ```
 
 ## Combining Videos

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -12,8 +12,7 @@ needing to learn the surface from examples.
    structured-output schema.
 2. **Validate** — call `edit.validate()` for a dry-run via metadata. No
    frames load.
-3. **Execute** — `edit.run()` returns a `Video`; `edit.run_to_file()`
-   streams directly to disk.
+3. **Execute** — `edit.run_to_file()` streams directly to disk.
 
 ```python
 from videopython.editing import VideoEdit
@@ -25,8 +24,7 @@ plan = call_your_llm(schema=schema,
 edit = VideoEdit.from_dict(plan)
 predicted = edit.validate()           # catches bad plans before any I/O
 print(predicted)
-video = edit.run()
-video.save("output.mp4")
+edit.run_to_file("output.mp4")
 ```
 
 ## Passing the Schema
@@ -79,7 +77,7 @@ response = client.messages.create(
 tool_block = next(b for b in response.content if b.type == "tool_use")
 edit = VideoEdit.from_dict(tool_block.input)
 edit.validate()
-edit.run().save("output.mp4")
+edit.run_to_file("output.mp4")
 ```
 
 ### OpenAI function calling
@@ -112,7 +110,7 @@ response = client.chat.completions.create(
 plan = json.loads(response.choices[0].message.tool_calls[0].function.arguments)
 edit = VideoEdit.from_dict(plan)
 edit.validate()
-edit.run().save("output.mp4")
+edit.run_to_file("output.mp4")
 ```
 
 ## Discovering Operations
@@ -271,15 +269,13 @@ out of the `context` dict and threads them into the op:
 ```python
 # silence_removal and add_subtitles both need a transcription
 edit = VideoEdit.from_dict(plan)
-video = edit.run(context={"transcription": transcription})
-# ... or stream to disk; context-requiring effects stream too
+# context-requiring effects stream too
 edit.run_to_file("out.mp4", context={"transcription": transcription})
 ```
 
 Time-based context values (e.g. a `Transcription` with source-absolute
 timestamps) are re-based onto each cut segment's local timeline
-automatically, on the streaming engine that backs both `run()` and
-`run_to_file()`.
+automatically, on the streaming engine that backs `run_to_file()`.
 
 Discover requires-aware ops via the registry:
 
@@ -306,7 +302,7 @@ schema = VideoEdit.json_schema()    # now includes face_crop
 - **Start with the schema.** Pass `VideoEdit.json_schema()` as the tool
   schema — it encodes all structural rules so the LLM doesn't need
   examples.
-- **Always validate.** Call `edit.validate()` before `edit.run()`.
+- **Always validate.** Call `edit.validate()` before `edit.run_to_file()`.
   Validation is fast and catches most errors.
 - **Use the error loop.** If validation fails, feed the error back to
   the LLM and ask it to fix the plan. Most issues correct in one retry.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,7 @@ edit = VideoEdit.from_dict({
          ]},
     ],
 })
-final = edit.run().add_audio_from_file("music.mp3")
-final.save("output.mp4")
+edit.run_to_file("output.mp4")
 ```
 
 <div class="feature-grid" markdown>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.43.1"
+version = "0.44.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_effects.py
+++ b/src/tests/ai/test_effects.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from videopython.ai.effects import ObjectDetectionOverlay
 from videopython.base.description import BoundingBox, DetectedObject
-from videopython.base.video import Video, VideoMetadata
+from videopython.base.video import VideoMetadata
 from videopython.editing.operation import Operation
 
 
@@ -50,33 +50,40 @@ class TestRegistrationAndSchema:
         assert (out.width, out.height, out.frame_count) == (640, 480, 60)
 
 
-class TestApply:
+def _stream(eff: ObjectDetectionOverlay, frames: np.ndarray, fps: float = 30.0) -> np.ndarray:
+    """Run an overlay over ``frames`` (T, H, W, 3) via the streaming contract."""
+    n, h, w = frames.shape[0], frames.shape[1], frames.shape[2]
+    eff.streaming_init(n, fps, w, h)
+    return np.stack([eff.process_frame(frames[i].copy(), i) for i in range(n)])
+
+
+class TestStreamingDraw:
     @patch("videopython.ai.effects.ObjectDetector")
     def test_apply_preserves_shape_and_draws(self, mock_cls):
         mock_cls.return_value = _mock_detector([_detection()])
-        video = Video.from_frames(np.zeros((5, 200, 200, 3), dtype=np.uint8), fps=30)
+        frames = np.zeros((5, 200, 200, 3), dtype=np.uint8)
 
-        out = ObjectDetectionOverlay().apply(video)
+        out = _stream(ObjectDetectionOverlay(), frames)
 
-        assert out.frame_shape == (200, 200, 3)
-        assert len(out.frames) == 5
-        assert out.frames.sum() > 0  # boxes were drawn
+        assert out.shape == (5, 200, 200, 3)
+        assert out.dtype == np.uint8
+        assert out.sum() > 0  # boxes were drawn
 
     @patch("videopython.ai.effects.ObjectDetector")
     def test_no_detections_is_noop(self, mock_cls):
         mock_cls.return_value = _mock_detector([])
-        video = Video.from_frames(np.zeros((4, 64, 64, 3), dtype=np.uint8), fps=30)
+        frames = np.zeros((4, 64, 64, 3), dtype=np.uint8)
 
-        out = ObjectDetectionOverlay().apply(video)
-        assert out.frames.sum() == 0
+        out = _stream(ObjectDetectionOverlay(), frames)
+        assert out.sum() == 0
 
     @patch("videopython.ai.effects.ObjectDetector")
     def test_detection_interval_controls_cadence(self, mock_cls):
         inst = _mock_detector([])
         mock_cls.return_value = inst
-        video = Video.from_frames(np.zeros((7, 64, 64, 3), dtype=np.uint8), fps=30)
+        frames = np.zeros((7, 64, 64, 3), dtype=np.uint8)
 
-        ObjectDetectionOverlay(detection_interval=3).apply(video)
+        _stream(ObjectDetectionOverlay(detection_interval=3), frames)
 
         # Frames 0, 3, 6 trigger detection; the rest reuse the cache.
         assert inst.detect.call_count == 3
@@ -84,9 +91,9 @@ class TestApply:
     @patch("videopython.ai.effects.ObjectDetector")
     def test_class_filter_passed_to_detector(self, mock_cls):
         mock_cls.return_value = _mock_detector([])
-        video = Video.from_frames(np.zeros((2, 64, 64, 3), dtype=np.uint8), fps=30)
+        frames = np.zeros((2, 64, 64, 3), dtype=np.uint8)
 
-        ObjectDetectionOverlay(class_filter=["person", "car"]).apply(video)
+        _stream(ObjectDetectionOverlay(class_filter=["person", "car"]), frames)
 
         _, kwargs = mock_cls.call_args
         assert kwargs["class_filter"] == ("person", "car")
@@ -95,9 +102,9 @@ class TestApply:
     @patch("videopython.ai.effects.ObjectDetector")
     def test_model_size_maps_to_weights(self, mock_cls):
         mock_cls.return_value = _mock_detector([])
-        video = Video.from_frames(np.zeros((1, 64, 64, 3), dtype=np.uint8), fps=30)
+        frames = np.zeros((1, 64, 64, 3), dtype=np.uint8)
 
-        ObjectDetectionOverlay(model_size="m").apply(video)
+        _stream(ObjectDetectionOverlay(model_size="m"), frames)
         _, kwargs = mock_cls.call_args
         assert kwargs["model_name"] == "yolov8m.pt"
 
@@ -116,20 +123,6 @@ class TestStreamingContract:
 
         assert eff.streamable is True
         assert eff.requires == ()  # stays in the streaming plan path
-
-    @patch("videopython.ai.effects.ObjectDetector")
-    def test_eager_matches_streaming(self, mock_cls):
-        # Shared mock instance -> deterministic detections on both paths.
-        mock_cls.return_value = _mock_detector([_detection()])
-        frames = np.zeros((6, 96, 96, 3), dtype=np.uint8)
-
-        eager = ObjectDetectionOverlay(detection_interval=2).apply(Video.from_frames(frames.copy(), fps=30))
-
-        eff = ObjectDetectionOverlay(detection_interval=2)
-        eff.streaming_init(6, 30.0, 96, 96)
-        streamed = np.stack([eff.process_frame(frames[i].copy(), i) for i in range(6)])
-
-        np.testing.assert_array_equal(eager.frames, streamed)
 
 
 class TestPlanValidation:

--- a/src/tests/ai/test_transforms.py
+++ b/src/tests/ai/test_transforms.py
@@ -10,7 +10,7 @@ from videopython.ai.transforms import (
     FaceTracker,
     FaceTrackingCrop,
 )
-from videopython.base.video import Video, VideoMetadata
+from videopython.base.video import VideoMetadata
 
 
 class MockBoundingBox:
@@ -260,24 +260,6 @@ class TestFaceTrackingCrop:
 
         assert positions == [(0, 0)]  # clamped at the left edge
 
-    @patch("videopython.ai.transforms.FaceTracker")
-    def test_apply_creates_correct_output_shape(self, mock_tracker_class):
-        """Test apply produces correct output dimensions."""
-        mock_tracker = MagicMock()
-        mock_tracker.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.15)
-        mock_tracker_class.return_value = mock_tracker
-
-        # Create test video 1920x1080, 10 frames
-        frames = np.zeros((10, 1080, 1920, 3), dtype=np.uint8)
-        video = Video.from_frames(frames, fps=30)
-
-        crop = FaceTrackingCrop(target_aspect=(9, 16))
-        result = crop.apply(video)
-
-        # Output should be 9:16 aspect ratio
-        out_h, out_w = result.frame_shape[:2]
-        assert abs(out_w / out_h - 9 / 16) < 0.01
-
     @pytest.mark.parametrize(
         "src_w, src_h, aspect",
         [
@@ -287,42 +269,41 @@ class TestFaceTrackingCrop:
             (1080, 1920, (16, 9)),
         ],
     )
-    @patch("videopython.ai.transforms.FaceTracker")
-    def test_predict_metadata_matches_apply(self, mock_tracker_class, src_w, src_h, aspect):
-        """Closes the validate/run gap precondition: the dry-run dimensions
-        must equal what apply() actually produces (was identity = a lie)."""
-        mock_tracker = MagicMock()
-        mock_tracker.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.15)
-        mock_tracker_class.return_value = mock_tracker
+    def test_predict_metadata_output_dims(self, src_w, src_h, aspect):
+        """The dry-run output dims are the fixed crop window the streaming filter
+        emits: the requested aspect ratio, even (ffmpeg requires it), and fitting
+        within the source. Everything but the dimensions is identity.
 
+        Asserts these invariants directly rather than re-deriving them via
+        ``_resolved_output_dims`` (which ``predict_metadata`` calls), so a bug in
+        that shared helper can actually surface here."""
         crop = FaceTrackingCrop(target_aspect=aspect)
-        video = Video.from_frames(np.zeros((4, src_h, src_w, 3), dtype=np.uint8), fps=30)
-        applied = crop.apply(video)
-
         meta = VideoMetadata(height=src_h, width=src_w, fps=30, frame_count=4, total_seconds=4 / 30)
         predicted = crop.predict_metadata(meta)
 
-        assert (predicted.width, predicted.height) == (applied.frame_shape[1], applied.frame_shape[0])
+        out_w, out_h = predicted.width, predicted.height
+        assert abs(out_w / out_h - aspect[0] / aspect[1]) < 0.02
+        assert out_w % 2 == 0 and out_h % 2 == 0
+        assert out_w <= src_w and out_h <= src_h
         # Identity for everything except dimensions.
         assert predicted.fps == meta.fps
         assert predicted.frame_count == meta.frame_count
         assert predicted.total_seconds == meta.total_seconds
 
     @patch("videopython.ai.transforms.FaceTracker")
-    def test_apply_with_fallback_center(self, mock_tracker_class):
-        """Test fallback to center when no face detected."""
+    def test_track_positions_fallback_center(self, mock_tracker_class):
+        """With no face detected, ``center`` fallback centers the crop window."""
         mock_tracker = MagicMock()
         mock_tracker.detect_and_track.return_value = None  # No face
         mock_tracker_class.return_value = mock_tracker
 
-        frames = np.zeros((10, 1080, 1920, 3), dtype=np.uint8)
-        video = Video.from_frames(frames, fps=30)
+        frames = [np.zeros((1080, 1920, 3), dtype=np.uint8)] * 10
 
         crop = FaceTrackingCrop(target_aspect=(9, 16), fallback="center")
-        result = crop.apply(video)
+        positions = crop._track_crop_positions(frames, 1920, 1080)
 
-        # Should still produce valid output
-        assert len(result.frames) == 10
+        # 9:16 of 1920x1080 -> 606x1080, centered: ((1920-606)//2, 0) = (657, 0).
+        assert positions == [(657, 0)] * 10
 
 
 class TestFaceTrackingCropFraming:
@@ -363,33 +344,18 @@ class TestFaceTrackingCropFraming:
         assert distance == pytest.approx(0.1, abs=0.01)
 
     @patch("videopython.ai.transforms.FaceTracker")
-    def test_apply_headroom_framing_creates_correct_output_shape(self, mock_tracker_class):
-        mock_tracker = MagicMock()
-        mock_tracker.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.15)
-        mock_tracker_class.return_value = mock_tracker
-
-        frames = np.zeros((10, 1080, 1920, 3), dtype=np.uint8)
-        video = Video.from_frames(frames, fps=30)
-
-        crop = FaceTrackingCrop(target_aspect=(9, 16), framing_rule="headroom", max_speed=0.1)
-        result = crop.apply(video)
-
-        out_h, out_w = result.frame_shape[:2]
-        assert abs(out_w / out_h - 9 / 16) < 0.01
-
-    @patch("videopython.ai.transforms.FaceTracker")
-    def test_apply_headroom_without_face_uses_fallback(self, mock_tracker_class):
+    def test_track_positions_headroom_without_face_uses_fallback(self, mock_tracker_class):
         mock_tracker = MagicMock()
         mock_tracker.detect_and_track.return_value = None
         mock_tracker_class.return_value = mock_tracker
 
-        frames = np.zeros((10, 1080, 1920, 3), dtype=np.uint8)
-        video = Video.from_frames(frames, fps=30)
+        frames = [np.zeros((1080, 1920, 3), dtype=np.uint8)] * 10
 
         crop = FaceTrackingCrop(target_aspect=(9, 16), framing_rule="headroom", fallback="center")
-        result = crop.apply(video)
+        positions = crop._track_crop_positions(frames, 1920, 1080)
 
-        assert len(result.frames) == 10
+        # No face -> centered crop regardless of framing rule: ((1920-606)//2, 0).
+        assert positions == [(657, 0)] * 10
 
 
 class TestGPUFaceTracking:
@@ -538,14 +504,13 @@ class TestGPUFaceTracking:
         mock_tracker.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.1)
         mock_tracker_class.return_value = mock_tracker
 
-        frames = np.zeros((5, 480, 640, 3), dtype=np.uint8)
-        video = Video.from_frames(frames, fps=30)
+        frames = [np.zeros((480, 640, 3), dtype=np.uint8)] * 5
 
         crop = FaceTrackingCrop(
             backend="gpu",
             sample_rate=5,
         )
-        crop.apply(video)
+        crop._track_crop_positions(frames, 640, 480)
 
         # Verify FaceTracker was created with GPU params
         call_kwargs = mock_tracker_class.call_args[1]

--- a/src/tests/base/test_transcription.py
+++ b/src/tests/base/test_transcription.py
@@ -1,22 +1,58 @@
+from typing import Any
+
 import numpy as np
 import pytest
 
 from tests.test_config import TEST_FONT_PATH
 from videopython.base.transcription import Transcription, TranscriptionSegment, TranscriptionWord
 from videopython.base.video import Video
+from videopython.editing import VideoEdit
 from videopython.editing.transcription_overlay import TranscriptionOverlay
 
+# Eager VideoEdit/TranscriptionOverlay.apply() is gone (0.44.0); subtitles only
+# exist on the streaming-to-file engine. These overlay tests therefore render a
+# real `add_subtitles` plan via `VideoEdit.run_to_file` and read the mp4 back.
+# This file lives in tests/base/, which has no editing `render` fixture, so the
+# helpers below build the run_to_file + Video.from_path round-trip inline. The
+# x264/AAC round-trip is lossy, so anything checked on decoded frames uses
+# mean-abs-diff tolerances, never exact equality.
 
-@pytest.fixture
-def dummy_video():
-    """Create a 10-second video with black frames.
+# Subtitle pixels drawn against the black source clear this fraction of pixels
+# changed by >50; codec bleed on a truly inactive frame stays well below it.
+_ACTIVE_PIXEL_FRACTION = 0.005
 
-    Function-scoped: ``TranscriptionOverlay.apply`` replays the streaming
-    contract via ``Effect._apply``, which (like every effect) mutates the
-    input frames in place, so a shared instance would leak overlays across
-    tests.
+
+@pytest.fixture(scope="session")
+def black_source(tmp_path_factory):
+    """Path to an 8s black source video on disk (read-only, shared).
+
+    `SegmentConfig.source` is a file path, so the in-memory black clip the old
+    eager tests used must be materialized once to disk for plans to cut from.
+    A pure-black source keeps subtitle pixels a clean, isolated signal against
+    near-zero re-encode noise.
     """
-    return Video.from_image(np.zeros((360, 640, 3), dtype=np.uint8), fps=30, length_seconds=10.0)
+    src = tmp_path_factory.mktemp("black_src") / "black.mp4"
+    Video.from_image(np.zeros((360, 640, 3), dtype=np.uint8), fps=30, length_seconds=8.0).save(src)
+    return str(src)
+
+
+def _subtitles_plan(source: str, operation: dict[str, Any], *, end: float = 6.0) -> VideoEdit:
+    """A single-segment plan cutting [0, end) from `source` with one add_subtitles op."""
+    return VideoEdit.model_validate(
+        {"segments": [{"source": source, "start": 0.0, "end": end, "operations": [operation]}]}
+    )
+
+
+def _plain_plan(source: str, *, end: float = 6.0) -> VideoEdit:
+    """The same cut with no operations -- the A/B reference for frame diffs."""
+    return VideoEdit.model_validate({"segments": [{"source": source, "start": 0.0, "end": end}]})
+
+
+def _render(plan: VideoEdit, tmp_path, name: str, *, transcription: Transcription | None = None) -> Video:
+    """Run a plan to file and load it back as a Video (the only execution engine)."""
+    context = {"transcription": transcription} if transcription is not None else None
+    out = plan.run_to_file(tmp_path / name, context=context)
+    return Video.from_path(str(out))
 
 
 @pytest.fixture(scope="session")
@@ -53,6 +89,27 @@ def dummy_transcription():
     return Transcription(segments=segments)
 
 
+@pytest.fixture(scope="session")
+def early_cue_transcription():
+    """One cue at 0.0-1.8s, then a long silent tail.
+
+    The frame-content tests need an inactive sampling point (~4s) that is far
+    enough from every cue that x264 inter-frame bleed from a nearby subtitle
+    does not leak into it. A single early cue gives an active frame at ~1s and a
+    provably blank frame at ~4s.
+    """
+    words = [
+        TranscriptionWord(start=0.0, end=0.5, word="Hello"),
+        TranscriptionWord(start=0.5, end=1.0, word="world"),
+        TranscriptionWord(start=1.0, end=1.2, word="this"),
+        TranscriptionWord(start=1.2, end=1.4, word="is"),
+        TranscriptionWord(start=1.4, end=1.8, word="test"),
+    ]
+    return Transcription(
+        segments=[TranscriptionSegment(start=0.0, end=1.8, text="Hello world this is test", words=words)]
+    )
+
+
 def test_transcription_overlay_initialization(dummy_transcription):
     """Test that TranscriptionOverlay can be initialized with default parameters."""
     overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH)
@@ -60,87 +117,94 @@ def test_transcription_overlay_initialization(dummy_transcription):
     assert overlay.font_filename == TEST_FONT_PATH
 
 
-def test_transcription_overlay_apply_basic(dummy_video, dummy_transcription):
-    """Test basic application of TranscriptionOverlay to a video."""
-    overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH, font_size=20)
+def test_transcription_overlay_render_preserves_shape_and_audio(black_source, dummy_transcription, tmp_path):
+    """A subtitled render keeps dimensions, fps, frame count, and the audio track.
 
-    result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
+    add_subtitles is a video-only libass filter, so the streamed output must
+    match a plain render of the same cut everywhere except the burned pixels.
+    """
+    op = {"op": "add_subtitles", "font_scale": 0.1, "font_filename": TEST_FONT_PATH}
+    subs = _render(_subtitles_plan(black_source, op), tmp_path, "subs.mp4", transcription=dummy_transcription)
+    plain = _render(_plain_plan(black_source), tmp_path, "plain.mp4")
 
-    # Check that the result is a Video object
-    assert isinstance(result_video, Video)
+    subs_meta, plain_meta = subs.metadata, plain.metadata
+    assert (subs_meta.width, subs_meta.height) == (plain_meta.width, plain_meta.height)
+    assert subs_meta.fps == plain_meta.fps
+    assert subs_meta.frame_count == plain_meta.frame_count
 
-    # Check that the video dimensions are preserved
-    assert result_video.frame_shape == dummy_video.frame_shape
-    assert result_video.fps == dummy_video.fps
-    assert len(result_video.frames) == len(dummy_video.frames)
-
-    # Check that audio is preserved
-    assert result_video.audio == dummy_video.audio
-
-
-def test_transcription_overlay_with_custom_settings(dummy_video, dummy_transcription):
-    """Test TranscriptionOverlay with custom text styling parameters."""
-    overlay = TranscriptionOverlay(
-        font_filename=TEST_FONT_PATH,
-        font_size=30,
-        text_color=(255, 0, 0),  # Red text
-        background_color=(0, 0, 0, 200),  # Black background with transparency
-        highlight_color=(0, 255, 0),  # Green highlight
-        position=(0.5, 0.8),
-        box_width=0.6,
-    )
-
-    result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
-
-    # Check that the overlay was applied (video should still have same basic properties)
-    assert isinstance(result_video, Video)
-    assert result_video.frame_shape == dummy_video.frame_shape
-    assert len(result_video.frames) == len(dummy_video.frames)
+    # Audio passes through untouched (video-only filter).
+    assert subs.audio.metadata.duration_seconds == plain.audio.metadata.duration_seconds
+    assert subs.audio.metadata.sample_rate == plain.audio.metadata.sample_rate
 
 
-def test_transcription_overlay_no_background(dummy_video, dummy_transcription):
-    """Test TranscriptionOverlay with no background color."""
-    overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH, background_color=None)
+def test_transcription_overlay_with_custom_settings(black_source, dummy_transcription, tmp_path):
+    """Custom styling fields still render end-to-end and preserve dimensions."""
+    op = {
+        "op": "add_subtitles",
+        "font_filename": TEST_FONT_PATH,
+        "font_size": 30,
+        "text_color": [255, 0, 0],  # Red text
+        "background_color": [0, 0, 0, 200],  # Black background with transparency
+        "highlight_color": [0, 255, 0],  # Green highlight
+        "position": [0.5, 0.8],
+        "box_width": 0.6,
+    }
+    subs = _render(_subtitles_plan(black_source, op), tmp_path, "subs.mp4", transcription=dummy_transcription)
+    plain = _render(_plain_plan(black_source), tmp_path, "plain.mp4")
 
-    result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
-
-    assert isinstance(result_video, Video)
-    assert len(result_video.frames) == len(dummy_video.frames)
-
-
-def test_transcription_overlay_frame_content_changes(dummy_video, dummy_transcription):
-    """Test that TranscriptionOverlay actually modifies frame content during active segments."""
-    overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH)
-
-    # apply() mutates frames in place (the Effect contract), so snapshot first.
-    original_frame_at_1s = dummy_video.frames[30].copy()  # 30fps * 1s = frame 30
-    original_frame_at_4s = dummy_video.frames[120].copy()  # 30fps * 4s = frame 120
-
-    result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
-
-    # Frame at timestamp 1.0 should have text overlay (within first segment 0.0-1.8)
-    assert not np.array_equal(result_video.frames[30], original_frame_at_1s)
-
-    # Frame at timestamp 4.0 should be unchanged (no active segment)
-    assert np.array_equal(result_video.frames[120], original_frame_at_4s)
+    assert subs.frame_shape == plain.frame_shape
+    assert len(subs.frames) == len(plain.frames)
 
 
-def test_transcription_overlay_defaults_font_when_none(dummy_video, dummy_transcription):
+def test_transcription_overlay_no_background(black_source, dummy_transcription, tmp_path):
+    """A subtitle render with the background disabled still produces a full clip."""
+    op = {"op": "add_subtitles", "font_filename": TEST_FONT_PATH, "background_color": None}
+    subs = _render(_subtitles_plan(black_source, op), tmp_path, "subs.mp4", transcription=dummy_transcription)
+    plain = _render(_plain_plan(black_source), tmp_path, "plain.mp4")
+
+    assert len(subs.frames) == len(plain.frames)
+
+
+def test_transcription_overlay_frame_content_changes(black_source, early_cue_transcription, tmp_path):
+    """Active-segment frames gain subtitle pixels; an inactive frame does not.
+
+    The eager path could assert exact equality on in-memory black frames; the
+    streaming engine round-trips through x264, so this compares the subtitled
+    render against a plain render of the same cut with mean-abs-diff tolerances.
+    """
+    op = {"op": "add_subtitles", "font_scale": 0.1, "font_filename": TEST_FONT_PATH}
+    subs = _render(_subtitles_plan(black_source, op), tmp_path, "subs.mp4", transcription=early_cue_transcription)
+    plain = _render(_plain_plan(black_source), tmp_path, "plain.mp4")
+
+    fps = subs.fps
+    active = subs.frames[round(1.0 * fps)].astype(int) - plain.frames[round(1.0 * fps)].astype(int)
+    inactive = subs.frames[round(4.0 * fps)].astype(int) - plain.frames[round(4.0 * fps)].astype(int)
+
+    # Active frame (cue 0.0-1.8s): a meaningful fraction of pixels lit up.
+    assert (np.abs(active) > 50).mean() > _ACTIVE_PIXEL_FRACTION, "no subtitle pixels drawn on the active frame"
+    # Inactive frame (~4s, far from any cue): unchanged within codec noise.
+    assert np.abs(inactive).mean() < 1.0
+
+
+def test_transcription_overlay_defaults_font_when_none(black_source, early_cue_transcription, tmp_path):
     """font_filename is optional: None renders with the bundled default font."""
     overlay = TranscriptionOverlay(font_size=20)
+    assert overlay.font_filename is None  # construction default preserved
 
-    assert overlay.font_filename is None
+    # No font_filename in the op -> the bundled default font is used. A larger
+    # font_scale keeps the rendered pixels a robust signal through x264.
+    op = {"op": "add_subtitles", "font_scale": 0.14}
+    subs = _render(_subtitles_plan(black_source, op), tmp_path, "subs.mp4", transcription=early_cue_transcription)
+    plain = _render(_plain_plan(black_source), tmp_path, "plain.mp4")
 
-    # apply() mutates frames in place (the Effect contract), so snapshot first.
-    original_at_1s = dummy_video.frames[30].copy()
-    original_at_4s = dummy_video.frames[120].copy()
-
-    result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
+    fps = subs.fps
+    active = subs.frames[round(1.0 * fps)].astype(int) - plain.frames[round(1.0 * fps)].astype(int)
+    inactive = subs.frames[round(4.0 * fps)].astype(int) - plain.frames[round(4.0 * fps)].astype(int)
 
     # Active segment (0.0-1.8): frame at 1s must be modified despite no font path.
-    assert not np.array_equal(result_video.frames[30], original_at_1s)
-    # Inactive region (~4s): frame unchanged.
-    assert np.array_equal(result_video.frames[120], original_at_4s)
+    assert (np.abs(active) > 50).mean() > _ACTIVE_PIXEL_FRACTION, "default font drew no subtitle pixels"
+    # Inactive region (~4s): unchanged within codec noise.
+    assert np.abs(inactive).mean() < 1.0
 
 
 def test_transcription_with_offset(dummy_transcription):
@@ -725,8 +789,14 @@ def test_overlay_normalization_defaults():
     assert overlay.capitalize is True
 
 
-def test_overlay_normalizes_long_lowercase_segment(dummy_video):
-    """A long lowercase single segment still renders end-to-end with defaults on."""
+def test_overlay_normalizes_long_lowercase_segment():
+    """Defaults chunk a long lowercase segment into cues and capitalize sentence starts.
+
+    The end-to-end render is dropped: the underlying transforms
+    (``chunk_segments`` / ``capitalize_sentences``) are exercised by their own
+    unit tests above, so this asserts the overlay's shared cue transform
+    (``_transform``) directly -- the exact data the libass compile path feeds.
+    """
     words = _lc_words(
         ("the", 0.0, 0.2),
         ("quick", 0.2, 0.4),
@@ -743,28 +813,26 @@ def test_overlay_normalizes_long_lowercase_segment(dummy_video):
             TranscriptionSegment(start=0.0, end=1.8, text="the quick brown fox jumps over the lazy dog", words=words)
         ]
     )
-    overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH, font_size=20)
+    overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH, font_size=20)  # defaults: 5 words/cue, capitalize
 
-    # apply() mutates frames in place (the Effect contract), so snapshot first.
-    original_at_1s = dummy_video.frames[30].copy()
-    original_at_4s = dummy_video.frames[120].copy()
+    result = overlay._transform(transcription)
 
-    result_video = overlay.apply(video=dummy_video, transcription=transcription)
-
-    assert isinstance(result_video, Video)
-    # Active region (~1s) is modified; inactive region (~4s) is untouched.
-    assert not np.array_equal(result_video.frames[30], original_at_1s)
-    assert np.array_equal(result_video.frames[120], original_at_4s)
+    # Chunked to <= 5 words/cue and the first word capitalized.
+    assert [s.text for s in result.segments] == ["The quick brown fox jumps", "over the lazy dog"]
+    assert all(len(s.words) <= overlay.max_words_per_cue for s in result.segments)
 
 
-def test_overlay_normalization_can_be_disabled(dummy_video, dummy_transcription):
-    """Disabling both knobs preserves source segmentation and casing without error."""
+def test_overlay_normalization_can_be_disabled(dummy_transcription):
+    """Disabling both knobs makes the cue transform an identity (source segmentation/casing kept)."""
     overlay = TranscriptionOverlay(font_filename=TEST_FONT_PATH, font_size=20, max_words_per_cue=None, capitalize=False)
 
-    result_video = overlay.apply(video=dummy_video, transcription=dummy_transcription)
+    result = overlay._transform(dummy_transcription)
 
-    assert isinstance(result_video, Video)
-    assert len(result_video.frames) == len(dummy_video.frames)
+    # No re-chunking and no re-casing: segments pass through verbatim.
+    assert [s.text for s in result.segments] == [s.text for s in dummy_transcription.segments]
+    assert [[w.word for w in s.words] for s in result.segments] == [
+        [w.word for w in s.words] for s in dummy_transcription.segments
+    ]
 
 
 def test_transcription_initialization_with_words():

--- a/src/tests/editing/conftest.py
+++ b/src/tests/editing/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures shared across editing tests."""
+
+import pytest
+
+from videopython.base.video import Video
+
+
+@pytest.fixture
+def render(tmp_path):
+    """Render a VideoEdit plan to a file and load it back as a ``Video``.
+
+    Streaming-to-file is the only execution engine, so a test that needs a
+    ``Video`` object runs the plan to disk and reads it back. Keyword arguments
+    (e.g. ``context=``) are forwarded to ``run_to_file``. Pass distinct
+    ``name=`` values when rendering more than one plan in a single test.
+    """
+
+    def _render(plan, *, name="out.mp4", **kwargs):
+        out = plan.run_to_file(tmp_path / name, **kwargs)
+        return Video.from_path(str(out))
+
+    return _render

--- a/src/tests/editing/test_audio_filter_graph.py
+++ b/src/tests/editing/test_audio_filter_graph.py
@@ -6,8 +6,8 @@ ffmpeg filter graph: the original source is a second ``-i`` input routed through
 ``to_ffmpeg_audio_filter`` twin (``atempo``/silence-splice/``atrim``+``concat``
 keep-windows/``volume`` envelope). These tests pin: per-op duration parity vs the old numpy
 twins, the native ``anullsrc`` silent-track contract, the single-invocation
-shape, ``run()`` vs ``run_to_file`` audio equivalence, and that ``run_to_file``
-never materialises a full-length source ``Audio`` array.
+shape, and that ``run_to_file`` never materialises a full-length source
+``Audio`` array.
 """
 
 from __future__ import annotations
@@ -57,27 +57,27 @@ class TestPerOpDurationParity:
     """The native af graph must produce the same output audio duration the old
     numpy twin did (which == the video duration), within the A/V tolerance."""
 
-    def test_speedup_atempo_matches_video(self, tmp_path, audio_source):
+    def test_speedup_atempo_matches_video(self, render, audio_source):
         plan = _plan([{"op": "speed_change", "speed": 2.0}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "speed.mp4")))
+        video = render(plan, name="speed.mp4")
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < TOL
 
-    def test_slowdown_atempo_chain_matches_video(self, tmp_path, audio_source):
+    def test_slowdown_atempo_chain_matches_video(self, render, audio_source):
         # 0.5x exercises the atempo chaining boundary shared with time_stretch.
         plan = _plan([{"op": "speed_change", "speed": 0.5}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "slow.mp4")))
+        video = render(plan, name="slow.mp4")
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < TOL
 
-    def test_adjust_audio_false_leaves_audio_unstretched(self, tmp_path, audio_source):
+    def test_adjust_audio_false_leaves_audio_unstretched(self, render, audio_source):
         # adjust_audio=False compiles to no atempo; the length pin still trims
         # the (untouched) audio to the predicted output duration.
         plan = _plan([{"op": "speed_change", "speed": 2.0, "adjust_audio": False}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "noadj.mp4")))
+        video = render(plan, name="noadj.mp4")
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < TOL
 
-    def test_freeze_silence_position_matches_eager_window(self, tmp_path, audio_source):
+    def test_freeze_silence_position_window(self, render, audio_source):
         plan = _plan([{"op": "freeze_frame", "timestamp": 1.0, "duration": 1.0}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "freeze.mp4")))
+        video = render(plan, name="freeze.mp4")
         sr = video.audio.metadata.sample_rate
         d = np.abs(video.audio.data)
         # The held window [1.0, 2.0) is the inserted silence; just before/after audible.
@@ -86,7 +86,7 @@ class TestPerOpDurationParity:
         assert inside < before * 0.2, f"freeze window not silent: {inside} vs {before}"
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < TOL
 
-    def test_silence_removal_keep_windows_match_video(self, tmp_path, audio_source):
+    def test_silence_removal_keep_windows_match_video(self, render, audio_source):
         tr = Transcription(
             words=[
                 TranscriptionWord(word="a", start=2.5, end=3.5),
@@ -95,12 +95,12 @@ class TestPerOpDurationParity:
             ]
         )
         plan = _plan([{"op": "silence_removal", "min_silence_duration": 1.0, "padding": 0.0}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "sr.mp4", context={"transcription": tr})))
+        video = render(plan, name="sr.mp4", context={"transcription": tr})
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < TOL
 
-    def test_fade_out_audio_decays(self, tmp_path, audio_source):
+    def test_fade_out_audio_decays(self, render, audio_source):
         plan = _plan([{"op": "fade", "mode": "out", "duration": 1.0}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "fade.mp4")))
+        video = render(plan, name="fade.mp4")
         sr = video.audio.metadata.sample_rate
         d = video.audio.data
         head = _rms(d[: int(0.5 * sr)])
@@ -108,19 +108,16 @@ class TestPerOpDurationParity:
         assert tail < head * 0.5, f"fade-out did not decay: head={head}, tail={tail}"
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < TOL
 
-    def test_windowed_fade_out_keeps_audio_after_window(self, tmp_path, audio_source):
+    def test_windowed_fade_out_keeps_audio_after_window(self, render, audio_source):
         # 6s segment, fade-out windowed to [1.0, 3.0]. After the window the audio
         # must return to full volume -- the regression: native afade held gain 0
         # for the whole tail, silencing audio while the video kept playing.
         win = {"start": 1.0, "stop": 3.0}
-        faded = Video.from_path(
-            str(
-                _plan([{"op": "fade", "mode": "out", "duration": 0.5, "window": win}], audio_source).run_to_file(
-                    tmp_path / "wf.mp4"
-                )
-            )
+        faded = render(
+            _plan([{"op": "fade", "mode": "out", "duration": 0.5, "window": win}], audio_source),
+            name="wf.mp4",
         )
-        plain = Video.from_path(str(_plan([], audio_source).run_to_file(tmp_path / "plain.mp4")))
+        plain = render(_plan([], audio_source), name="plain.mp4")
         sr = faded.audio.metadata.sample_rate
 
         def _region(v: Video, lo: float, hi: float) -> np.ndarray:
@@ -135,9 +132,9 @@ class TestPerOpDurationParity:
         plain_ramp = _rms(_region(plain, 2.6, 3.0))
         assert faded_ramp < 0.7 * plain_ramp, f"fade ramp did not attenuate: {faded_ramp} vs {plain_ramp}"
 
-    def test_volume_adjust_window_mutes_in_sync(self, tmp_path, audio_source):
+    def test_volume_adjust_window_mutes_in_sync(self, render, audio_source):
         plan = _plan([{"op": "volume_adjust", "volume": 0.0, "window": {"start": 2.0, "stop": 4.0}}], audio_source)
-        video = Video.from_path(str(plan.run_to_file(tmp_path / "vol.mp4")))
+        video = render(plan, name="vol.mp4")
         sr = video.audio.metadata.sample_rate
         d = np.abs(video.audio.data)
         inside = d[int(2.3 * sr) : int(3.7 * sr)].mean()
@@ -150,7 +147,7 @@ class TestPerOpDurationParity:
 
 
 class TestNoAudioSource:
-    def test_source_without_audio_gets_native_silent_track(self, tmp_path):
+    def test_source_without_audio_gets_native_silent_track(self, render):
         # SMALL_VIDEO_PATH has no audio stream -> anullsrc silence, not a Python
         # Audio.create_silent round-trip.
         assert (
@@ -160,8 +157,7 @@ class TestNoAudioSource:
             is False
         )
         plan = _plan([], SMALL_VIDEO_PATH)
-        out = plan.run_to_file(tmp_path / "silent.mp4")
-        video = Video.from_path(str(out))
+        video = render(plan, name="silent.mp4")
         # An AAC audio stream exists and is digitally silent.
         assert video.audio is not None
         assert video.audio.is_silent
@@ -217,27 +213,6 @@ class TestSingleInvocation:
         assert "-an" in cmd
         assert "-filter_complex" not in cmd
         assert cmd.count("-i") == 1
-
-
-# --------------------------------------------- run() vs run_to_file equivalence
-
-
-class TestRunPathEquivalence:
-    def test_run_and_run_to_file_audio_durations_match(self, tmp_path, audio_source):
-        ops = [{"op": "speed_change", "speed": 2.0}]
-        in_memory = _plan(ops, audio_source).run()
-        on_disk = Video.from_path(str(_plan(ops, audio_source).run_to_file(tmp_path / "eq.mp4")))
-        assert abs(in_memory.audio.metadata.duration_seconds - on_disk.audio.metadata.duration_seconds) < TOL
-        # Both track their own video duration.
-        assert abs(in_memory.audio.metadata.duration_seconds - in_memory.total_seconds) < TOL
-        assert abs(on_disk.audio.metadata.duration_seconds - len(on_disk.frames) / on_disk.fps) < TOL
-
-    def test_run_materializes_audio_for_no_audio_source(self):
-        # run() must still produce a (silent) Audio view for video.audio.
-        video = _plan([], SMALL_VIDEO_PATH).run()
-        assert video.audio is not None
-        assert video.audio.is_silent
-        assert abs(video.audio.metadata.duration_seconds - video.total_seconds) < TOL
 
 
 # ------------------------------------------------------- no eager audio decode

--- a/src/tests/editing/test_audio_ops.py
+++ b/src/tests/editing/test_audio_ops.py
@@ -2,8 +2,8 @@
 
 The music bed is NOT a per-segment op: it is a frozen ``MusicBed`` field on
 ``VideoEdit`` mixed under the WHOLE assembled program in a final ffmpeg ``amix``
-pass after concat / transitions. ``run`` and ``run_to_file`` share one
-``build_music_bed_filter_complex`` builder so they cannot diverge. Ducking is
+pass after concat / transitions, built by the shared
+``build_music_bed_filter_complex`` builder. Ducking is
 deterministic and transcription-derived (a ``volume=...:eval=frame`` automation
 over the shared ``speech_windows`` helper), single-segment only.
 
@@ -334,40 +334,38 @@ class TestMusicBedEndToEnd:
     def _plan(self, music_bed: dict[str, object]) -> VideoEdit:
         return VideoEdit.model_validate({"segments": [{**self.SEG}], "music_bed": music_bed})
 
-    def test_flat_bed_is_audible_under_silent_program(self, tmp_path, bed_wav):
+    def test_flat_bed_is_audible_under_silent_program(self, render, bed_wav):
         # The program is silent (no source audio), so the output RMS is the bed.
         plan = self._plan({"source": bed_wav, "gain": 0.8})
-        out = Video.from_path(str(plan.run_to_file(tmp_path / "flat.mp4")))
+        out = render(plan, name="flat.mp4")
         assert _rms(out.audio.data) > 0.05, "flat bed not audible in the mix"
         # The bed loops/trims to exactly the program timeline.
         assert abs(out.audio.metadata.duration_seconds - out.total_seconds) < 0.15
 
-    def test_bed_preserves_program_audio_level(self, tmp_path, bed_wav, voiced_source):
+    def test_bed_preserves_program_audio_level(self, render, bed_wav, voiced_source):
         # Attaching a bed must NOT attenuate the program audio. amix's default
         # normalize=1 divides every input by 2, halving the dialogue; normalize=0
         # passes the program through at full level. A silent (gain=0) bed must
         # therefore leave the program RMS unchanged (ratio ~1.0, not ~0.5).
         seg = {"source": voiced_source, "start": 0.0, "end": 4.0}
-        plain = VideoEdit.model_validate({"segments": [seg]}).run_to_file(tmp_path / "plain.mp4")
-        plain_rms = _rms(Video.from_path(str(plain)).audio.data)
-        with_bed = VideoEdit.model_validate(
-            {"segments": [seg], "music_bed": {"source": bed_wav, "gain": 0.0}}
-        ).run_to_file(tmp_path / "withbed.mp4")
-        bed_rms = _rms(Video.from_path(str(with_bed)).audio.data)
+        plain_rms = _rms(render(VideoEdit.model_validate({"segments": [seg]}), name="plain.mp4").audio.data)
+        with_bed = render(
+            VideoEdit.model_validate({"segments": [seg], "music_bed": {"source": bed_wav, "gain": 0.0}}),
+            name="withbed.mp4",
+        )
+        bed_rms = _rms(with_bed.audio.data)
         assert 0.8 < bed_rms / plain_rms < 1.25, f"bed attenuated the program: {bed_rms} vs {plain_rms}"
 
-    def test_duck_lowers_bed_under_speech_window(self, tmp_path, bed_wav):
+    def test_duck_lowers_bed_under_speech_window(self, render, bed_wav):
         # Speech at absolute [3, 4) -> segment-local [1, 2); the duck (with the
         # 0.15 padding) lowers the bed there and restores it away from speech.
         tr = Transcription(words=[TranscriptionWord(word="hello", start=3.0, end=4.0)])
-        ducked = Video.from_path(
-            str(
-                self._plan({"source": bed_wav, "gain": 0.8, "duck": 0.9}).run_to_file(
-                    tmp_path / "ducked.mp4", context={"transcription": tr}
-                )
-            )
+        ducked = render(
+            self._plan({"source": bed_wav, "gain": 0.8, "duck": 0.9}),
+            name="ducked.mp4",
+            context={"transcription": tr},
         )
-        flat = Video.from_path(str(self._plan({"source": bed_wav, "gain": 0.8}).run_to_file(tmp_path / "flat2.mp4")))
+        flat = render(self._plan({"source": bed_wav, "gain": 0.8}), name="flat2.mp4")
         sr = ducked.audio.metadata.sample_rate
 
         def region(v: Video, lo: float, hi: float) -> np.ndarray:
@@ -381,19 +379,21 @@ class TestMusicBedEndToEnd:
             f"flat bed should be louder than ducked under speech: {flat_in} vs {ducked_in}"
         )
 
-    def test_run_and_run_to_file_bed_mix_agree(self, tmp_path, bed_wav):
+    def test_run_to_file_bed_mix_agree(self, render, bed_wav):
         tr = Transcription(words=[TranscriptionWord(word="hello", start=3.0, end=4.0)])
         plan = self._plan({"source": bed_wav, "gain": 0.8, "duck": 0.9})
-        in_memory = plan.run(context={"transcription": tr})
-        on_disk = Video.from_path(str(plan.run_to_file(tmp_path / "eq.mp4", context={"transcription": tr})))
-        sr = in_memory.audio.metadata.sample_rate
+        # Streaming-to-file is the only engine now; render the same plan twice and
+        # confirm the duck is applied deterministically (shared builder).
+        first = render(plan, name="eq_a.mp4", context={"transcription": tr})
+        second = render(plan, name="eq_b.mp4", context={"transcription": tr})
+        sr = first.audio.metadata.sample_rate
 
         def region(v: Video, lo: float, hi: float) -> np.ndarray:
             return v.audio.data[round(lo * sr) : round(hi * sr)]
 
-        # Both paths duck the bed under the same window (shared builder).
-        mem_in, mem_away = _rms(region(in_memory, 1.3, 1.8)), _rms(region(in_memory, 3.0, 3.7))
-        disk_in, disk_away = _rms(region(on_disk, 1.3, 1.8)), _rms(region(on_disk, 3.0, 3.7))
-        assert mem_in < mem_away * 0.5
-        assert disk_in < disk_away * 0.5
-        assert abs(in_memory.audio.metadata.duration_seconds - on_disk.audio.metadata.duration_seconds) < 0.15
+        # Both renders duck the bed under the same window (shared builder).
+        first_in, first_away = _rms(region(first, 1.3, 1.8)), _rms(region(first, 3.0, 3.7))
+        second_in, second_away = _rms(region(second, 1.3, 1.8)), _rms(region(second, 3.0, 3.7))
+        assert first_in < first_away * 0.5
+        assert second_in < second_away * 0.5
+        assert abs(first.audio.metadata.duration_seconds - second.audio.metadata.duration_seconds) < 0.15

--- a/src/tests/editing/test_effects.py
+++ b/src/tests/editing/test_effects.py
@@ -3,10 +3,10 @@ import pytest
 from PIL import Image
 from pydantic import ValidationError
 
-from tests.test_config import TEST_FONT_PATH
-from videopython.audio import Audio, AudioMetadata
+from tests.test_config import SMALL_VIDEO_PATH, TEST_AUDIO_PATH, TEST_FONT_PATH
 from videopython.base.description import BoundingBox
 from videopython.base.video import Video, VideoMetadata
+from videopython.editing import VideoEdit
 from videopython.editing.effects import (
     Blur,
     ChromaticAberration,
@@ -29,7 +29,23 @@ from videopython.editing.effects import (
     VolumeAdjust,
     Zoom,
 )
-from videopython.editing.operation import TimeRange
+from videopython.editing.operation import Effect, FilterCtx, TimeRange
+
+
+def _stream(effect: Effect, video: Video) -> np.ndarray:
+    """Drive the streaming contract over ``video`` and return the stacked frames.
+
+    The eager ``Effect.apply`` path was removed -- ``streaming_init`` +
+    ``process_frame`` is the single source of truth for an effect's pixels, and
+    it produces bit-identical output (no codec). This mirrors the AI-effect
+    streaming template in ``tests/ai/test_effects.py``: init once with the
+    stream geometry, then process each frame in order. Frames are copied so an
+    in-place effect cannot mutate the caller's array.
+    """
+    frames = video.frames
+    n, h, w = frames.shape[0], frames.shape[1], frames.shape[2]
+    effect.streaming_init(n, video.fps, w, h)
+    return np.stack([effect.process_frame(frames[i].copy(), i) for i in range(n)])
 
 
 def _write_overlay(arr: np.ndarray, tmp_path) -> str:
@@ -48,72 +64,79 @@ def test_full_image_overlay_rgba(black_frames_test_video, tmp_path):
     overlay[:, :, 3] = 127
     source = _write_overlay(overlay, tmp_path)
 
-    original_shape = black_frames_test_video.video_shape
-    overlayed_video = FullImageOverlay(source=source).apply(black_frames_test_video)
+    out = _stream(FullImageOverlay(source=source), black_frames_test_video)
 
-    assert (overlayed_video.frames.flatten() == 127).all()
-    assert overlayed_video.video_shape == original_shape
+    assert (out.flatten() == 127).all()
+    assert out.shape == black_frames_test_video.video_shape
 
 
 def test_full_image_overlay_rgb(black_frames_test_video, tmp_path):
     overlay = 255 * np.ones(shape=black_frames_test_video.frame_shape, dtype=np.uint8)
     source = _write_overlay(overlay, tmp_path)
-    original_shape = black_frames_test_video.video_shape
-    original_audio_length = len(black_frames_test_video.audio)
-    overlayed_video = FullImageOverlay(source=source, alpha=0.5).apply(black_frames_test_video)
+    out = _stream(FullImageOverlay(source=source, alpha=0.5), black_frames_test_video)
 
-    assert (overlayed_video.frames.flatten() == 127).all()
-    assert overlayed_video.video_shape == original_shape
-    assert len(overlayed_video.audio) == original_audio_length
+    assert (out.flatten() == 127).all()
+    assert out.shape == black_frames_test_video.video_shape
 
 
 def test_full_image_overlay_with_fade(black_frames_test_video, tmp_path):
     overlay = 255 * np.ones(shape=black_frames_test_video.frame_shape, dtype=np.uint8)
     source = _write_overlay(overlay, tmp_path)
-    original_shape = black_frames_test_video.video_shape
-    overlayed_video = FullImageOverlay(source=source, alpha=0.5, fade_time=2.0).apply(black_frames_test_video)
+    out = _stream(FullImageOverlay(source=source, alpha=0.5, fade_time=2.0), black_frames_test_video)
 
-    assert overlayed_video.video_shape == original_shape
+    assert out.shape == black_frames_test_video.video_shape
 
 
 def test_zoom_in_out(small_video):
-    zoomed_in_video = Zoom(zoom_factor=2.0, mode="in").apply(small_video)
-    zoomed_out_video = Zoom(zoom_factor=2.0, mode="out").apply(small_video)
+    zoomed_in = _stream(Zoom(zoom_factor=2.0, mode="in"), small_video)
+    zoomed_out = _stream(Zoom(zoom_factor=2.0, mode="out"), small_video)
 
-    assert zoomed_in_video.video_shape == small_video.video_shape
-    assert zoomed_in_video.metadata.frame_count == small_video.metadata.frame_count
-
-    assert zoomed_out_video.video_shape == small_video.video_shape
-    assert zoomed_out_video.metadata.frame_count == small_video.metadata.frame_count
+    assert zoomed_in.shape == small_video.video_shape
+    assert zoomed_out.shape == small_video.video_shape
 
 
-def test_effect_window(small_video):
-    blur = Blur(mode="constant", iterations=10, window=TimeRange(start=6.0))
-    small_video_with_blur = blur.apply(small_video.copy())
-    assert (small_video.frames[0] == small_video_with_blur.frames[0]).all()
-    assert (small_video.frames[-1] != small_video_with_blur.frames[-1]).any()
+def test_effect_window(render):
+    """Canonical window check: frames outside an effect's ``window`` are untouched.
+
+    ``process_frame`` has no outer-timeline window concept -- the streaming
+    engine resolves the window and routes only in-window frames through the
+    effect. So the window is exercised end-to-end via a rendered plan: a Blur
+    windowed to the second half of a 0-4s cut. A pre-window frame must match the
+    un-windowed render (lossy x264, hence a tolerance) and an in-window frame
+    must visibly change. Broader window coverage lives in
+    ``test_streaming.py::TestStreamingEffects::test_effect_with_window``.
+    """
+    blur = {"op": "blur_effect", "mode": "constant", "iterations": 30, "window": {"start": 2.0}}
+    seg = {"source": SMALL_VIDEO_PATH, "start": 0.0, "end": 4.0}
+    blurred = render(VideoEdit.from_dict({"segments": [{**seg, "operations": [blur]}]}), name="blurred.mp4")
+    plain = render(VideoEdit.from_dict({"segments": [{**seg, "operations": []}]}), name="plain.mp4")
+
+    # Frame 0 is before the window (starts at 2.0s == frame 48): ~ unblurred source.
+    pre_diff = np.abs(blurred.frames[0].astype(int) - plain.frames[0].astype(int)).mean()
+    # The last frame (~3.96s) is inside the window: heavily blurred -> very different.
+    in_diff = np.abs(blurred.frames[-1].astype(int) - plain.frames[-1].astype(int)).mean()
+    assert pre_diff < 5.0, f"pre-window frame changed: {pre_diff}"
+    assert in_diff > pre_diff * 3, f"in-window frame not blurred: in={in_diff}, pre={pre_diff}"
 
 
 class TestColorGrading:
     def test_default_no_change(self, small_video):
-        original_shape = small_video.video_shape
-        result = ColorGrading().apply(small_video)
-        assert result.video_shape == original_shape
+        out = _stream(ColorGrading(), small_video)
+        assert out.shape == small_video.video_shape
 
     def test_brightness_increase(self, black_frames_test_video):
-        result = ColorGrading(brightness=0.5).apply(black_frames_test_video)
-        assert result.frames.mean() > 0
+        out = _stream(ColorGrading(brightness=0.5), black_frames_test_video)
+        assert out.mean() > 0
 
     def test_saturation_zero_grayscale(self, small_video):
-        result = ColorGrading(saturation=0.0).apply(small_video)
-        for frame in result.frames[:5]:
+        out = _stream(ColorGrading(saturation=0.0), small_video)
+        for frame in out[:5]:
             r, g, b = frame[:, :, 0], frame[:, :, 1], frame[:, :, 2]
             assert np.allclose(r, g, atol=5) or np.allclose(g, b, atol=5)
 
     def test_preserves_shape(self, small_video):
-        result = ColorGrading(brightness=0.1, contrast=1.2, saturation=0.8).apply(small_video)
-        assert result.video_shape == small_video.video_shape
-        assert result.frame_shape == small_video.frame_shape
+        out = _stream(ColorGrading(brightness=0.1, contrast=1.2, saturation=0.8), small_video)
+        assert out.shape == small_video.video_shape
 
     def test_invalid_params_raise(self):
         with pytest.raises(ValidationError):
@@ -125,29 +148,24 @@ class TestColorGrading:
         with pytest.raises(ValidationError):
             ColorGrading(temperature=2.0)
 
-    def test_windowed_application(self, small_video):
-        original_first = small_video.frames[0].copy()
-        result = ColorGrading(brightness=0.5, window=TimeRange(start=5.0)).apply(small_video.copy())
-        assert np.array_equal(result.frames[0], original_first)
-
 
 class TestVignette:
     def test_vignette_darkens_edges(self, black_frames_test_video):
         black_frames_test_video.frames[:] = 200
         h, w = black_frames_test_video.frames[0].shape[:2]
-        result = Vignette(strength=0.8, radius=1.0).apply(black_frames_test_video)
-        result_corner = float(result.frames[0][0, 0].mean())
-        result_center = float(result.frames[0][h // 2, w // 2].mean())
+        out = _stream(Vignette(strength=0.8, radius=1.0), black_frames_test_video)
+        result_corner = float(out[0][0, 0].mean())
+        result_center = float(out[0][h // 2, w // 2].mean())
         assert result_corner < result_center
 
     def test_preserves_shape(self, small_video):
-        result = Vignette(strength=0.5).apply(small_video)
-        assert result.video_shape == small_video.video_shape
+        out = _stream(Vignette(strength=0.5), small_video)
+        assert out.shape == small_video.video_shape
 
     def test_zero_strength_minimal_change(self, small_video):
         original_mean = small_video.frames.mean()
-        result = Vignette(strength=0.0).apply(small_video.copy())
-        assert abs(result.frames.mean() - original_mean) < 1
+        out = _stream(Vignette(strength=0.0), small_video)
+        assert abs(out.mean() - original_mean) < 1
 
     def test_invalid_params_raise(self):
         with pytest.raises(ValidationError):
@@ -157,46 +175,40 @@ class TestVignette:
         with pytest.raises(ValidationError):
             Vignette(radius=0.1)
 
-    def test_windowed_application(self, small_video):
-        original_first = small_video.frames[0].copy()
-        result = Vignette(strength=0.8, window=TimeRange(start=5.0)).apply(small_video.copy())
-        assert np.array_equal(result.frames[0], original_first)
-
 
 class TestKenBurns:
     def test_preserves_shape(self, small_video):
         start = BoundingBox(x=0.0, y=0.0, width=1.0, height=1.0)
         end = BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5)
-        result = KenBurns(start_region=start, end_region=end).apply(small_video)
-        assert result.video_shape == small_video.video_shape
-        assert result.frame_shape == small_video.frame_shape
+        out = _stream(KenBurns(start_region=start, end_region=end), small_video)
+        assert out.shape == small_video.video_shape
 
     def test_zoom_in_effect(self, black_frames_test_video):
         for i, frame in enumerate(black_frames_test_video.frames):
             frame[:] = i * 2
         start = BoundingBox(x=0.0, y=0.0, width=1.0, height=1.0)
         end = BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5)
-        result = KenBurns(start_region=start, end_region=end).apply(black_frames_test_video)
-        assert result.video_shape == black_frames_test_video.video_shape
+        out = _stream(KenBurns(start_region=start, end_region=end), black_frames_test_video)
+        assert out.shape == black_frames_test_video.video_shape
 
     def test_zoom_out_effect(self, black_frames_test_video):
         start = BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5)
         end = BoundingBox(x=0.0, y=0.0, width=1.0, height=1.0)
-        result = KenBurns(start_region=start, end_region=end).apply(black_frames_test_video)
-        assert result.video_shape == black_frames_test_video.video_shape
+        out = _stream(KenBurns(start_region=start, end_region=end), black_frames_test_video)
+        assert out.shape == black_frames_test_video.video_shape
 
     def test_pan_effect(self, small_video):
         start = BoundingBox(x=0.0, y=0.0, width=0.5, height=0.5)
         end = BoundingBox(x=0.5, y=0.5, width=0.5, height=0.5)
-        result = KenBurns(start_region=start, end_region=end).apply(small_video)
-        assert result.video_shape == small_video.video_shape
+        out = _stream(KenBurns(start_region=start, end_region=end), small_video)
+        assert out.shape == small_video.video_shape
 
     def test_easing_options(self, black_frames_test_video):
         start = BoundingBox(x=0.0, y=0.0, width=1.0, height=1.0)
         end = BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5)
         for easing in ["linear", "ease_in", "ease_out", "ease_in_out"]:
-            result = KenBurns(start_region=start, end_region=end, easing=easing).apply(black_frames_test_video.copy())
-            assert result.video_shape == black_frames_test_video.video_shape
+            out = _stream(KenBurns(start_region=start, end_region=end, easing=easing), black_frames_test_video)
+            assert out.shape == black_frames_test_video.video_shape
 
     def test_invalid_region_raises(self):
         valid = BoundingBox(x=0.0, y=0.0, width=0.5, height=0.5)
@@ -213,13 +225,6 @@ class TestKenBurns:
         with pytest.raises(ValidationError):
             KenBurns(start_region=start, end_region=end, easing="invalid")
 
-    def test_windowed_application(self, small_video):
-        original_first = small_video.frames[0].copy()
-        start = BoundingBox(x=0.0, y=0.0, width=1.0, height=1.0)
-        end = BoundingBox(x=0.25, y=0.25, width=0.5, height=0.5)
-        result = KenBurns(start_region=start, end_region=end, window=TimeRange(start=5.0)).apply(small_video.copy())
-        assert np.array_equal(result.frames[0], original_first)
-
 
 @pytest.fixture
 def video_1s():
@@ -228,66 +233,78 @@ def video_1s():
     return Video.from_frames(frames, fps=30)
 
 
-@pytest.fixture
-def video_with_audio():
-    """1-second video at 30fps with a sine wave audio track."""
-    frames = np.full((30, 64, 64, 3), 200, dtype=np.uint8)
-    video = Video.from_frames(frames, fps=30)
-    sample_rate = 44100
-    t = np.linspace(0, 1.0, sample_rate, dtype=np.float32)
-    audio_data = (np.sin(2 * np.pi * 440 * t) * 0.5).astype(np.float32)
-    video.audio = Audio(
-        data=audio_data,
-        metadata=AudioMetadata(
-            sample_rate=sample_rate,
-            channels=1,
-            sample_width=2,
-            duration_seconds=1.0,
-            frame_count=sample_rate,
-        ),
-    )
-    return video
-
-
 class TestFade:
     def test_fade_in_starts_black(self, video_1s):
-        result = Fade(mode="in", duration=0.5).apply(video_1s)
-        assert result.frames[0].mean() == 0
+        out = _stream(Fade(mode="in", duration=0.5), video_1s)
+        assert out[0].mean() == 0
 
     def test_fade_out_ends_black(self, video_1s):
-        result = Fade(mode="out", duration=0.5).apply(video_1s)
-        assert result.frames[-1].mean() == 0
+        out = _stream(Fade(mode="out", duration=0.5), video_1s)
+        assert out[-1].mean() == 0
 
     def test_fade_in_out(self, video_1s):
-        result = Fade(mode="in_out", duration=0.3).apply(video_1s)
-        assert result.frames[0].mean() == 0
-        assert result.frames[-1].mean() == 0
-        mid = len(result.frames) // 2
-        assert result.frames[mid].mean() > 100
+        out = _stream(Fade(mode="in_out", duration=0.3), video_1s)
+        assert out[0].mean() == 0
+        assert out[-1].mean() == 0
+        mid = len(out) // 2
+        assert out[mid].mean() > 100
 
     def test_preserves_shape(self, video_1s):
-        original_shape = video_1s.video_shape
-        result = Fade(mode="in", duration=0.5).apply(video_1s)
-        assert result.video_shape == original_shape
-
-    def test_windowed_apply(self, video_1s):
-        original_first = video_1s.frames[0].copy()
-        result = Fade(mode="out", duration=0.3, window=TimeRange(start=0.5)).apply(video_1s.copy())
-        assert np.array_equal(result.frames[0], original_first)
-
-    def test_audio_fade_in(self, video_with_audio):
-        result = Fade(mode="in", duration=0.5).apply(video_with_audio)
-        assert abs(result.audio.data[0]) < 0.01
-
-    def test_audio_fade_out(self, video_with_audio):
-        result = Fade(mode="out", duration=0.5).apply(video_with_audio)
-        assert abs(result.audio.data[-1]) < 0.01
+        out = _stream(Fade(mode="in", duration=0.5), video_1s)
+        assert out.shape == video_1s.video_shape
 
     def test_all_curves(self, video_1s):
         for curve in ("sqrt", "linear", "exponential"):
-            result = Fade(mode="in", duration=0.3, curve=curve).apply(video_1s.copy())
-            assert result.frames[0].mean() == 0
-            assert result.video_shape == video_1s.video_shape
+            out = _stream(Fade(mode="in", duration=0.3, curve=curve), video_1s)
+            assert out[0].mean() == 0
+            assert out.shape == video_1s.video_shape
+
+    def test_audio_fade_in_compiles_leading_ramp(self):
+        # The eager numpy audio twin is gone -- the fade's gain envelope now
+        # compiles to a windowed `volume` expression. A fade-in ramps from 0 at
+        # t=0 (the `between(t,0,...)` term) up to 1, the audio analogue of
+        # process_frame starting at a black frame.
+        ctx = FilterCtx(width=64, height=64, fps=30.0, frame_count=30, audio_label="f0")
+        frag = Fade(mode="in", duration=0.5).to_ffmpeg_audio_filter(ctx)
+        assert frag is not None
+        assert frag.startswith("volume=volume=") and ":eval=frame" in frag
+        assert "between(t,0.000000,0.500000)" in frag
+        assert "sqrt((t-0.000000)/0.500000)" in frag  # default sqrt curve
+
+    def test_audio_fade_out_compiles_trailing_ramp(self):
+        # Fade-out ramps to 0 over the last `duration` of the clip (1.0s here),
+        # the audio twin of process_frame ending on a black frame.
+        ctx = FilterCtx(width=64, height=64, fps=30.0, frame_count=30, audio_label="f0")
+        frag = Fade(mode="out", duration=0.5).to_ffmpeg_audio_filter(ctx)
+        assert frag is not None
+        assert "between(t,0.500000,1.000000)" in frag  # trailing ramp [stop-dur, stop]
+        assert "sqrt((1.000000-t)/0.500000)" in frag
+
+    def test_audio_fade_render_decays(self, render, tmp_path):
+        # Coarse end-to-end sanity that the compiled envelope actually attenuates
+        # the rendered audio tail (lossy AAC -> RMS comparison, not exact). The
+        # small test video is silent, so an audible track is muxed in first.
+        source = str(
+            Video.from_path(SMALL_VIDEO_PATH).add_audio_from_file(TEST_AUDIO_PATH).save(tmp_path / "with_audio.mp4")
+        )
+        plan = VideoEdit.from_dict(
+            {
+                "segments": [
+                    {
+                        "source": source,
+                        "start": 0.0,
+                        "end": 3.0,
+                        "operations": [{"op": "fade", "mode": "out", "duration": 1.0}],
+                    }
+                ]
+            }
+        )
+        video = render(plan, name="fade_render.mp4")
+        sr = video.audio.metadata.sample_rate
+        head = float(np.sqrt(np.mean(video.audio.data[: int(0.5 * sr)] ** 2)))
+        tail = float(np.sqrt(np.mean(video.audio.data[-int(0.3 * sr) :] ** 2)))
+        assert tail < head * 0.5, f"fade-out did not decay: head={head}, tail={tail}"
+        assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < 0.15
 
     def test_invalid_mode_raises(self):
         with pytest.raises(ValidationError):
@@ -299,38 +316,44 @@ class TestFade:
 
 
 class TestVolumeAdjust:
-    def test_mute(self, video_with_audio):
-        result = VolumeAdjust(volume=0.0).apply(video_with_audio)
-        assert np.allclose(result.audio.data, 0.0)
+    def _ctx(self, frame_count=30, fps=30.0):
+        return FilterCtx(width=64, height=64, fps=fps, frame_count=frame_count, audio_label="f0")
 
-    def test_unchanged(self, video_with_audio):
-        original_audio = video_with_audio.audio.data.copy()
-        result = VolumeAdjust(volume=1.0).apply(video_with_audio)
-        assert np.allclose(result.audio.data, original_audio)
+    def test_mute_compiles_zero_gain(self):
+        frag = VolumeAdjust(volume=0.0).to_ffmpeg_audio_filter(self._ctx())
+        assert frag is not None
+        assert frag.startswith("volume=0.000000:enable=")
 
-    def test_half_volume(self, video_with_audio):
-        original_rms = np.sqrt(np.mean(video_with_audio.audio.data**2))
-        result = VolumeAdjust(volume=0.5).apply(video_with_audio)
-        new_rms = np.sqrt(np.mean(result.audio.data**2))
-        assert np.isclose(new_rms, original_rms * 0.5, atol=0.01)
+    def test_unchanged_is_noop(self):
+        # volume == 1 with no ramp is a no-op -> no audio filter compiled.
+        assert VolumeAdjust(volume=1.0).to_ffmpeg_audio_filter(self._ctx()) is None
 
-    def test_windowed_apply(self, video_with_audio):
-        original_start = video_with_audio.audio.data[:100].copy()
-        result = VolumeAdjust(volume=0.0, window=TimeRange(start=0.5)).apply(video_with_audio)
-        assert np.allclose(result.audio.data[:100], original_start)
+    def test_half_volume_compiles_multiplier(self):
+        frag = VolumeAdjust(volume=0.5).to_ffmpeg_audio_filter(self._ctx())
+        assert frag == "volume=0.500000:enable='between(t,0.000000,1.000000)'"
 
-    def test_ramp_duration(self, video_with_audio):
-        result = VolumeAdjust(volume=0.0, ramp_duration=0.1).apply(video_with_audio)
-        assert abs(result.audio.data[1000]) > 0.01
+    def test_windowed_apply_restricts_enable(self):
+        # The window restricts the `enable` predicate so the gain only applies
+        # within [start, stop); the old test asserted the pre-window samples were
+        # untouched, which the `between` predicate now encodes.
+        frag = VolumeAdjust(volume=0.0, window=TimeRange(start=0.5)).to_ffmpeg_audio_filter(self._ctx())
+        assert frag is not None
+        assert "between(t,0.500000,1.000000)" in frag
 
-    def test_frames_unchanged(self, video_with_audio):
-        original_frames = video_with_audio.frames.copy()
-        result = VolumeAdjust(volume=0.5).apply(video_with_audio)
-        assert np.array_equal(result.frames, original_frames)
+    def test_ramp_duration_compiles_piecewise(self):
+        # A ramp_duration makes the gain a per-frame piecewise expression that
+        # eases 1 -> volume and back, so the very start is not yet fully muted.
+        frag = VolumeAdjust(volume=0.0, ramp_duration=0.1).to_ffmpeg_audio_filter(self._ctx())
+        assert frag is not None
+        assert ":eval=frame" in frag
+        assert "sqrt((t-0.000000)/0.100000)" in frag
+
+    def test_frames_unchanged(self, video_1s):
+        # VolumeAdjust is pixel-passthrough: process_frame returns frames verbatim.
+        out = _stream(VolumeAdjust(volume=0.5), video_1s)
+        assert np.array_equal(out, video_1s.frames)
 
     def test_isinstance_effect(self):
-        from videopython.editing.effects import Effect
-
         assert isinstance(VolumeAdjust(), Effect)
 
     def test_invalid_volume_raises(self):
@@ -341,42 +364,32 @@ class TestVolumeAdjust:
         with pytest.raises(ValidationError):
             VolumeAdjust(ramp_duration=-0.1)
 
-    def test_silent_audio_passthrough(self, video_1s):
-        result = VolumeAdjust(volume=0.5).apply(video_1s)
-        assert result.audio is not None
-
 
 class TestTextOverlay:
     def test_renders_text_on_black(self):
         frames = np.zeros((10, 100, 200, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=10)
-        result = TextOverlay(text="Hello", font_size=20, font_filename=TEST_FONT_PATH).apply(video)
-        assert result.frames.max() > 0
+        out = _stream(TextOverlay(text="Hello", font_size=20, font_filename=TEST_FONT_PATH), video)
+        assert out.max() > 0
 
     def test_preserves_shape(self, video_1s):
-        original_shape = video_1s.video_shape
-        result = TextOverlay(text="Test", font_size=16).apply(video_1s)
-        assert result.video_shape == original_shape
-
-    def test_windowed_apply(self, video_1s):
-        original_first = video_1s.frames[0].copy()
-        result = TextOverlay(text="Late", font_size=16, window=TimeRange(start=0.5)).apply(video_1s.copy())
-        assert np.array_equal(result.frames[0], original_first)
+        out = _stream(TextOverlay(text="Test", font_size=16), video_1s)
+        assert out.shape == video_1s.video_shape
 
     def test_multiline_text(self, video_1s):
-        result = TextOverlay(text="Line 1\nLine 2", font_size=16).apply(video_1s)
-        assert result.video_shape == video_1s.video_shape
+        out = _stream(TextOverlay(text="Line 1\nLine 2", font_size=16), video_1s)
+        assert out.shape == video_1s.video_shape
 
     def test_no_background(self):
         frames = np.full((5, 100, 200, 3), 128, dtype=np.uint8)
         video = Video.from_frames(frames, fps=10)
-        result = TextOverlay(text="Hi", font_size=16, background_color=None).apply(video)
-        assert result.video_shape == video.video_shape
+        out = _stream(TextOverlay(text="Hi", font_size=16, background_color=None), video)
+        assert out.shape == video.video_shape
 
     def test_all_anchors(self, video_1s):
         for anchor in ("center", "top_left", "top_center", "bottom_center", "bottom_left", "bottom_right"):
-            result = TextOverlay(text="X", font_size=16, anchor=anchor).apply(video_1s.copy())
-            assert result.video_shape == video_1s.video_shape
+            out = _stream(TextOverlay(text="X", font_size=16, anchor=anchor), video_1s)
+            assert out.shape == video_1s.video_shape
 
     def test_empty_text_raises(self):
         with pytest.raises(ValidationError):
@@ -394,8 +407,8 @@ class TestTextOverlay:
         frames = np.zeros((5, 100, 200, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=10)
         long_text = "This is a very long text that should definitely wrap to multiple lines"
-        result = TextOverlay(text=long_text, font_size=16, max_width=0.5, font_filename=TEST_FONT_PATH).apply(video)
-        assert result.frames.max() > 0
+        out = _stream(TextOverlay(text=long_text, font_size=16, max_width=0.5, font_filename=TEST_FONT_PATH), video)
+        assert out.max() > 0
 
 
 class TestImageOverlay:
@@ -409,68 +422,55 @@ class TestImageOverlay:
         # white overlay, alpha 127, on black -> ~127 where pasted, black elsewhere
         video = Video.from_frames(np.zeros((4, 80, 80, 3), dtype=np.uint8), fps=10)
         src = self._solid_overlay(tmp_path, 40, 40, rgb=(255, 255, 255), a=127)
-        result = ImageOverlay(source=src, scale=0.5, anchor="top_left", position=(0.0, 0.0)).apply(video)
-        assert np.allclose(result.frames[0][:40, :40], 127, atol=1)
-        assert result.frames[0][50:, 50:].max() == 0
+        out = _stream(ImageOverlay(source=src, scale=0.5, anchor="top_left", position=(0.0, 0.0)), video)
+        assert np.allclose(out[0][:40, :40], 127, atol=1)
+        assert out[0][50:, 50:].max() == 0
 
     def test_opacity_scales_blend(self, tmp_path):
         video = Video.from_frames(np.zeros((3, 60, 60, 3), dtype=np.uint8), fps=10)
         src = self._solid_overlay(tmp_path, 30, 30, rgb=(255, 255, 255), a=255)
-        full = ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), opacity=1.0).apply(
-            video.copy()
-        )
-        half = ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), opacity=0.5).apply(
-            video.copy()
-        )
-        assert full.frames[0][0, 0, 0] == 255
-        assert half.frames[0][0, 0, 0] == 127
+        full = _stream(ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), opacity=1.0), video)
+        half = _stream(ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), opacity=0.5), video)
+        assert full[0][0, 0, 0] == 255
+        assert half[0][0, 0, 0] == 127
 
     def test_resolution_independence(self, tmp_path):
         # Same op, two frame sizes -> overlay width is the same FRACTION of each.
         src = self._solid_overlay(tmp_path, 20, 20)
         small = Video.from_frames(np.zeros((2, 100, 100, 3), dtype=np.uint8), fps=10)
         large = Video.from_frames(np.zeros((2, 200, 200, 3), dtype=np.uint8), fps=10)
-        rs = ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)).apply(small)
-        rl = ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)).apply(large)
-        small_w = int((rs.frames[0][:, :, 0] == 255).any(axis=0).sum())
-        large_w = int((rl.frames[0][:, :, 0] == 255).any(axis=0).sum())
+        rs = _stream(ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)), small)
+        rl = _stream(ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)), large)
+        small_w = int((rs[0][:, :, 0] == 255).any(axis=0).sum())
+        large_w = int((rl[0][:, :, 0] == 255).any(axis=0).sum())
         assert small_w == 25
         assert large_w == 50
 
     def test_all_anchors_preserve_shape(self, video_1s, tmp_path):
         src = self._solid_overlay(tmp_path, 16, 16)
         for anchor in ("center", "top_left", "top_center", "bottom_center", "bottom_left", "bottom_right"):
-            result = ImageOverlay(source=src, scale=0.2, anchor=anchor).apply(video_1s.copy())
-            assert result.video_shape == video_1s.video_shape
+            out = _stream(ImageOverlay(source=src, scale=0.2, anchor=anchor), video_1s)
+            assert out.shape == video_1s.video_shape
 
     def test_off_frame_is_noop(self, tmp_path):
         # bottom_right anchor at (0, 0) places the whole box off the top-left -> no-op, no raise.
         original = np.full((3, 50, 50, 3), 70, dtype=np.uint8)
         video = Video.from_frames(original.copy(), fps=10)
         src = self._solid_overlay(tmp_path, 20, 20)
-        result = ImageOverlay(source=src, scale=0.3, anchor="bottom_right", position=(0.0, 0.0)).apply(video)
-        assert np.array_equal(result.frames, original)
-
-    def test_window_restricts_effect(self, tmp_path):
-        video = Video.from_frames(np.zeros((20, 40, 40, 3), dtype=np.uint8), fps=10)
-        src = self._solid_overlay(tmp_path, 40, 40, rgb=(255, 255, 255), a=255)
-        result = ImageOverlay(
-            source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), window=TimeRange(start=1.0)
-        ).apply(video)
-        assert result.frames[0].max() == 0  # before window: untouched
-        assert result.frames[-1].min() == 255  # inside window: fully overlaid
+        out = _stream(ImageOverlay(source=src, scale=0.3, anchor="bottom_right", position=(0.0, 0.0)), video)
+        assert np.array_equal(out, original)
 
     def test_preserves_shape(self, video_1s, tmp_path):
         src = self._solid_overlay(tmp_path, 24, 24)
-        result = ImageOverlay(source=src, scale=0.3).apply(video_1s)
-        assert result.video_shape == video_1s.video_shape
+        out = _stream(ImageOverlay(source=src, scale=0.3), video_1s)
+        assert out.shape == video_1s.video_shape
 
     def test_opaque_rgb_source_blends_by_opacity(self, tmp_path):
         # RGB (no alpha) source -> alpha treated as 255, so opacity alone drives the blend.
         src = _write_overlay(255 * np.ones((20, 20, 3), dtype=np.uint8), tmp_path)
         video = Video.from_frames(np.zeros((2, 40, 40, 3), dtype=np.uint8), fps=10)
-        result = ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), opacity=0.5).apply(video)
-        assert result.frames[0][0, 0, 0] == 127
+        out = _stream(ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0), opacity=0.5), video)
+        assert out[0][0, 0, 0] == 127
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -511,7 +511,7 @@ class TestImageOverlay:
     def test_svg_rasterized_at_target_resolution(self, tmp_path):
         src = self._write_svg(tmp_path, '<rect width="100" height="40" fill="rgb(0,128,255)"/>')
         video = Video.from_frames(np.zeros((2, 120, 200, 3), dtype=np.uint8), fps=10)
-        f = ImageOverlay(source=src, scale=0.5, anchor="top_left", position=(0.0, 0.0)).apply(video).frames[0]
+        f = _stream(ImageOverlay(source=src, scale=0.5, anchor="top_left", position=(0.0, 0.0)), video)[0]
         # Width is exactly the target box (0.5 * 200) and the fill is the exact
         # SVG color -> rendered at target, not an upscaled/blurred bitmap.
         assert int((f[:, :, 2] == 255).any(axis=0).sum()) == 100
@@ -521,15 +521,15 @@ class TestImageOverlay:
         src = self._write_svg(tmp_path, '<rect width="100" height="40" fill="rgb(0,128,255)"/>')
         small = Video.from_frames(np.zeros((2, 120, 200, 3), dtype=np.uint8), fps=10)
         large = Video.from_frames(np.zeros((2, 240, 400, 3), dtype=np.uint8), fps=10)
-        rs = ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)).apply(small)
-        rl = ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)).apply(large)
-        assert int((rs.frames[0][:, :, 2] == 255).any(axis=0).sum()) == 50  # 0.25 * 200
-        assert int((rl.frames[0][:, :, 2] == 255).any(axis=0).sum()) == 100  # 0.25 * 400
+        rs = _stream(ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)), small)
+        rl = _stream(ImageOverlay(source=src, scale=0.25, anchor="top_left", position=(0.0, 0.0)), large)
+        assert int((rs[0][:, :, 2] == 255).any(axis=0).sum()) == 50  # 0.25 * 200
+        assert int((rl[0][:, :, 2] == 255).any(axis=0).sum()) == 100  # 0.25 * 400
 
     def test_svg_transparent_background(self, tmp_path):
         src = self._write_svg(tmp_path, '<circle cx="50" cy="20" r="18" fill="red"/>', name="dot.svg")
         video = Video.from_frames(np.full((2, 80, 80, 3), 90, dtype=np.uint8), fps=10)
-        f = ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0)).apply(video).frames[0]
+        f = _stream(ImageOverlay(source=src, scale=1.0, anchor="top_left", position=(0.0, 0.0)), video)[0]
         assert np.array_equal(f[0, 0], [90, 90, 90])  # corner outside the dot: transparent -> untouched
         assert f[:, :, 0].max() > 150  # the red dot is composited
 
@@ -562,28 +562,28 @@ def synthetic_color_video():
 class TestShake:
     def test_random_changes_frames(self, synthetic_color_video):
         original = synthetic_color_video.frames.copy()
-        result = Shake(intensity_px=4.0, mode="random", seed=7).apply(synthetic_color_video.copy())
-        assert result.video_shape == synthetic_color_video.video_shape
-        assert not np.array_equal(result.frames, original)
+        out = _stream(Shake(intensity_px=4.0, mode="random", seed=7), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
+        assert not np.array_equal(out, original)
 
     def test_rhythmic_oscillates(self, synthetic_color_video):
-        result = Shake(intensity_px=4.0, mode="rhythmic", frequency_hz=4.0).apply(synthetic_color_video.copy())
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(Shake(intensity_px=4.0, mode="rhythmic", frequency_hz=4.0), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_decay_first_frame_changes_more_than_last(self):
         rng = np.random.default_rng(0)
         frames = rng.integers(0, 255, (30, 64, 64, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=30)
         original = video.frames.copy()
-        result = Shake(intensity_px=8.0, mode="decay", seed=1).apply(video)
-        diff_first = np.abs(result.frames[0].astype(int) - original[0].astype(int)).mean()
-        diff_last = np.abs(result.frames[-1].astype(int) - original[-1].astype(int)).mean()
+        out = _stream(Shake(intensity_px=8.0, mode="decay", seed=1), video)
+        diff_first = np.abs(out[0].astype(int) - original[0].astype(int)).mean()
+        diff_last = np.abs(out[-1].astype(int) - original[-1].astype(int)).mean()
         assert diff_first > diff_last
 
     def test_seed_reproducible(self, synthetic_color_video):
-        a = Shake(intensity_px=4.0, mode="random", seed=42).apply(synthetic_color_video.copy())
-        b = Shake(intensity_px=4.0, mode="random", seed=42).apply(synthetic_color_video.copy())
-        assert np.array_equal(a.frames, b.frames)
+        a = _stream(Shake(intensity_px=4.0, mode="random", seed=42), synthetic_color_video)
+        b = _stream(Shake(intensity_px=4.0, mode="random", seed=42), synthetic_color_video)
+        assert np.array_equal(a, b)
 
     def test_invalid_intensity_raises(self):
         with pytest.raises(ValidationError):
@@ -592,27 +592,27 @@ class TestShake:
 
 class TestPunchIn:
     def test_preserves_shape(self, synthetic_color_video):
-        result = PunchIn(zoom_factor=1.5, attack_frames=3).apply(synthetic_color_video)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(PunchIn(zoom_factor=1.5, attack_frames=3), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_attack_progression(self):
         frames = np.tile(np.arange(64, dtype=np.uint8)[:, None], (1, 64))
         frames = np.broadcast_to(frames[None, :, :, None], (12, 64, 64, 3)).copy()
         video = Video.from_frames(frames, fps=12)
         original = video.frames.copy()
-        result = PunchIn(zoom_factor=2.0, attack_frames=4).apply(video)
+        out = _stream(PunchIn(zoom_factor=2.0, attack_frames=4), video)
         # First frame should be untouched (zoom 1.0), middle frame zoomed in
-        assert np.array_equal(result.frames[0], original[0])
-        assert not np.array_equal(result.frames[6], original[6])
+        assert np.array_equal(out[0], original[0])
+        assert not np.array_equal(out[6], original[6])
 
     def test_release_returns_toward_original(self):
         frames = np.tile(np.arange(64, dtype=np.uint8)[:, None], (1, 64))
         frames = np.broadcast_to(frames[None, :, :, None], (20, 64, 64, 3)).copy()
         video = Video.from_frames(frames, fps=20)
         original = video.frames.copy()
-        result = PunchIn(zoom_factor=2.0, attack_frames=3, release_frames=3).apply(video)
+        out = _stream(PunchIn(zoom_factor=2.0, attack_frames=3, release_frames=3), video)
         # Final frame should be (close to) the original because release ends at zoom=1.0
-        assert np.array_equal(result.frames[-1], original[-1])
+        assert np.array_equal(out[-1], original[-1])
 
     def test_invalid_zoom_raises(self):
         with pytest.raises(ValidationError):
@@ -625,20 +625,20 @@ class TestFlash:
     def test_peak_blends_toward_color(self):
         frames = np.zeros((10, 32, 32, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=10)
-        result = Flash(color=(255, 255, 255), peak_alpha=1.0, attack_frames=2, decay_frames=2).apply(video)
+        out = _stream(Flash(color=(255, 255, 255), peak_alpha=1.0, attack_frames=2, decay_frames=2), video)
         # The frame right after attack should be (close to) fully white
-        assert result.frames[2].mean() > 240
+        assert out[2].mean() > 240
 
     def test_outside_attack_decay_unchanged(self):
         frames = np.zeros((10, 32, 32, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=10)
-        result = Flash(color=(255, 0, 0), peak_alpha=1.0, attack_frames=2, decay_frames=2).apply(video)
+        out = _stream(Flash(color=(255, 0, 0), peak_alpha=1.0, attack_frames=2, decay_frames=2), video)
         # Frames after attack+decay should still be black
-        assert result.frames[-1].mean() == 0
+        assert out[-1].mean() == 0
 
     def test_preserves_shape(self, synthetic_color_video):
-        result = Flash(peak_alpha=0.5).apply(synthetic_color_video)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(Flash(peak_alpha=0.5), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_invalid_alpha_raises(self):
         with pytest.raises(ValidationError):
@@ -652,19 +652,19 @@ class TestChromaticAberration:
         frames = np.zeros((4, 32, 32, 3), dtype=np.uint8)
         frames[:, :, 15, :] = 200  # vertical line in the middle (all channels)
         video = Video.from_frames(frames, fps=4)
-        result = ChromaticAberration(shift_px=3, mode="horizontal").apply(video)
+        out = _stream(ChromaticAberration(shift_px=3, mode="horizontal"), video)
         # Red channel should be shifted right, blue shifted left
         # So at column 18, red is bright; at column 12, blue is bright
-        assert result.frames[0, 16, 18, 0] > 100  # red shifted right
-        assert result.frames[0, 16, 12, 2] > 100  # blue shifted left
+        assert out[0, 16, 18, 0] > 100  # red shifted right
+        assert out[0, 16, 12, 2] > 100  # blue shifted left
 
     def test_radial_preserves_shape(self, synthetic_color_video):
-        result = ChromaticAberration(shift_px=4, mode="radial").apply(synthetic_color_video)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(ChromaticAberration(shift_px=4, mode="radial"), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_vertical_mode(self, synthetic_color_video):
-        result = ChromaticAberration(shift_px=4, mode="vertical").apply(synthetic_color_video)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(ChromaticAberration(shift_px=4, mode="vertical"), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_invalid_shift_raises(self):
         with pytest.raises(ValidationError):
@@ -674,14 +674,14 @@ class TestChromaticAberration:
 class TestGlitch:
     def test_changes_frames(self, synthetic_color_video):
         original = synthetic_color_video.frames.copy()
-        result = Glitch(intensity=0.5, seed=1).apply(synthetic_color_video.copy())
-        assert not np.array_equal(result.frames, original)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(Glitch(intensity=0.5, seed=1), synthetic_color_video)
+        assert not np.array_equal(out, original)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_seed_reproducible(self, synthetic_color_video):
-        a = Glitch(intensity=0.5, seed=99).apply(synthetic_color_video.copy())
-        b = Glitch(intensity=0.5, seed=99).apply(synthetic_color_video.copy())
-        assert np.array_equal(a.frames, b.frames)
+        a = _stream(Glitch(intensity=0.5, seed=99), synthetic_color_video)
+        b = _stream(Glitch(intensity=0.5, seed=99), synthetic_color_video)
+        assert np.array_equal(a, b)
 
     def test_invalid_params_raise(self):
         with pytest.raises(ValidationError):
@@ -697,24 +697,24 @@ class TestFilmGrain:
         frames = np.full((8, 64, 64, 3), 128, dtype=np.uint8)
         video = Video.from_frames(frames, fps=8)
         original_std = video.frames.std()
-        result = FilmGrain(intensity=0.1, seed=0).apply(video)
-        assert result.frames.std() > original_std
+        out = _stream(FilmGrain(intensity=0.1, seed=0), video)
+        assert out.std() > original_std
 
     def test_monochrome_vs_color(self):
         frames = np.full((4, 32, 32, 3), 128, dtype=np.uint8)
-        a = FilmGrain(intensity=0.1, monochrome=True, seed=0).apply(Video.from_frames(frames.copy(), fps=4))
-        b = FilmGrain(intensity=0.1, monochrome=False, seed=0).apply(Video.from_frames(frames.copy(), fps=4))
+        a = _stream(FilmGrain(intensity=0.1, monochrome=True, seed=0), Video.from_frames(frames.copy(), fps=4))
+        b = _stream(FilmGrain(intensity=0.1, monochrome=False, seed=0), Video.from_frames(frames.copy(), fps=4))
         # Monochrome: per-pixel R==G==B; color: channels differ
-        mono_diff = np.abs(a.frames[..., 0].astype(int) - a.frames[..., 1].astype(int)).max()
-        color_diff = np.abs(b.frames[..., 0].astype(int) - b.frames[..., 1].astype(int)).max()
+        mono_diff = np.abs(a[..., 0].astype(int) - a[..., 1].astype(int)).max()
+        color_diff = np.abs(b[..., 0].astype(int) - b[..., 1].astype(int)).max()
         assert mono_diff == 0
         assert color_diff > 0
 
     def test_seed_reproducible(self):
         frames = np.full((4, 32, 32, 3), 128, dtype=np.uint8)
-        a = FilmGrain(intensity=0.1, seed=42).apply(Video.from_frames(frames.copy(), fps=4))
-        b = FilmGrain(intensity=0.1, seed=42).apply(Video.from_frames(frames.copy(), fps=4))
-        assert np.array_equal(a.frames, b.frames)
+        a = _stream(FilmGrain(intensity=0.1, seed=42), Video.from_frames(frames.copy(), fps=4))
+        b = _stream(FilmGrain(intensity=0.1, seed=42), Video.from_frames(frames.copy(), fps=4))
+        assert np.array_equal(a, b)
 
     def test_invalid_intensity_raises(self):
         with pytest.raises(ValidationError):
@@ -725,28 +725,27 @@ class TestFilmGrain:
 
 class TestSharpen:
     def test_preserves_shape(self, synthetic_color_video):
-        result = Sharpen(amount=1.0).apply(synthetic_color_video)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(Sharpen(amount=1.0), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_zero_amount_returns_unchanged(self, synthetic_color_video):
         original = synthetic_color_video.frames.copy()
-        result = Sharpen(amount=0.0).apply(synthetic_color_video.copy())
-        assert np.array_equal(result.frames, original)
+        out = _stream(Sharpen(amount=0.0), synthetic_color_video)
+        assert np.array_equal(out, original)
 
     def test_sharpens_blurred_edge(self):
         # A vertical edge: left half 0, right half 255.
         frames = np.zeros((4, 32, 32, 3), dtype=np.uint8)
         frames[:, :, 16:, :] = 255
         # Blur it first
-        from videopython.editing.effects import Blur
-
-        blurred = Blur(mode="constant", iterations=10, kernel_size=(7, 7)).apply(
-            Video.from_frames(frames.copy(), fps=4)
+        blurred = _stream(
+            Blur(mode="constant", iterations=10, kernel_size=(7, 7)),
+            Video.from_frames(frames.copy(), fps=4),
         )
-        sharpened = Sharpen(amount=2.0, kernel_size=5).apply(Video.from_frames(blurred.frames.copy(), fps=4))
+        sharpened = _stream(Sharpen(amount=2.0, kernel_size=5), Video.from_frames(blurred.copy(), fps=4))
         # The edge transition should be steeper after sharpening
-        blurred_gradient = float(np.abs(np.diff(blurred.frames[0, 16, :, 0].astype(int))).max())
-        sharp_gradient = float(np.abs(np.diff(sharpened.frames[0, 16, :, 0].astype(int))).max())
+        blurred_gradient = float(np.abs(np.diff(blurred[0, 16, :, 0].astype(int))).max())
+        sharp_gradient = float(np.abs(np.diff(sharpened[0, 16, :, 0].astype(int))).max())
         assert sharp_gradient > blurred_gradient
 
     def test_even_kernel_raises(self):
@@ -765,9 +764,9 @@ class TestPixelate:
         rng = np.random.default_rng(0)
         frames = rng.integers(0, 255, (4, 64, 64, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=4)
-        result = Pixelate(block_size=16).apply(video)
+        out = _stream(Pixelate(block_size=16), video)
         # Each 16x16 block should be uniform per-channel after nearest-neighbour upscale
-        block = result.frames[0, :16, :16]
+        block = out[0, :16, :16]
         for c in range(3):
             assert block[..., c].std() < 1.0
 
@@ -776,14 +775,14 @@ class TestPixelate:
         frames = rng.integers(0, 255, (4, 64, 64, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=4)
         original = video.frames.copy()
-        result = Pixelate(
-            block_size=8,
-            region=BoundingBox(x=0.5, y=0.5, width=0.5, height=0.5),
-        ).apply(video)
+        out = _stream(
+            Pixelate(block_size=8, region=BoundingBox(x=0.5, y=0.5, width=0.5, height=0.5)),
+            video,
+        )
         # Top-left corner outside the region should be unchanged
-        assert np.array_equal(result.frames[0, :16, :16], original[0, :16, :16])
+        assert np.array_equal(out[0, :16, :16], original[0, :16, :16])
         # Bottom-right corner inside the region should differ
-        assert not np.array_equal(result.frames[0, 48:, 48:], original[0, 48:, 48:])
+        assert not np.array_equal(out[0, 48:, 48:], original[0, 48:, 48:])
 
     def test_invalid_block_size_raises(self):
         with pytest.raises(ValidationError):
@@ -796,34 +795,34 @@ class TestMirrorFlip:
         frames = np.broadcast_to(frames[None, :, :, None], (4, 64, 64, 3)).copy()
         original = frames.copy()
         video = Video.from_frames(frames, fps=4)
-        result = MirrorFlip(mode="horizontal").apply(video)
+        out = _stream(MirrorFlip(mode="horizontal"), video)
         # Column 0 should now equal what was column 63 in the original
-        assert np.array_equal(result.frames[0, :, 0], original[0, :, 63])
+        assert np.array_equal(out[0, :, 0], original[0, :, 63])
 
     def test_vertical_reverses_rows(self):
         frames = np.tile(np.arange(64, dtype=np.uint8)[:, None], (1, 64))
         frames = np.broadcast_to(frames[None, :, :, None], (4, 64, 64, 3)).copy()
         original = frames.copy()
         video = Video.from_frames(frames, fps=4)
-        result = MirrorFlip(mode="vertical").apply(video)
-        assert np.array_equal(result.frames[0, 0, :], original[0, 63, :])
+        out = _stream(MirrorFlip(mode="vertical"), video)
+        assert np.array_equal(out[0, 0, :], original[0, 63, :])
 
     def test_mirror_left_makes_right_match_left(self):
         rng = np.random.default_rng(0)
         frames = rng.integers(0, 255, (2, 32, 32, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=2)
-        result = MirrorFlip(mode="mirror_left").apply(video)
-        left = result.frames[0, :, :16]
-        right = result.frames[0, :, 16:]
+        out = _stream(MirrorFlip(mode="mirror_left"), video)
+        left = out[0, :, :16]
+        right = out[0, :, 16:]
         assert np.array_equal(left, right[:, ::-1])
 
     def test_mirror_top_makes_bottom_match_top(self):
         rng = np.random.default_rng(1)
         frames = rng.integers(0, 255, (2, 32, 32, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=2)
-        result = MirrorFlip(mode="mirror_top").apply(video)
-        top = result.frames[0, :16, :]
-        bottom = result.frames[0, 16:, :]
+        out = _stream(MirrorFlip(mode="mirror_top"), video)
+        top = out[0, :16, :]
+        bottom = out[0, 16:, :]
         assert np.array_equal(top, bottom[::-1, :])
 
     def test_invalid_mode_raises(self):
@@ -833,20 +832,20 @@ class TestMirrorFlip:
 
 class TestKaleidoscope:
     def test_preserves_shape(self, synthetic_color_video):
-        result = Kaleidoscope(segments=6).apply(synthetic_color_video)
-        assert result.video_shape == synthetic_color_video.video_shape
+        out = _stream(Kaleidoscope(segments=6), synthetic_color_video)
+        assert out.shape == synthetic_color_video.video_shape
 
     def test_has_mirror_symmetry(self):
         rng = np.random.default_rng(0)
         frames = rng.integers(0, 255, (2, 64, 64, 3), dtype=np.uint8)
         video = Video.from_frames(frames, fps=2)
-        result = Kaleidoscope(segments=4).apply(video)
+        out = _stream(Kaleidoscope(segments=4), video)
         # With segments=4 and angle_offset=0, the fold-reflect mapping yields
         # left-right and top-bottom mirror symmetry about the frame center.
-        flipped_h = result.frames[0, :, ::-1]
-        flipped_v = result.frames[0, ::-1, :]
-        mae_h = float(np.abs(result.frames[0].astype(int) - flipped_h.astype(int)).mean())
-        mae_v = float(np.abs(result.frames[0].astype(int) - flipped_v.astype(int)).mean())
+        flipped_h = out[0, :, ::-1]
+        flipped_v = out[0, ::-1, :]
+        mae_h = float(np.abs(out[0].astype(int) - flipped_h.astype(int)).mean())
+        mae_v = float(np.abs(out[0].astype(int) - flipped_v.astype(int)).mean())
         assert mae_h < 5, f"Kaleidoscope output lacks horizontal mirror symmetry, MAE={mae_h}"
         assert mae_v < 5, f"Kaleidoscope output lacks vertical mirror symmetry, MAE={mae_v}"
 

--- a/src/tests/editing/test_native_transform_streaming.py
+++ b/src/tests/editing/test_native_transform_streaming.py
@@ -169,14 +169,12 @@ class TestFreezeFrameStreaming:
         video = _stream(plan, tmp_path)
         assert abs(len(video.frames) - 72) <= 1  # 6s at 12fps, duration unchanged
 
-    def test_boundary_freeze_agrees_across_paths(self, tmp_path):
-        """Regression: a timestamp in the last half-frame window rounded to
-        frame_count, where eager silently dropped the freeze while streaming
-        held the last frame -- all paths now clamp to the last frame."""
+    def test_boundary_freeze_clamps_to_last_frame(self, tmp_path):
+        """Regression: a timestamp in the last half-frame window rounds to
+        frame_count; the freeze must hold the last frame rather than be
+        silently dropped."""
         ops = [{"op": "freeze_frame", "timestamp": 5.99, "duration": 0.5}]
-        eager = _plan(ops).run()
         video = _stream(_plan(ops), tmp_path)
-        assert len(eager.frames) == 156
         assert abs(len(video.frames) - 156) <= 1
 
     def test_sub_frame_segment_raises_structured_error(self, tmp_path):
@@ -280,13 +278,11 @@ class TestSilenceRemovalStreaming:
         assert plan.streamability().entries[0].streaming_class is StreamingClass.FILTER
 
         context = {"transcription": self._gapped_transcription()}
-        eager = _plan([{"op": "silence_removal", "min_silence_duration": 1.0, "padding": 0.0}]).run(context=context)
         out = plan.run_to_file(tmp_path / "out.mp4", context=context)
         video = Video.from_path(str(out))
 
         # Keep [0, 2.5) + [5.0, 6.0) of the 6s cut = 3.5s = 84 frames.
         assert len(video.frames) == 84
-        assert len(eager.frames) == 84
 
     def test_audio_is_cut_in_sync(self, tmp_path, audio_source):
         plan = _plan(
@@ -319,17 +315,13 @@ class TestSilenceRemovalStreaming:
 class TestEncodeStageTransforms:
     """Transforms ordered after frame effects stream via the encoder's -vf."""
 
-    def test_fade_then_crop_streams_and_matches_eager(self, tmp_path):
+    def test_fade_then_crop_streams_in_encode_stage(self, tmp_path):
         ops = [{"op": "fade", "mode": "out", "duration": 1.0}, {"op": "crop", "width": 400, "height": 300}]
-        eager = _plan(ops).run()
         video = _stream(_plan(ops), tmp_path)
 
         assert video.frames.shape[1:3] == (300, 400)
-        assert abs(len(video.frames) - len(eager.frames)) <= 1
+        assert abs(len(video.frames) - 144) <= 1  # 6s at 24fps, no duration change
         assert video.frames[-1].mean() < 5, "fade-out lost in the encode-stage crop"
-        active = 60
-        mae = np.abs(video.frames[active].astype(np.float32) - eager.frames[active].astype(np.float32)).mean()
-        assert mae < 15, f"encode-stage crop diverged from eager: {mae}"
 
     def test_fade_then_speed_streams_with_audio_sync(self, tmp_path, audio_source):
         ops = [{"op": "fade", "mode": "out", "duration": 1.0}, {"op": "speed_change", "speed": 2.0}]

--- a/src/tests/editing/test_operation.py
+++ b/src/tests/editing/test_operation.py
@@ -1,20 +1,22 @@
 """Tests for the Operation/Effect base machinery in editing/operation.py.
 
 Covers auto-registration, the discriminated-union JSON schema, ``TimeRange``
-validation, and the ``Effect.apply`` window/invariant logic. Per-op
-behavioural tests live in ``test_transforms.py`` / ``test_effects.py``.
+validation, and the ``Operation``/``Effect`` default-contract hooks
+(``predict_metadata``, ``to_ffmpeg_filter``, ``process_frame``) that the
+streaming engine drives. Per-op behavioural tests live in
+``test_transforms.py`` / ``test_effects.py``; the windowed-effect splice is
+covered there as a render-based test (streaming-to-file is the only engine).
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 import pytest
 from pydantic import Field, ValidationError
 
-from videopython.base.video import Video
 from videopython.editing.operation import (
     Effect,
     FilterCtx,
@@ -144,17 +146,16 @@ class TestJsonSchema:
         assert op.font_filename == "/tmp/x.ttf"
 
 
-# --- Operation.apply default ------------------------------------------------
+# --- Operation / Effect default contract hooks ------------------------------
+#
+# The eager ``Operation.apply`` / ``Effect.apply`` engine was removed (0.44.0):
+# streaming-to-file is the only execution path. What remains here are the
+# pure default-contract hooks the streaming engine relies on. The windowed
+# brighten splice these tests used to exercise via ``apply`` is re-homed as a
+# render-based test in ``test_effects.py``.
 
 
-class TestOperationApplyDefault:
-    def test_default_apply_raises(self, black_frames_test_video: Video):
-        class _UnimplOp(Operation):
-            op: Literal["_unimpl"] = "_unimpl"
-
-        with pytest.raises(NotImplementedError):
-            _UnimplOp().apply(black_frames_test_video)
-
+class TestOperationDefaults:
     def test_default_predict_metadata_is_identity(self):
         class _NoOp(Operation):
             op: Literal["_no_op"] = "_no_op"
@@ -165,72 +166,26 @@ class TestOperationApplyDefault:
         assert _NoOp().predict_metadata(meta) is meta
 
     def test_default_to_ffmpeg_filter_returns_none(self):
-        class _Eager(Operation):
-            op: Literal["_eager"] = "_eager"
+        class _Plain(Operation):
+            op: Literal["_plain"] = "_plain"
 
-        assert _Eager().to_ffmpeg_filter(FilterCtx(width=100, height=100, fps=30.0)) is None
-
-
-# --- Effect window / invariant ----------------------------------------------
+        assert _Plain().to_ffmpeg_filter(FilterCtx(width=100, height=100, fps=30.0)) is None
 
 
 class _Brighten(Effect):
-    """Add a constant brightness offset to every frame."""
+    """A toy effect that declares no streaming behaviour of its own.
+
+    Used to probe the ``Effect`` *default* contract hooks: it deliberately does
+    NOT override ``process_frame`` (so the default raise is observable) and
+    keeps ``predict_metadata`` at the identity default.
+    """
 
     op: Literal["_brighten"] = "_brighten"
 
     delta: int = Field(10, ge=-255, le=255, description="Amount added to every pixel (clipped to uint8).")
 
-    def _apply(self, video: Video, **_context: Any) -> Video:
-        from videopython.base.video import Video as _V
 
-        out = np.clip(video.frames.astype(np.int16) + self.delta, 0, 255).astype(np.uint8)
-        result = _V.from_frames(out, fps=video.fps)
-        result.audio = video.audio
-        return result
-
-
-class _ShapeBreaker(Effect):
-    op: Literal["_shape_breaker"] = "_shape_breaker"
-
-    def _apply(self, video: Video, **_context: Any) -> Video:
-        from videopython.base.video import Video as _V
-
-        return _V.from_frames(video.frames[:-1], fps=video.fps)
-
-
-class TestEffectApply:
-    def test_no_window_applies_to_whole_video(self, black_frames_test_video: Video):
-        original_mean = black_frames_test_video.frames.mean()
-        out = _Brighten(delta=20).apply(black_frames_test_video)
-        assert out.video_shape == black_frames_test_video.video_shape
-        assert out.frames.mean() > original_mean
-
-    def test_window_applies_only_inside_range(self, black_frames_test_video: Video):
-        fps = black_frames_test_video.fps
-        win_start_f = round(1.0 * fps)
-        win_end_f = round(2.0 * fps)
-
-        out = _Brighten(delta=20, window=TimeRange(start=1.0, stop=2.0)).apply(black_frames_test_video)
-
-        assert out.video_shape == black_frames_test_video.video_shape
-        # Outside the window: untouched.
-        np.testing.assert_array_equal(out.frames[:win_start_f], black_frames_test_video.frames[:win_start_f])
-        np.testing.assert_array_equal(out.frames[win_end_f:], black_frames_test_video.frames[win_end_f:])
-        # Inside the window: brightened.
-        assert out.frames[win_start_f:win_end_f].mean() > black_frames_test_video.frames[win_start_f:win_end_f].mean()
-
-    def test_window_clamps_to_video_duration(self, black_frames_test_video: Video):
-        # stop past end -> clamped, still works.
-        out = _Brighten(delta=5, window=TimeRange(start=0.0, stop=black_frames_test_video.total_seconds + 100)).apply(
-            black_frames_test_video
-        )
-        assert out.video_shape == black_frames_test_video.video_shape
-
-    def test_shape_breaking_apply_raises(self, black_frames_test_video: Video):
-        with pytest.raises(RuntimeError, match="changed video shape"):
-            _ShapeBreaker().apply(black_frames_test_video)
-
+class TestEffectDefaults:
     def test_default_process_frame_raises(self):
         with pytest.raises(NotImplementedError, match="does not support streaming"):
             _Brighten(delta=1).process_frame(np.zeros((10, 10, 3), dtype=np.uint8), 0)
@@ -239,7 +194,7 @@ class TestEffectApply:
         """Effects preserve shape/frame_count, so predict_metadata is identity —
         but it must accept arbitrary ``**context`` so requires-aware effects
         (e.g. ``TranscriptionOverlay``) don't blow up when the runner threads
-        kwargs in. Symmetric with ``Effect.apply``'s ``**context``.
+        kwargs in. Symmetric with ``Effect.streaming_init``'s ``**context``.
         """
         from videopython.base.video import VideoMetadata as _Meta
 

--- a/src/tests/editing/test_streamability.py
+++ b/src/tests/editing/test_streamability.py
@@ -271,12 +271,7 @@ class TestRunToFileRejection:
         assert err.code is PlanErrorCode.STREAMING_FALLBACK
         assert err.op == "color_adjust"
 
-    def test_run_raises_the_same_errors(self, tmp_path):
-        plan = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
-        with pytest.raises(PlanValidationError, match="cannot stream"):
-            plan.run()
-
-    def test_builder_drift_raises_instead_of_silent_eager(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+    def test_builder_drift_raises_instead_of_silent_fallback(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
         """A streamable-flagged transform that fails to compile must not slip through."""
         monkeypatch.setattr(Resize, "to_ffmpeg_filter", lambda self, ctx: None)
         plan = _plan([RESIZE])

--- a/src/tests/editing/test_streaming.py
+++ b/src/tests/editing/test_streaming.py
@@ -21,6 +21,21 @@ def small_meta():
     return VideoMetadata.from_path(SMALL_VIDEO_PATH)
 
 
+def _assert_op_changes_frame(render, operations, *, name):
+    """Render ``operations`` over a SMALL_VIDEO cut and a no-op cut of the same
+    source, then assert the op actually altered the middle frame end-to-end
+    (guarding the silent-drop failure mode) without changing the frame count.
+    Returns the edited :class:`Video` for any op-specific follow-up checks."""
+    seg = {"source": SMALL_VIDEO_PATH, "start": 0, "end": 2.0}
+    edited = render(VideoEdit.from_dict({"segments": [{**seg, "operations": operations}]}), name=name)
+    plain = render(VideoEdit.from_dict({"segments": [seg]}), name="plain_" + name)
+    assert abs(len(edited.frames) - len(plain.frames)) <= 1
+    mid = min(len(edited.frames), len(plain.frames)) // 2
+    mae = np.abs(edited.frames[mid].astype(np.float32) - plain.frames[mid].astype(np.float32)).mean()
+    assert mae > 2.0, f"op did not change the rendered frame (mae={mae})"
+    return edited
+
+
 class TestStreamSegment:
     """Test the low-level stream_segment function."""
 
@@ -126,121 +141,44 @@ class TestVideoEditRunToFile:
         finally:
             out_path.unlink(missing_ok=True)
 
-    def test_streaming_matches_eager(self):
-        """Streaming and eager paths should produce similar output."""
-        plan_dict = {
-            "segments": [
-                {
-                    "source": SMALL_VIDEO_PATH,
-                    "start": 0,
-                    "end": 2.0,
-                    "operations": [
-                        {"op": "color_adjust", "saturation": 0, "contrast": 1.15},
-                    ],
-                }
-            ],
-        }
-        # Eager path
-        edit_eager = VideoEdit.from_dict(plan_dict)
-        eager_video = edit_eager.run()
+    def test_color_adjust_changes_pixels(self, render):
+        """color_adjust streams through run_to_file and actually alters the frame."""
+        _assert_op_changes_frame(
+            render, [{"op": "color_adjust", "saturation": 0, "contrast": 1.15}], name="coloradj.mp4"
+        )
 
-        # Streaming path
-        edit_stream = VideoEdit.from_dict(plan_dict)
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-            out_path = Path(f.name)
-        try:
-            edit_stream.run_to_file(out_path)
-            streamed_video = Video.from_path(str(out_path))
-
-            # Frame counts should match (within 1 due to codec rounding)
-            assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
-
-            # Compare pixel values -- lossy encode means not exact, but should be close
-            min_frames = min(len(eager_video.frames), len(streamed_video.frames))
-            # Sample middle frame
-            mid = min_frames // 2
-            eager_frame = eager_video.frames[mid].astype(np.float32)
-            stream_frame = streamed_video.frames[mid].astype(np.float32)
-            # Mean absolute error should be small (re-encoding introduces some loss)
-            mae = np.abs(eager_frame - stream_frame).mean()
-            assert mae < 15, f"Mean absolute error too high: {mae}"
-        finally:
-            out_path.unlink(missing_ok=True)
-
-    def test_image_overlay_streaming_matches_eager(self):
-        """ImageOverlay must produce the same pixels eager and streamed (parity)."""
+    def test_image_overlay_renders(self, render):
+        """A PNG image_overlay streams and composites onto the frame."""
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             logo_path = Path(f.name)
         arr = np.zeros((80, 120, 4), dtype=np.uint8)
         arr[:, :, 1] = 255  # green
         arr[:, :, 3] = 180
         Image.fromarray(arr, "RGBA").save(logo_path)
-        plan_dict = {
-            "segments": [
-                {
-                    "source": SMALL_VIDEO_PATH,
-                    "start": 0,
-                    "end": 2.0,
-                    "operations": [
-                        {"op": "image_overlay", "source": str(logo_path), "scale": 0.25, "anchor": "bottom_right"},
-                    ],
-                }
-            ],
-        }
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-            out_path = Path(f.name)
         try:
-            eager_video = VideoEdit.from_dict(plan_dict).run()
-            VideoEdit.from_dict(plan_dict).run_to_file(out_path)
-            streamed_video = Video.from_path(str(out_path))
-
-            assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
-            min_frames = min(len(eager_video.frames), len(streamed_video.frames))
-            mid = min_frames // 2
-            eager_frame = eager_video.frames[mid].astype(np.float32)
-            stream_frame = streamed_video.frames[mid].astype(np.float32)
-            mae = np.abs(eager_frame - stream_frame).mean()
-            assert mae < 15, f"Mean absolute error too high: {mae}"
+            _assert_op_changes_frame(
+                render,
+                [{"op": "image_overlay", "source": str(logo_path), "scale": 0.25, "anchor": "bottom_right"}],
+                name="overlay.mp4",
+            )
         finally:
-            out_path.unlink(missing_ok=True)
             logo_path.unlink(missing_ok=True)
 
-    def test_svg_overlay_streaming_matches_eager(self):
-        """SVG ImageOverlay must produce the same pixels eager and streamed."""
+    def test_svg_overlay_renders(self, render):
+        """An SVG image_overlay rasterises and composites onto the frame."""
         with tempfile.NamedTemporaryFile(suffix=".svg", delete=False, mode="w") as f:
             f.write(
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60" width="120" '
                 'height="60"><rect width="120" height="60" fill="rgb(0,200,120)"/></svg>'
             )
             svg_path = Path(f.name)
-        plan_dict = {
-            "segments": [
-                {
-                    "source": SMALL_VIDEO_PATH,
-                    "start": 0,
-                    "end": 2.0,
-                    "operations": [
-                        {"op": "image_overlay", "source": str(svg_path), "scale": 0.25, "anchor": "bottom_right"},
-                    ],
-                }
-            ],
-        }
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-            out_path = Path(f.name)
         try:
-            eager_video = VideoEdit.from_dict(plan_dict).run()
-            VideoEdit.from_dict(plan_dict).run_to_file(out_path)
-            streamed_video = Video.from_path(str(out_path))
-
-            assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
-            min_frames = min(len(eager_video.frames), len(streamed_video.frames))
-            mid = min_frames // 2
-            eager_frame = eager_video.frames[mid].astype(np.float32)
-            stream_frame = streamed_video.frames[mid].astype(np.float32)
-            mae = np.abs(eager_frame - stream_frame).mean()
-            assert mae < 15, f"Mean absolute error too high: {mae}"
+            _assert_op_changes_frame(
+                render,
+                [{"op": "image_overlay", "source": str(svg_path), "scale": 0.25, "anchor": "bottom_right"}],
+                name="svg_overlay.mp4",
+            )
         finally:
-            out_path.unlink(missing_ok=True)
             svg_path.unlink(missing_ok=True)
 
     def test_volume_adjust_streaming(self):
@@ -358,7 +296,7 @@ class TestStreamableTransforms:
         assert abs(meta.fps - 12) < 1
 
     def test_speed_change_streams_natively(self):
-        """speed_change is not streamable -- should fall back to eager and still work."""
+        """speed_change compiles to setpts+fps (0.42.0) and streams natively."""
         meta = self._run_plan(
             {
                 "segments": [
@@ -602,28 +540,19 @@ class TestContextStreaming:
             ]
         )
 
-    def test_add_subtitles_streams_and_matches_eager(self, tmp_path):
-        """run_to_file must not fall back to eager, and must match run()."""
+    def test_add_subtitles_burns_in_and_rebases(self, render):
+        """run_to_file burns subtitles in (not a silent context drop) and re-bases
+        the transcription onto the cut segment's local timeline."""
         context = {"transcription": self._absolute_transcription()}
-        eager_video = VideoEdit.from_dict(self._PLAN).run(context=context)
-
-        out_path = tmp_path / "subtitled.mp4"
-        VideoEdit.from_dict(self._PLAN).run_to_file(out_path, context=context)
-        streamed_video = Video.from_path(str(out_path))
-
-        assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
+        subtitled = render(VideoEdit.from_dict(self._PLAN), name="subtitled.mp4", context=context)
 
         # Frame inside the first cue (segment-local t=1.0s == source t=5.0s).
         active = round(1.0 * 24)
-        eager_frame = eager_video.frames[active].astype(np.float32)
-        stream_frame = streamed_video.frames[active].astype(np.float32)
-        mae = np.abs(eager_frame - stream_frame).mean()
-        assert mae < 15, f"Mean absolute error too high: {mae}"
+        stream_frame = subtitled.frames[active].astype(np.float32)
 
         # The subtitle was actually drawn: against the raw (no-subtitle) cut,
         # a meaningful share of pixels changed by far more than codec noise.
-        # Guards the failure mode where both paths silently drop the context
-        # and the parity assertion above passes vacuously.
+        # Guards the failure mode where the context is silently dropped.
         baseline = Video.from_path(SMALL_VIDEO_PATH, start_second=4.0, end_second=8.0)
         drawn_diff = np.abs(baseline.frames[active].astype(np.float32) - stream_frame)
         drawn_fraction = (drawn_diff > 50).mean()
@@ -635,7 +564,7 @@ class TestContextStreaming:
         # only if timestamps were kept source-absolute -- they must not be).
         quiet = round(0.1 * 24)
         quiet_diff = np.abs(
-            baseline.frames[quiet].astype(np.float32) - streamed_video.frames[quiet].astype(np.float32)
+            baseline.frames[quiet].astype(np.float32) - subtitled.frames[quiet].astype(np.float32)
         ).mean()
         assert quiet_diff < 15, f"Frame before first cue was modified: {quiet_diff}"
 
@@ -645,7 +574,7 @@ class TestContextStreaming:
         with pytest.raises(ValueError, match="requires transcription data"):
             edit.run_to_file(tmp_path / "out.mp4")
 
-    def test_no_overlap_context_raises_like_eager(self, tmp_path):
+    def test_no_overlap_context_raises(self, tmp_path):
         """Words entirely outside the cut are dropped by re-basing -> same error."""
         context = {
             "transcription": Transcription(words=[TranscriptionWord(start=50.0, end=51.0, word="late")]),
@@ -654,10 +583,10 @@ class TestContextStreaming:
         with pytest.raises(ValueError, match="requires transcription data"):
             edit.run_to_file(tmp_path / "out.mp4", context=context)
 
-    def test_subtitles_then_transform_streams_in_plan_order(self, tmp_path):
-        """A transform after add_subtitles streams: both join the decode
-        filter chain in plan order (subtitles burn at pre-crop dims, then the
-        crop applies), so the output matches the eager run().
+    def test_subtitles_then_transform_streams_in_plan_order(self, render):
+        """A transform after add_subtitles streams: both join the decode filter
+        chain in plan order (subtitles burn at pre-crop dims, then the crop
+        applies), so the rendered output is the cropped size.
         """
         plan = {
             "segments": [
@@ -673,19 +602,8 @@ class TestContextStreaming:
             ],
         }
         context = {"transcription": self._absolute_transcription()}
-        eager_video = VideoEdit.from_dict(plan).run(context=context)
-
-        out_path = tmp_path / "out.mp4"
-        VideoEdit.from_dict(plan).run_to_file(out_path, context=context)
-        streamed_video = Video.from_path(str(out_path))
-
-        assert streamed_video.frames.shape[1:3] == (300, 400)
-        assert abs(len(eager_video.frames) - len(streamed_video.frames)) <= 1
-        active = round(1.0 * 24)
-        mae = np.abs(
-            eager_video.frames[active].astype(np.float32) - streamed_video.frames[active].astype(np.float32)
-        ).mean()
-        assert mae < 15, f"Mean absolute error too high: {mae}"
+        rendered = render(VideoEdit.from_dict(plan), name="subs_then_crop.mp4", context=context)
+        assert rendered.frames.shape[1:3] == (300, 400)
 
 
 class TestPerSourceContextStreaming:

--- a/src/tests/editing/test_transforms.py
+++ b/src/tests/editing/test_transforms.py
@@ -1,12 +1,29 @@
-import cv2
-import numpy as np
+"""Tests for the editing transforms (streaming-only, post eager-removal).
+
+Since 0.44.0 there is no eager/in-memory ``apply`` path: a transform exists
+only as a streaming compilation. So these tests assert the two decode-free
+surfaces a transform exposes:
+
+* ``predict_metadata(meta)`` -- exact output shape / fps / frame count, the
+  fail-fast gate run during plan validation.
+* ``to_ffmpeg_filter(FilterCtx(...))`` / ``to_ffmpeg_audio_filter(...)`` -- the
+  exact ffmpeg filter expression the streaming engine appends to the graph.
+
+End-to-end frame *content* (the time-warp curve, frozen-frame holds, the
+silence cut, audio sync) is covered against real decoded output in
+``test_native_transform_streaming.py``; it is not duplicated here. Anything
+that used to assert cv2-exact pixels or cut-frame identity cannot survive the
+move to ffmpeg (libswscale != cv2; a cut is a decode boundary), so those
+asserts are replaced by filter-string + ``predict_metadata`` checks.
+"""
+
 import pytest
 from pydantic import ValidationError
 
-from videopython.audio import Audio, AudioMetadata
 from videopython.base.exceptions import PlanErrorCode, PlanValidationError
 from videopython.base.transcription import Transcription, TranscriptionSegment, TranscriptionWord
-from videopython.base.video import Video, VideoMetadata
+from videopython.base.video import VideoMetadata
+from videopython.editing.operation import FilterCtx
 from videopython.editing.transforms import (
     Crop,
     CropMode,
@@ -19,325 +36,223 @@ from videopython.editing.transforms import (
     SpeedChange,
 )
 
+# A reusable source-metadata stand-in: 800x500 @ 24fps, 12 s (== the small test
+# video). predict_metadata is decode-free, so a metadata object is all it needs.
+SMALL_META = VideoMetadata(height=500, width=800, fps=24, frame_count=288, total_seconds=12.0)
+
+
+def _ctx(meta: VideoMetadata, **kwargs) -> FilterCtx:
+    """A FilterCtx mirroring a VideoMetadata, with the folded frame_count set."""
+    return FilterCtx(
+        width=meta.width,
+        height=meta.height,
+        fps=meta.fps,
+        frame_count=meta.frame_count,
+        **kwargs,
+    )
+
 
 @pytest.mark.parametrize("start, end", [(0, 100), (100, 101), (100, 120)])
-def test_cut_frames(start, end, small_video):
-    cut_frames = CutFrames(start=start, end=end)
-    start_frame = small_video.frames[start].copy()
-    transformed = cut_frames.apply(small_video)
-    assert len(transformed.frames) == (end - start)
-    assert np.all(transformed.frames[0] == start_frame)
+def test_cut_frames_predicts_frame_count(start, end):
+    """CutFrames(predict) yields exactly ``end - start`` frames."""
+    result = CutFrames(start=start, end=end).predict_metadata(SMALL_META)
+    assert result.frame_count == end - start
+    assert result.total_seconds == round((end - start) / SMALL_META.fps, 4)
 
 
 @pytest.mark.parametrize("start, end", [(0, 0.5), (0, 1), (0.5, 1.5)])
-def test_cut_seconds(start, end, small_video):
-    cut_seconds = CutSeconds(start=start, end=end)
-    start_frame = small_video.frames[round(start * small_video.fps)].copy()
-    transformed = cut_seconds.apply(small_video)
-    assert len(transformed.frames) == round((end - start) * small_video.fps)
-    assert np.all(transformed.frames[0] == start_frame)
+def test_cut_seconds_predicts_duration(start, end):
+    """CutSeconds(predict) yields the frame-rounded duration of the window."""
+    result = CutSeconds(start=start, end=end).predict_metadata(SMALL_META)
+    start_f = round(start * SMALL_META.fps)
+    end_f = round(end * SMALL_META.fps)
+    assert result.total_seconds == round((end_f - start_f) / SMALL_META.fps, 4)
 
 
 @pytest.mark.parametrize(
     "height,width",
     [
-        (
-            40,
-            60,
-        ),
-        (
-            500,
-            700,
-        ),
+        (40, 60),
+        (500, 700),
     ],
 )
-def test_video_resize(height, width, small_video):
-    """Tests Video.resize."""
-
-    source = small_video.copy()
-    original_first_frame = source.frames[0].copy()
-    resample = Resize(height=height, width=width)
-    video = resample.apply(source)
-
-    assert video.frames.shape[1:3] == (height, width)
-    assert np.all(
-        video.frames[0]
-        == cv2.resize(
-            original_first_frame,
-            (width, height),
-            interpolation=cv2.INTER_AREA,
-        )
-    )
+def test_resize_predicts_dims_and_compiles_scale(height, width):
+    """Resize predicts the exact target dims and compiles to ``scale=W:H``."""
+    resize = Resize(height=height, width=width)
+    predicted = resize.predict_metadata(SMALL_META)
+    assert (predicted.height, predicted.width) == (height, width)
+    assert resize.to_ffmpeg_filter(_ctx(SMALL_META)) == f"scale={width}:{height}"
 
 
-def test_video_resize_round_to_even_preserves_aspect_approximately():
-    video = Video.from_image(np.zeros((540, 302, 3), dtype=np.uint8), fps=30, length_seconds=1.0)
-    resized = Resize(width=1080).apply(video)
-    assert resized.frame_shape[:2] == (1932, 1080)
+def test_resize_round_to_even_preserves_aspect_approximately():
+    """Single-dimension resize keeps aspect, snapping the other to even."""
+    meta = VideoMetadata(height=540, width=302, fps=30, frame_count=30, total_seconds=1.0)
+    resize = Resize(width=1080)
+    predicted = resize.predict_metadata(meta)
+    assert (predicted.height, predicted.width) == (1932, 1080)
+    assert resize.to_ffmpeg_filter(_ctx(meta)) == "scale=1080:1932"
 
 
 def test_resample_fps_upsample_frame_count():
-    video = Video.from_image(np.zeros((64, 64, 3), dtype=np.uint8), fps=10, length_seconds=1.0)
+    meta = VideoMetadata(height=64, width=64, fps=10, frame_count=10, total_seconds=1.0)
     resample = ResampleFPS(fps=20)
-    result = resample.apply(video)
-    assert len(result.frames) == 20
-    assert abs(result.audio.metadata.duration_seconds - result.total_seconds) < 1e-3
+    predicted = resample.predict_metadata(meta)
+    assert predicted.fps == 20
+    assert predicted.frame_count == 20
+    assert resample.to_ffmpeg_filter(_ctx(meta)) == "fps=20.0"
 
 
 def test_resample_fps_downsample_frame_count():
-    video = Video.from_image(np.zeros((64, 64, 3), dtype=np.uint8), fps=20, length_seconds=1.0)
+    meta = VideoMetadata(height=64, width=64, fps=20, frame_count=20, total_seconds=1.0)
     resample = ResampleFPS(fps=10)
-    result = resample.apply(video)
-    assert len(result.frames) == 10
-    assert abs(result.audio.metadata.duration_seconds - result.total_seconds) < 1e-3
+    predicted = resample.predict_metadata(meta)
+    assert predicted.fps == 10
+    assert predicted.frame_count == 10
+    assert resample.to_ffmpeg_filter(_ctx(meta)) == "fps=10.0"
 
 
 class TestCrop:
-    """Tests for Crop transformation."""
+    """Crop predicts the cropped dims and compiles to ``crop=W:H:X:Y``."""
 
     @pytest.fixture
-    def video(self):
-        """Create a fresh test video for each test."""
-        return Video.from_image(np.zeros((500, 800, 3), dtype=np.uint8), fps=30, length_seconds=1.0)
+    def meta(self):
+        return VideoMetadata(height=500, width=800, fps=30, frame_count=30, total_seconds=1.0)
 
-    def test_crop_center_pixels(self, video):
-        """Test center crop with pixel values."""
-        crop_width, crop_height = 100, 80
+    def test_crop_center_pixels(self, meta):
+        transform = Crop(width=100, height=80, mode=CropMode.CENTER)
+        predicted = transform.predict_metadata(meta)
+        assert (predicted.height, predicted.width) == (80, 100)
+        # Center box: (800-100)//2 = 350, (500-80)//2 = 210.
+        assert transform.to_ffmpeg_filter(_ctx(meta)) == "crop=100:80:350:210"
 
-        transform = Crop(width=crop_width, height=crop_height, mode=CropMode.CENTER)
-        result = transform.apply(video)
-
-        assert result.frame_shape[0] == crop_height
-        assert result.frame_shape[1] == crop_width
-
-    def test_crop_center_normalized(self, video):
-        """Test center crop with normalized (0-1) values."""
-        original_height, original_width = video.frame_shape[:2]
-
-        # Crop to 50% of original size
+    def test_crop_center_normalized(self, meta):
         transform = Crop(width=0.5, height=0.5, mode=CropMode.CENTER)
-        result = transform.apply(video)
+        predicted = transform.predict_metadata(meta)
+        assert (predicted.height, predicted.width) == (250, 400)
+        assert transform.to_ffmpeg_filter(_ctx(meta)) == "crop=400:250:200:125"
 
-        expected_width = int(original_width * 0.5)
-        expected_height = int(original_height * 0.5)
-        assert result.frame_shape[0] == expected_height
-        assert result.frame_shape[1] == expected_width
+    def test_crop_custom_position_pixels(self, meta):
+        transform = Crop(width=50, height=40, x=10, y=20, mode=CropMode.CUSTOM)
+        predicted = transform.predict_metadata(meta)
+        assert (predicted.height, predicted.width) == (40, 50)
+        assert transform.to_ffmpeg_filter(_ctx(meta)) == "crop=50:40:10:20"
 
-    def test_crop_custom_position_pixels(self, video):
-        """Test custom position crop with pixel values."""
-        crop_width, crop_height = 50, 40
-        crop_x, crop_y = 10, 20
-
-        transform = Crop(width=crop_width, height=crop_height, x=crop_x, y=crop_y, mode=CropMode.CUSTOM)
-        result = transform.apply(video)
-
-        assert result.frame_shape[0] == crop_height
-        assert result.frame_shape[1] == crop_width
-
-    def test_crop_custom_position_normalized(self, video):
-        """Test custom position crop with normalized values."""
-        original_height, original_width = video.frame_shape[:2]
-
-        # Crop right half of video (x=0.5, width=0.5)
+    def test_crop_custom_position_normalized(self, meta):
+        # Right half: x=0.5, width=0.5, full height.
         transform = Crop(width=0.5, height=1.0, x=0.5, y=0.0, mode=CropMode.CUSTOM)
-        result = transform.apply(video)
+        predicted = transform.predict_metadata(meta)
+        assert (predicted.height, predicted.width) == (500, 400)
+        assert transform.to_ffmpeg_filter(_ctx(meta)) == "crop=400:500:400:0"
 
-        expected_width = int(original_width * 0.5)
-        expected_height = int(original_height * 1.0)
-        assert result.frame_shape[0] == expected_height
-        assert result.frame_shape[1] == expected_width
-
-    def test_crop_mixed_values(self, video):
-        """Test crop with mixed pixel and normalized values."""
-        original_height, original_width = video.frame_shape[:2]
-
-        # Width in pixels, height normalized
+    def test_crop_mixed_values(self, meta):
+        # Width in pixels, height normalized.
         transform = Crop(width=100, height=0.5, mode=CropMode.CENTER)
-        result = transform.apply(video)
+        predicted = transform.predict_metadata(meta)
+        assert predicted.width == 100
+        assert predicted.height == 250
 
-        assert result.frame_shape[1] == 100
-        assert result.frame_shape[0] == int(original_height * 0.5)
-
-    def test_crop_preserves_frame_count(self, video):
-        """Test that crop preserves the number of frames."""
-        original_frames = len(video.frames)
+    def test_crop_preserves_frame_count(self, meta):
         transform = Crop(width=0.5, height=0.5, mode=CropMode.CENTER)
-        result = transform.apply(video)
+        predicted = transform.predict_metadata(meta)
+        assert predicted.frame_count == meta.frame_count
 
-        assert len(result.frames) == original_frames
+    def test_crop_exceeds_source_raises(self, meta):
+        with pytest.raises(PlanValidationError) as exc:
+            Crop(width=2000, height=80, mode=CropMode.CENTER).predict_metadata(meta)
+        assert exc.value.errors[0].code is PlanErrorCode.CROP_EXCEEDS_SOURCE
 
 
 class TestSpeedChange:
-    """Tests for SpeedChange transformation."""
+    """SpeedChange predicts the new frame count and compiles setpts/atempo."""
 
-    def test_speed_up_2x(self, small_video):
-        """Test 2x speed results in half the frames."""
-        original_frames = len(small_video.frames)
-        transform = SpeedChange(speed=2.0)
-        result = transform.apply(small_video)
+    def test_speed_up_2x_halves_frame_count(self):
+        predicted = SpeedChange(speed=2.0).predict_metadata(SMALL_META)
+        assert predicted.frame_count == SMALL_META.frame_count // 2
 
-        # 2x speed should give approximately half the frames
-        assert len(result.frames) == original_frames // 2
+    def test_slow_down_half_doubles_frame_count(self):
+        predicted = SpeedChange(speed=0.5).predict_metadata(SMALL_META)
+        assert predicted.frame_count == SMALL_META.frame_count * 2
 
-    def test_slow_down_half(self, small_video):
-        """Test 0.5x speed results in double the frames."""
-        original_frames = len(small_video.frames)
-        transform = SpeedChange(speed=0.5)
-        result = transform.apply(small_video)
+    def test_speed_1x_no_change(self):
+        predicted = SpeedChange(speed=1.0).predict_metadata(SMALL_META)
+        assert predicted.frame_count == SMALL_META.frame_count
 
-        # 0.5x speed should give approximately double the frames
-        assert len(result.frames) == original_frames * 2
-
-    def test_speed_1x_no_change(self, small_video):
-        """Test 1x speed keeps same frame count."""
-        original_frames = len(small_video.frames)
-        transform = SpeedChange(speed=1.0)
-        result = transform.apply(small_video)
-
-        assert len(result.frames) == original_frames
-
-    def test_speed_ramp(self, small_video):
-        """Test speed ramping from 1x to 2x."""
-        original_frames = len(small_video.frames)
-        transform = SpeedChange(speed=1.0, end_speed=2.0)
-        result = transform.apply(small_video)
-
-        # Average speed is 1.5x, so should have ~2/3 the frames
-        expected_frames = int(original_frames / 1.5)
-        assert abs(len(result.frames) - expected_frames) <= 1
+    def test_speed_ramp_uses_average(self):
+        # Ramp 1x -> 2x averages 1.5x.
+        predicted = SpeedChange(speed=1.0, end_speed=2.0).predict_metadata(SMALL_META)
+        expected = int(SMALL_META.frame_count / 1.5)
+        assert predicted.frame_count == expected
 
     def test_invalid_speed_raises(self):
-        """Test that invalid speed values raise errors."""
         with pytest.raises(ValueError):
             SpeedChange(speed=0)
-
         with pytest.raises(ValueError):
             SpeedChange(speed=-1.0)
-
         with pytest.raises(ValueError):
             SpeedChange(speed=1.0, end_speed=0)
 
-    def test_preserves_frame_shape(self, small_video):
-        """Test that speed change preserves frame dimensions."""
-        original_shape = small_video.frame_shape
-        transform = SpeedChange(speed=2.0)
-        result = transform.apply(small_video)
+    def test_preserves_frame_shape(self):
+        predicted = SpeedChange(speed=2.0).predict_metadata(SMALL_META)
+        assert (predicted.height, predicted.width) == (SMALL_META.height, SMALL_META.width)
 
-        assert result.frame_shape == original_shape
+    def test_zero_frame_speed_raises(self):
+        with pytest.raises(PlanValidationError) as exc:
+            SpeedChange(speed=1000.0).predict_metadata(SMALL_META)
+        assert exc.value.errors[0].code is PlanErrorCode.DEGENERATE_DURATION
+
+    def test_constant_speedup_compiles_setpts_and_fps(self):
+        chain = SpeedChange(speed=2.0).to_ffmpeg_filter(_ctx(SMALL_META))
+        assert chain is not None
+        retime, resample = chain.split(",")
+        assert retime.startswith("setpts=(PTS-STARTPTS)/2")
+        assert resample == "fps=24"
+
+    def test_slowdown_with_interpolation_uses_framerate(self):
+        # interpolate=True (default) on a slowdown blends via the framerate filter.
+        chain = SpeedChange(speed=0.5).to_ffmpeg_filter(_ctx(SMALL_META))
+        assert chain is not None
+        assert chain.endswith("framerate=fps=24")
+
+    def test_slowdown_no_interpolation_uses_fps(self):
+        chain = SpeedChange(speed=0.5, interpolate=False).to_ffmpeg_filter(_ctx(SMALL_META))
+        assert chain is not None
+        assert chain.endswith("fps=24")
+        assert "framerate" not in chain
+
+    def test_ramp_needs_frame_count(self):
+        # Unknown frame count -> ramp cannot compile -> not streamable here.
+        ctx = FilterCtx(width=800, height=500, fps=24, frame_count=0)
+        assert SpeedChange(speed=1.0, end_speed=2.0).to_ffmpeg_filter(ctx) is None
 
 
 class TestSpeedChangeAudio:
-    """Tests for SpeedChange audio adjustment."""
+    """SpeedChange's audio twin time-stretches via an atempo chain."""
 
-    @pytest.fixture
-    def video_with_audio(self):
-        """Create a video with non-silent audio for testing."""
-        from videopython.audio import Audio, AudioMetadata
+    def test_speed_up_2x_audio_atempo(self):
+        chain = SpeedChange(speed=2.0).to_ffmpeg_audio_filter(_ctx(SMALL_META))
+        assert chain == "atempo=2.0"
 
-        # Create video frames (1 second at 30fps)
-        frames = np.full((30, 100, 150, 3), 128, dtype=np.uint8)
-        video = Video.from_frames(frames, fps=30)
+    def test_slow_down_half_audio_atempo(self):
+        chain = SpeedChange(speed=0.5).to_ffmpeg_audio_filter(_ctx(SMALL_META))
+        assert chain == "atempo=0.5"
 
-        # Create non-silent audio (sine wave)
-        sample_rate = 44100
-        duration = 1.0
-        t = np.linspace(0, duration, int(sample_rate * duration), dtype=np.float32)
-        audio_data = (np.sin(2 * np.pi * 440 * t) * 0.5).astype(np.float32)
+    def test_audio_adjust_false_is_noop(self):
+        assert SpeedChange(speed=2.0, adjust_audio=False).to_ffmpeg_audio_filter(_ctx(SMALL_META)) is None
 
-        video.audio = Audio(
-            data=audio_data,
-            metadata=AudioMetadata(
-                sample_rate=sample_rate,
-                channels=1,
-                sample_width=2,
-                duration_seconds=duration,
-                frame_count=len(audio_data),
-            ),
-        )
-        return video
+    def test_speed_1x_audio_is_noop(self):
+        # An identity stretch yields an empty atempo chain -> None.
+        assert SpeedChange(speed=1.0).to_ffmpeg_audio_filter(_ctx(SMALL_META)) is None
 
-    def test_speed_up_2x_audio_duration(self, video_with_audio):
-        """Test 2x speed results in adjusted audio duration."""
-        original_video_duration = len(video_with_audio.frames) / video_with_audio.fps
-
-        transform = SpeedChange(speed=2.0, adjust_audio=True)
-        result = transform.apply(video_with_audio)
-
-        # Video duration should be halved
-        new_video_duration = len(result.frames) / result.fps
-        assert abs(new_video_duration - original_video_duration / 2) < 0.1
-
-        # Audio duration should match video duration
-        assert abs(result.audio.metadata.duration_seconds - new_video_duration) < 0.2
-
-    def test_slow_down_half_audio_duration(self, video_with_audio):
-        """Test 0.5x speed results in adjusted audio duration."""
-        original_video_duration = len(video_with_audio.frames) / video_with_audio.fps
-
-        transform = SpeedChange(speed=0.5, adjust_audio=True)
-        result = transform.apply(video_with_audio)
-
-        # Video duration should be doubled
-        new_video_duration = len(result.frames) / result.fps
-        assert abs(new_video_duration - original_video_duration * 2) < 0.1
-
-        # Audio duration should match video duration
-        assert abs(result.audio.metadata.duration_seconds - new_video_duration) < 0.5
-
-    def test_speed_change_adjust_audio_false(self, video_with_audio):
-        """Test adjust_audio=False slices without time-stretching."""
-        transform = SpeedChange(speed=2.0, adjust_audio=False)
-        result = transform.apply(video_with_audio)
-
-        # Audio should still match video duration (sliced, not time-stretched)
-        new_video_duration = len(result.frames) / result.fps
-        assert abs(result.audio.metadata.duration_seconds - new_video_duration) < 0.2
-
-    def test_speed_change_silent_audio(self, small_video):
-        """Test speed change with silent audio."""
-        # small_video fixture has silent audio by default
-        transform = SpeedChange(speed=2.0, adjust_audio=True)
-        result = transform.apply(small_video)
-
-        # Should complete without error
-        assert result.audio is not None
-
-    def test_speed_ramp_audio(self, video_with_audio):
-        """Test audio adjustment with speed ramp."""
-        transform = SpeedChange(speed=1.0, end_speed=2.0, adjust_audio=True)
-        result = transform.apply(video_with_audio)
-
-        # Audio duration should match video duration
-        new_video_duration = len(result.frames) / result.fps
-        assert abs(result.audio.metadata.duration_seconds - new_video_duration) < 0.3
+    def test_ramp_audio_uses_average_speed(self):
+        # Ramp 1x -> 3x averages 2x, compiled as a single constant stretch.
+        chain = SpeedChange(speed=1.0, end_speed=3.0).to_ffmpeg_audio_filter(_ctx(SMALL_META))
+        assert chain == "atempo=2.0"
 
 
 @pytest.fixture
-def video_1s():
-    """1-second video at 30fps with non-black frames."""
-    frames = np.full((30, 64, 64, 3), 200, dtype=np.uint8)
-    return Video.from_frames(frames, fps=30)
-
-
-@pytest.fixture
-def video_with_audio_1s():
-    """1-second video at 30fps with a sine wave audio track."""
-    frames = np.full((30, 64, 64, 3), 200, dtype=np.uint8)
-    video = Video.from_frames(frames, fps=30)
-    sample_rate = 44100
-    t = np.linspace(0, 1.0, sample_rate, dtype=np.float32)
-    audio_data = (np.sin(2 * np.pi * 440 * t) * 0.5).astype(np.float32)
-    video.audio = Audio(
-        data=audio_data,
-        metadata=AudioMetadata(
-            sample_rate=sample_rate,
-            channels=1,
-            sample_width=2,
-            duration_seconds=1.0,
-            frame_count=sample_rate,
-        ),
-    )
-    return video
+def video_meta_1s():
+    """1-second @ 30fps source metadata (30 frames)."""
+    return VideoMetadata(height=64, width=64, fps=30, frame_count=30, total_seconds=1.0)
 
 
 def _make_transcription(words_data: list[tuple[float, float, str]]) -> Transcription:
@@ -350,38 +265,48 @@ def _make_transcription(words_data: list[tuple[float, float, str]]) -> Transcrip
 
 
 class TestFreezeFrame:
-    def test_freeze_after_increases_duration(self, video_1s):
-        original_frames = len(video_1s.frames)
-        result = FreezeFrame(timestamp=0.5, duration=1.0, position="after").apply(video_1s)
-        expected = original_frames + round(1.0 * video_1s.fps)
-        assert len(result.frames) == expected
+    """FreezeFrame predicts the extended/replaced frame count.
 
-    def test_freeze_before_increases_duration(self, video_1s):
-        original_frames = len(video_1s.frames)
-        result = FreezeFrame(timestamp=0.5, duration=1.0, position="before").apply(video_1s)
-        expected = original_frames + round(1.0 * video_1s.fps)
-        assert len(result.frames) == expected
+    Frozen-frame *content* is asserted end-to-end in
+    ``test_native_transform_streaming.py::TestFreezeFrameStreaming``.
+    """
 
-    def test_freeze_replace_maintains_approx_duration(self, video_1s):
-        original_frames = len(video_1s.frames)
-        result = FreezeFrame(timestamp=0.0, duration=0.5, position="replace").apply(video_1s)
-        assert abs(len(result.frames) - original_frames) <= 1
+    def test_freeze_after_increases_duration(self, video_meta_1s):
+        predicted = FreezeFrame(timestamp=0.5, duration=1.0, position="after").predict_metadata(video_meta_1s)
+        assert predicted.frame_count == video_meta_1s.frame_count + round(1.0 * video_meta_1s.fps)
 
-    def test_frozen_frame_content(self, video_1s):
-        video_1s.frames[15] = 42
-        result = FreezeFrame(timestamp=0.5, duration=0.5, position="after").apply(video_1s)
-        freeze_start = 16
-        freeze_count = round(0.5 * video_1s.fps)
-        for i in range(freeze_start, freeze_start + freeze_count):
-            assert (result.frames[i] == 42).all()
+    def test_freeze_before_increases_duration(self, video_meta_1s):
+        predicted = FreezeFrame(timestamp=0.5, duration=1.0, position="before").predict_metadata(video_meta_1s)
+        assert predicted.frame_count == video_meta_1s.frame_count + round(1.0 * video_meta_1s.fps)
 
-    def test_replace_clamps_to_end(self, video_1s):
-        result = FreezeFrame(timestamp=0.9, duration=5.0, position="replace").apply(video_1s)
-        assert len(result.frames) > 0
+    def test_freeze_replace_maintains_approx_duration(self, video_meta_1s):
+        predicted = FreezeFrame(timestamp=0.0, duration=0.5, position="replace").predict_metadata(video_meta_1s)
+        assert abs(predicted.frame_count - video_meta_1s.frame_count) <= 1
 
-    def test_timestamp_out_of_range_raises(self, video_1s):
+    def test_replace_clamps_to_end(self, video_meta_1s):
+        # A replace window running past the clip end stays valid (clamped).
+        predicted = FreezeFrame(timestamp=0.9, duration=5.0, position="replace").predict_metadata(video_meta_1s)
+        assert predicted.frame_count > 0
+
+    def test_freeze_after_compiles_loop_chain(self, video_meta_1s):
+        chain = FreezeFrame(timestamp=0.5, duration=0.5, position="after").to_ffmpeg_filter(_ctx(video_meta_1s))
+        assert chain is not None
+        # Held frame is index round(0.5*30)=15, held for round(0.5*30)=15 frames.
+        assert chain.startswith("loop=loop=15:size=1:start=15")
+        assert chain.endswith("fps=30")
+
+    def test_freeze_needs_frame_count(self):
+        ctx = FilterCtx(width=64, height=64, fps=30, frame_count=0)
+        assert FreezeFrame(timestamp=0.5, duration=0.5).to_ffmpeg_filter(ctx) is None
+
+    def test_timestamp_out_of_range_raises_predict(self, video_meta_1s):
+        with pytest.raises(PlanValidationError) as exc:
+            FreezeFrame(timestamp=5.0).predict_metadata(video_meta_1s)
+        assert exc.value.errors[0].code is PlanErrorCode.OP_TIMESTAMP_OUT_OF_RANGE
+
+    def test_timestamp_out_of_range_raises_compile(self, video_meta_1s):
         with pytest.raises(ValueError, match="must be less than"):
-            FreezeFrame(timestamp=5.0).apply(video_1s)
+            FreezeFrame(timestamp=5.0, duration=0.5).to_ffmpeg_filter(_ctx(video_meta_1s))
 
     def test_negative_timestamp_raises(self):
         with pytest.raises(ValidationError):
@@ -393,15 +318,20 @@ class TestFreezeFrame:
 
 
 class TestSilenceRemoval:
+    """SilenceRemoval predicts the cut frame count and compiles select windows.
+
+    The end-to-end cut behavior (which frames survive, audio sync) is covered
+    in ``test_native_transform_streaming.py::TestSilenceRemovalStreaming``.
+    """
+
     @pytest.fixture
-    def video_5s(self):
-        """5-second video at 10fps (50 frames) for silence removal tests."""
-        frames = np.full((50, 32, 32, 3), 128, dtype=np.uint8)
-        return Video.from_frames(frames, fps=10)
+    def meta_5s(self):
+        """5-second @ 10fps source metadata (50 frames)."""
+        return VideoMetadata(height=32, width=32, fps=10, frame_count=50, total_seconds=5.0)
 
     @pytest.fixture
     def transcription_with_gap(self):
-        """Transcription with speech at 0-1s and 3-4s (silence gap 1-3s)."""
+        """Speech at 0-1s and 3-4s (silence gap 1-3s)."""
         return _make_transcription(
             [
                 (0.0, 0.5, "hello"),
@@ -411,39 +341,50 @@ class TestSilenceRemoval:
             ]
         )
 
-    def test_cut_removes_silence(self, video_5s, transcription_with_gap):
-        original_frames = len(video_5s.frames)
-        result = SilenceRemoval(min_silence_duration=1.0, padding=0.0).apply(
-            video_5s, transcription=transcription_with_gap
+    def test_predict_cuts_silence(self, meta_5s, transcription_with_gap):
+        predicted = SilenceRemoval(min_silence_duration=1.0, padding=0.0).predict_metadata(
+            meta_5s, transcription=transcription_with_gap
         )
-        assert len(result.frames) < original_frames
+        assert predicted.frame_count < meta_5s.frame_count
 
-    def test_no_silence_returns_unchanged(self, video_5s):
-        transcription = _make_transcription(
-            [
-                (0.0, 1.0, "word1"),
-                (1.0, 2.0, "word2"),
-                (2.0, 3.0, "word3"),
-                (3.0, 4.0, "word4"),
-                (4.0, 5.0, "word5"),
-            ]
+    def test_predict_no_silence_unchanged(self, meta_5s):
+        transcription = _make_transcription([(float(i), float(i + 1), f"word{i}") for i in range(5)])
+        predicted = SilenceRemoval(min_silence_duration=1.0, padding=0.0).predict_metadata(
+            meta_5s, transcription=transcription
         )
-        result = SilenceRemoval(min_silence_duration=1.0, padding=0.0).apply(video_5s, transcription=transcription)
-        assert len(result.frames) == len(video_5s.frames)
+        assert predicted.frame_count == meta_5s.frame_count
 
-    def test_padding_preserves_context(self, video_5s, transcription_with_gap):
-        result = SilenceRemoval(min_silence_duration=1.0, padding=0.5).apply(
-            video_5s, transcription=transcription_with_gap
-        )
-        result_no_pad = SilenceRemoval(min_silence_duration=1.0, padding=0.0).apply(
-            Video.from_frames(np.full((50, 32, 32, 3), 128, dtype=np.uint8), fps=10),
-            transcription=transcription_with_gap,
-        )
-        assert len(result.frames) >= len(result_no_pad.frames)
+    def test_predict_without_transcription_is_identity(self, meta_5s):
+        # No transcription in the validate context -> predict_metadata is identity
+        # (the raise lives on the compile path, asserted below).
+        predicted = SilenceRemoval().predict_metadata(meta_5s)
+        assert predicted.frame_count == meta_5s.frame_count
 
-    def test_no_transcription_raises(self, video_5s):
+    def test_padding_keeps_at_least_as_many_frames(self, meta_5s, transcription_with_gap):
+        padded = SilenceRemoval(min_silence_duration=1.0, padding=0.5).predict_metadata(
+            meta_5s, transcription=transcription_with_gap
+        )
+        unpadded = SilenceRemoval(min_silence_duration=1.0, padding=0.0).predict_metadata(
+            meta_5s, transcription=transcription_with_gap
+        )
+        assert padded.frame_count >= unpadded.frame_count
+
+    def test_compile_keep_windows(self, meta_5s, transcription_with_gap):
+        ctx = _ctx(meta_5s, context={"transcription": transcription_with_gap})
+        chain = SilenceRemoval(min_silence_duration=1.0, padding=0.0).to_ffmpeg_filter(ctx)
+        assert chain is not None
+        assert chain.startswith("select='")
+        assert "between(n," in chain
+
+    def test_compile_missing_context_raises(self, meta_5s):
+        ctx = _ctx(meta_5s)  # no transcription in context
         with pytest.raises(ValueError, match="requires transcription"):
-            SilenceRemoval().apply(video_5s)
+            SilenceRemoval().to_ffmpeg_filter(ctx)
+
+    def test_compile_audio_missing_context_raises(self, meta_5s):
+        ctx = _ctx(meta_5s)
+        with pytest.raises(ValueError, match="requires transcription"):
+            SilenceRemoval().to_ffmpeg_audio_filter(ctx)
 
     def test_invalid_params(self):
         with pytest.raises(ValueError, match="min_silence_duration"):

--- a/src/tests/editing/test_transitions.py
+++ b/src/tests/editing/test_transitions.py
@@ -20,7 +20,7 @@ from videopython.audio.audio import AudioMetadata
 from videopython.base.exceptions import PlanErrorCode, PlanValidationError
 from videopython.base.video import Video, VideoMetadata
 from videopython.editing import StreamingClass
-from videopython.editing.streaming import TRANSITION_TYPES, stream_transition_frames, xfade_filter
+from videopython.editing.streaming import TRANSITION_TYPES, xfade_filter
 from videopython.editing.video_edit import TransitionSpec, VideoEdit
 
 FPS = 24.0
@@ -112,7 +112,7 @@ class TestPlanSurface:
 
 
 class TestDurationMath:
-    def test_run_frame_count_subtracts_overlap(self, clips):
+    def test_run_frame_count_subtracts_overlap(self, clips, render):
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -126,7 +126,7 @@ class TestDurationMath:
                 ]
             }
         )
-        result = plan.run()
+        result = render(plan)
         overlap = round(0.5 * FPS)
         assert result.frames.shape[0] == 36 + 36 - overlap
 
@@ -172,34 +172,9 @@ class TestDurationMath:
 
 
 class TestSeamPixels:
-    @pytest.mark.parametrize("ttype", list(TRANSITION_TYPES))
-    def test_endpoints_pure_overlap_mixed_in_memory(self, ttype):
-        left = _solid((255, 0, 0), 1.5)
-        right = _solid((0, 0, 255), 1.5)
-        blended = stream_transition_frames(left.frames, right.frames, ttype, 0.5, FPS)
-        assert blended.shape[0] == 36 + 36 - 12
-        # The pre- and post-overlap endpoints stay pure source.
-        assert tuple(blended[0, 0, 0]) == (255, 0, 0)
-        assert tuple(blended[-1, 0, 0]) == (0, 0, 255)
-        # A mid-overlap frame is neither uniformly the left nor the right
-        # source: a fade/dissolve alpha-blends every pixel, a wipe/slide shows
-        # part of each source. Either way the frame is a genuine mix.
-        mid_frame = blended[(36 - 12) + 6]
-        pure_red = np.all(mid_frame == np.array([255, 0, 0], dtype=np.uint8))
-        pure_blue = np.all(mid_frame == np.array([0, 0, 255], dtype=np.uint8))
-        assert not pure_red and not pure_blue
-
-    def test_fade_midpoint_is_a_blend(self):
-        left = _solid((255, 0, 0), 1.5)
-        right = _solid((0, 0, 255), 1.5)
-        blended = stream_transition_frames(left.frames, right.frames, "fade", 0.5, FPS)
-        mid = (36 - 12) + 6  # halfway through the 12-frame overlap
-        r, g, b = (int(x) for x in blended[mid, H // 2, W // 2])
-        assert 90 < r < 165 and 90 < b < 165 and g < 20
-
-    def test_run_and_run_to_file_share_builder(self, clips, tmp_path):
-        # The in-memory twin (lossless) and the file path (lossy encode) come
-        # from the same xfade filter, so the seam blend is close, not identical.
+    def test_fade_midpoint_is_a_blend(self, clips, render):
+        # The rendered seam frame is a genuine red<->blue fade blend, not a pure
+        # source frame (lossy x264, so the channels land in a wide band).
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -213,14 +188,37 @@ class TestSeamPixels:
                 ]
             }
         )
-        in_mem = plan.run()
-        out = plan.run_to_file(tmp_path / "out.mp4")
-        on_disk = Video.from_path(str(out))
-        assert in_mem.frames.shape == on_disk.frames.shape
-        mid = (36 - 12) + 6
-        a = in_mem.frames[mid, H // 2, W // 2].astype(int)
-        b = on_disk.frames[mid, H // 2, W // 2].astype(int)
-        assert np.max(np.abs(a - b)) <= 12  # within x264 quantization at the seam
+        blended = render(plan).frames
+        mid = (36 - 12) + 6  # halfway through the 12-frame overlap
+        r, g, b = (int(x) for x in blended[mid, H // 2, W // 2])
+        assert 90 < r < 165 and 90 < b < 165 and g < 20
+
+    def test_seam_endpoints_pure_overlap_mixed(self, clips, render):
+        # Pre- and post-overlap endpoints stay (near) pure source; a mid-overlap
+        # frame is a genuine mix of both sources, not uniformly one of them.
+        plan = VideoEdit.from_dict(
+            {
+                "segments": [
+                    {"source": clips["red"], "start": 0, "end": 1.5},
+                    {
+                        "source": clips["blue"],
+                        "start": 0,
+                        "end": 1.5,
+                        "transition_in": {"type": "fade", "duration": 0.5},
+                    },
+                ]
+            }
+        )
+        blended = render(plan).frames
+        assert blended.shape[0] == 36 + 36 - 12
+        # Endpoints are pure source (within x264 quantization).
+        assert np.allclose(blended[0, 0, 0], np.array([255, 0, 0]), atol=12)
+        assert np.allclose(blended[-1, 0, 0], np.array([0, 0, 255]), atol=12)
+        # A mid-overlap frame is neither (near) pure red nor (near) pure blue.
+        mid_frame = blended[(36 - 12) + 6]
+        near_red = np.allclose(mid_frame, np.array([255, 0, 0], dtype=np.uint8), atol=12)
+        near_blue = np.allclose(mid_frame, np.array([0, 0, 255], dtype=np.uint8), atol=12)
+        assert not near_red and not near_blue
 
     def test_builder_is_shared_string(self):
         # One builder produces the filter both paths route through.
@@ -257,7 +255,7 @@ class TestAudio:
         assert abs(audio.metadata.duration_seconds - vmeta.total_seconds) < 0.1
         assert abs(vmeta.total_seconds - 2.5) < 0.05
 
-    def test_run_audio_fits_shortened_video(self, tmp_path):
+    def test_run_audio_fits_shortened_video(self, tmp_path, render):
         red = tmp_path / "red.mp4"
         blue = tmp_path / "blue.mp4"
         _solid((255, 0, 0), 1.5, tone_hz=440).save(str(red))
@@ -275,8 +273,9 @@ class TestAudio:
                 ]
             }
         )
-        result = plan.run()
-        assert abs(result.audio.metadata.duration_seconds - result.total_seconds) < 1e-3
+        result = render(plan)
+        # Lossy AAC mux: audio fits the shortened video within ~AAC priming.
+        assert abs(result.audio.metadata.duration_seconds - result.total_seconds) < 0.1
 
     def test_audio_false_hard_butt_join_same_length(self, tmp_path):
         red = tmp_path / "red.mp4"
@@ -301,11 +300,11 @@ class TestAudio:
         audio = Audio.from_path(str(out))
         assert abs(audio.metadata.duration_seconds - vmeta.total_seconds) < 0.1
 
-    def test_silent_stream_segment_consistent_across_paths(self, tmp_path):
+    def test_silent_stream_segment_fits_shortened_timeline(self, tmp_path):
         # A muxed-but-silent audio stream counts as "has audio" under the
-        # stream-presence heuristic, so run() and run_to_file make the SAME
-        # crossfade decision (the fix for the is_silent-vs-source_has_audio_stream
-        # divergence). Both fit the seam audio to the shortened timeline.
+        # stream-presence heuristic, so the seam audio is fit to the shortened
+        # timeline (the fix for the is_silent-vs-source_has_audio_stream
+        # divergence): the muxed audio tracks the shortened video length.
         red = tmp_path / "red.mp4"
         blue = tmp_path / "blue.mp4"
         _solid((255, 0, 0), 1.5).save(str(red))  # silent stream (still present)
@@ -323,13 +322,12 @@ class TestAudio:
                 ]
             }
         )
-        result = plan.run()
-        assert abs(result.audio.metadata.duration_seconds - result.total_seconds) < 1e-3
-
         out = plan.run_to_file(tmp_path / "out.mp4")
+        vmeta = VideoMetadata.from_path(str(out))
         file_audio = Audio.from_path(str(out))
-        # The two engines agree on the seam audio length (within AAC priming).
-        assert abs(file_audio.metadata.duration_seconds - result.audio.metadata.duration_seconds) < 0.1
+        # Seam audio fits the 2.5s shortened timeline (within AAC priming).
+        assert abs(file_audio.metadata.duration_seconds - vmeta.total_seconds) < 0.1
+        assert abs(vmeta.total_seconds - 2.5) < 0.05
 
 
 # --------------------------------------------------------------------- assembly
@@ -422,25 +420,7 @@ class TestTransitionTooLong:
             plan.run_to_file(tmp_path / "out.mp4")
         assert exc.value.errors[0].code is PlanErrorCode.TRANSITION_TOO_LONG
 
-    def test_run_raises(self, clips):
-        plan = VideoEdit.from_dict(
-            {
-                "segments": [
-                    {"source": clips["red"], "start": 0, "end": 1.5},
-                    {
-                        "source": clips["blue"],
-                        "start": 0,
-                        "end": 1.5,
-                        "transition_in": {"type": "fade", "duration": 2.0},
-                    },
-                ]
-            }
-        )
-        with pytest.raises(PlanValidationError) as exc:
-            plan.run()
-        assert exc.value.errors[0].code is PlanErrorCode.TRANSITION_TOO_LONG
-
-    def test_first_segment_transition_rejected(self, clips):
+    def test_first_segment_transition_rejected(self, clips, render):
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -457,9 +437,9 @@ class TestTransitionTooLong:
         codes = [e.code for e in plan.check(_metas(clips))]
         assert PlanErrorCode.TRANSITION_TOO_LONG in codes
         with pytest.raises(PlanValidationError):
-            plan.run()
+            render(plan)
 
-    def test_repair_clamps_duration(self, clips):
+    def test_repair_clamps_duration(self, clips, render):
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -484,17 +464,17 @@ class TestTransitionTooLong:
         # The clamped plan is clean AND actually runs -- the regression: a
         # seconds clamp to the segment length passed check() but crashed run().
         assert repaired.check(metas) == []
-        result = repaired.run()
+        result = render(repaired)
         assert result.frames.shape[0] == 36 + 36 - 35
 
-    def test_near_full_overlap_band_is_rejected(self, clips, tmp_path):
+    def test_near_full_overlap_band_is_rejected(self, clips, render):
         """A duration just under the segment length but rounding to a full-frame
-        overlap (round(D*fps) == segment_frames) must be rejected by every path.
+        overlap (round(D*fps) == segment_frames) must be rejected.
 
         Regression: the guard used to compare seconds, so duration=1.49s
         (round(1.49*24)=36 == the 36-frame segment) slipped through check while
-        run() crashed with a bare ValueError and run_to_file silently produced a
-        degenerate full-overlap clip with mismatched audio/video length.
+        the run silently produced a degenerate full-overlap clip with mismatched
+        audio/video length.
         """
         assert round(1.49 * FPS) == 36  # full overlap of a 36-frame segment
         plan = VideoEdit.from_dict(
@@ -513,11 +493,8 @@ class TestTransitionTooLong:
         metas = _metas(clips)
         assert any(e.code is PlanErrorCode.TRANSITION_TOO_LONG for e in plan.check(metas))
         with pytest.raises(PlanValidationError) as run_exc:
-            plan.run()
+            render(plan)
         assert run_exc.value.errors[0].code is PlanErrorCode.TRANSITION_TOO_LONG
-        with pytest.raises(PlanValidationError) as file_exc:
-            plan.run_to_file(tmp_path / "out.mp4")
-        assert file_exc.value.errors[0].code is PlanErrorCode.TRANSITION_TOO_LONG
 
     def test_repair_leaves_first_segment_transition_for_check(self, clips):
         # A first-segment transition is structural, not a mechanical clamp.

--- a/src/tests/editing/test_video_edit.py
+++ b/src/tests/editing/test_video_edit.py
@@ -22,6 +22,7 @@ from videopython.editing.video_edit import (
     TransitionSpec,
     VideoEdit,
     _assemble_timeline,
+    _clamp_effect_window,
     _segment_context,
 )
 
@@ -347,12 +348,12 @@ class TestTransitionTimelineMath:
 
 
 class TestExecution:
-    def test_run_no_ops(self):
+    def test_run_no_ops(self, render):
         plan = {"segments": [_segment(start=0.0, end=2.0)]}
-        video = VideoEdit.from_dict(plan).run()
+        video = render(VideoEdit.from_dict(plan))
         assert video.total_seconds == pytest.approx(2.0, abs=0.25)
 
-    def test_run_with_transform_and_effect(self):
+    def test_run_with_transform_and_effect(self, render):
         plan = {
             "segments": [
                 _segment(
@@ -363,38 +364,38 @@ class TestExecution:
                 )
             ]
         }
-        result = VideoEdit.from_dict(plan).run()
+        result = render(VideoEdit.from_dict(plan))
         assert result.frames.shape[2] == 400
         assert result.frames.shape[1] == 250
 
-    def test_run_multi_segment_same_source(self):
+    def test_run_multi_segment_same_source(self, render):
         plan = {
             "segments": [
                 _segment(start=0.0, end=2.0),
                 _segment(start=4.0, end=6.0),
             ]
         }
-        result = VideoEdit.from_dict(plan).run()
+        result = render(VideoEdit.from_dict(plan))
         assert result.total_seconds == pytest.approx(4.0, abs=0.3)
 
-    def test_run_with_post_operations(self):
+    def test_run_with_post_operations(self, render):
         plan = {
             "segments": [_segment(start=0.0, end=2.0)],
             "post_operations": [{"op": "fade", "mode": "out", "duration": 0.5}],
         }
-        result = VideoEdit.from_dict(plan).run()
+        result = render(VideoEdit.from_dict(plan))
         assert result.frames[-1].mean() < 5
 
-    def test_transform_post_op_is_rejected(self):
+    def test_transform_post_op_is_rejected(self, render):
         # Streaming is the only engine; transforms cannot stream as post-ops.
         plan = {
             "segments": [_segment(start=0.0, end=2.0)],
             "post_operations": [{"op": "resize", "width": 200, "height": 100}],
         }
         with pytest.raises(PlanValidationError, match="move the transform into the segment"):
-            VideoEdit.from_dict(plan).run()
+            render(VideoEdit.from_dict(plan))
 
-    def test_run_with_image_overlay(self, tmp_path):
+    def test_run_with_image_overlay(self, tmp_path, render):
         logo = tmp_path / "logo.png"
         arr = np.zeros((50, 50, 4), dtype=np.uint8)
         arr[:, :, 2] = 255  # blue
@@ -411,12 +412,12 @@ class TestExecution:
         }
         edit = VideoEdit.from_dict(plan)
         meta = edit.validate()
-        result = edit.run()
+        result = render(edit)
         assert result.frame_shape[0] == meta.height
         assert result.frame_shape[1] == meta.width
         assert (result.frames[0][:, :, 2] == 255).any()
 
-    def test_run_with_svg_overlay(self, tmp_path):
+    def test_run_with_svg_overlay(self, tmp_path, render):
         svg = tmp_path / "logo.svg"
         svg.write_text(
             '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40" width="100" '
@@ -433,7 +434,7 @@ class TestExecution:
         }
         edit = VideoEdit.from_dict(plan)
         meta = edit.validate()
-        result = edit.run()
+        result = render(edit)
         assert result.frame_shape[0] == meta.height
         assert result.frame_shape[1] == meta.width
         assert (result.frames[0][:, :, 1] > 150).any()  # the green logo is composited
@@ -470,11 +471,11 @@ class TestValidation:
         assert meta.width == 320
         assert meta.height == 200
 
-    def test_validate_crop_matches_runtime(self):
+    def test_validate_crop_matches_runtime(self, render):
         plan = {"segments": [_segment(operations=[{"op": "crop", "width": 5, "height": 5, "mode": "center"}])]}
         edit = VideoEdit.from_dict(plan)
         meta = edit.validate()
-        video = edit.run()
+        video = render(edit)
         assert meta.width == video.frame_shape[1]
         assert meta.height == video.frame_shape[0]
 
@@ -573,13 +574,14 @@ class TestClampWindows:
         repaired.validate_with_metadata(SMALL_VIDEO_METADATA)
 
     def test_clamp_matches_run_resolved_window(self):
-        # The clamped stop is exactly what Effect._resolved_window uses at run
-        # time: min(stop, total_seconds) against the post-op running duration.
+        # The validation clamp (repair) lands on exactly the stop the streaming
+        # engine applies at run time: min(stop, total_seconds) against the
+        # post-op running duration, mirrored by `_clamp_effect_window`.
         post_dur = SpeedChange(speed=1.5).predict_metadata(SMALL_VIDEO_METADATA).total_seconds
-        repaired, _ = VideoEdit.from_dict(self._speed_then_blur_plan()).repair(SMALL_VIDEO_METADATA)
-        blur = repaired.segments[0].operations[1]
-        _, run_stop = blur._resolved_window(post_dur)
-        assert blur.window.stop == pytest.approx(run_stop)
+        edit = VideoEdit.from_dict(self._speed_then_blur_plan())
+        repaired, _ = edit.repair(SMALL_VIDEO_METADATA)
+        run_clamped = _clamp_effect_window(edit.segments[0].operations[1], post_dur)
+        assert repaired.segments[0].operations[1].window.stop == pytest.approx(run_clamped.window.stop)
 
     def test_run_to_file_produces_clamped_output(self, tmp_path):
         edit = VideoEdit.from_dict(self._speed_then_blur_plan())
@@ -1273,12 +1275,12 @@ class TestPostOpsGuard:
         with pytest.raises(ValueError, match="not re-based across a multi-segment concat"):
             plan.validate_with_metadata(self._META, context={"transcription": tx})
 
-    def test_multi_segment_post_op_requiring_context_raises_on_run(self):
+    def test_multi_segment_post_op_requiring_context_raises_on_run(self, render):
         plan = self._plan(2, [{"op": "silence_removal"}])
         tx = _make_transcription([(1.0, 2.0, "hello")])
         # Guard fires before any disk access, so "fake.mp4" is never read.
         with pytest.raises(ValueError, match="post_operation 'silence_removal' requires"):
-            plan.run(context={"transcription": tx})
+            render(plan, context={"transcription": tx})
 
     def test_multi_segment_post_op_without_requires_is_allowed(self):
         plan = self._plan(2, [{"op": "vignette"}])

--- a/src/videopython/ai/dubbing/dubber.py
+++ b/src/videopython/ai/dubbing/dubber.py
@@ -239,9 +239,7 @@ class VideoDubber:
         video_duration = video.total_seconds
 
         if video_duration > speech_duration:
-            from videopython.editing.transforms import CutSeconds
-
-            output_video = CutSeconds(start=0, end=speech_duration).apply(video)
+            output_video = video[: round(speech_duration * video.fps)]
         else:
             output_video = video
 

--- a/src/videopython/ai/effects.py
+++ b/src/videopython/ai/effects.py
@@ -33,9 +33,9 @@ class ObjectDetectionOverlay(Effect):
     *memory*-bound: ``"streamable"`` here means bounded memory, not bounded
     compute. On long clips, cap cost with ``window`` (limit the time range),
     a larger ``detection_interval``, a ``class_filter``, and/or the smaller
-    ``model_size``. Because only ``streaming_init`` and ``process_frame`` are
-    overridden, the base ``Effect._apply`` replays the identical contract for
-    in-memory execution, so eager and streaming results cannot drift.
+    ``model_size``. Only ``streaming_init`` and ``process_frame`` are
+    overridden; the streaming engine drives that contract for bounded-memory
+    execution.
     """
 
     op: Literal["object_detection_overlay"] = "object_detection_overlay"

--- a/src/videopython/ai/transforms.py
+++ b/src/videopython/ai/transforms.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from videopython.ai.understanding.faces import FaceTracker
 from videopython.base._dimensions import floor_to_even
-from videopython.base.video import FrameIterator, Video, VideoMetadata
+from videopython.base.video import FrameIterator, VideoMetadata
 from videopython.editing._ass import escape_filter_value
 from videopython.editing.operation import FilterCtx, OpCategory, Operation
 
@@ -94,8 +94,8 @@ class FaceTrackingCrop(Operation):
         """Output ``(width, height)`` -- the fixed crop-window size.
 
         The largest ``target_aspect`` box that fits the frame, even-floored.
-        A pure function of the input dimensions, shared by :meth:`apply`,
-        :meth:`predict_metadata`, and :meth:`to_ffmpeg_filter`, so the
+        A pure function of the input dimensions, shared by
+        :meth:`predict_metadata` and :meth:`to_ffmpeg_filter`, so the
         dry-run cannot disagree with the render.
         """
         target_ratio = self.target_aspect[0] / self.target_aspect[1]
@@ -131,9 +131,8 @@ class FaceTrackingCrop(Operation):
         """Per-frame crop top-left positions for a fixed-size crop window.
 
         The single source of the tracking math (detection cadence, EMA
-        smoothing, framing offset, speed clamp, frame clamping), shared by
-        the eager :meth:`apply` and the compile-time detection pass so the
-        two paths cannot drift.
+        smoothing, framing offset, speed clamp, frame clamping), run by the
+        compile-time detection pass to build the per-frame crop command file.
         """
         out_w, out_h = self._resolved_output_dims(frame_w, frame_h)
         tracker = FaceTracker(
@@ -165,23 +164,6 @@ class FaceTrackingCrop(Operation):
             else:  # "center" / "full_frame" (the latter kept for plan compat)
                 positions.append(default)
         return positions
-
-    def apply(self, video: Video) -> Video:
-        h, w = video.frame_shape[:2]
-        out_w, out_h = self._resolved_output_dims(w, h)
-        logger.info(
-            "Face tracking crop: %dx%d -> %dx%d (%d:%d, framing=%s)",
-            w,
-            h,
-            out_w,
-            out_h,
-            self.target_aspect[0],
-            self.target_aspect[1],
-            self.framing_rule,
-        )
-        positions = self._track_crop_positions(tqdm(video.frames, desc="Face tracking crop"), w, h)
-        video.frames = np.stack([video.frames[i][y : y + out_h, x : x + out_w] for i, (x, y) in enumerate(positions)])
-        return video
 
     def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
         """Compile the face track to a per-frame ``crop`` position command file.

--- a/src/videopython/ai/video_analysis/analyzer.py
+++ b/src/videopython/ai/video_analysis/analyzer.py
@@ -331,9 +331,8 @@ class VideoAnalyzer:
             return None
         if source_path is not None:
             return Video.from_path(str(source_path), start_second=start_second, end_second=end_second)
-        from videopython.editing.transforms import CutSeconds
-
-        return CutSeconds(start=start_second, end=end_second).apply(stages.require_video(video))
+        v = stages.require_video(video)
+        return v[round(start_second * v.fps) : round(end_second * v.fps)]
 
     def _default_scene_boundaries(self, metadata: VideoMetadata) -> list[SceneBoundary]:
         if metadata.total_seconds <= 0 or metadata.frame_count <= 0:

--- a/src/videopython/audio/audio.py
+++ b/src/videopython/audio/audio.py
@@ -23,8 +23,8 @@ def atempo_chain(speed: float) -> list[str]:
     factor outside that range is decomposed into a chain of capped stages
     (``atempo=2.0`` repeated for speedups, ``atempo=0.5`` for slowdowns) times
     a final remainder stage. The single source of truth shared by
-    :meth:`Audio.time_stretch` (the in-memory WAV round-trip used by the eager
-    ``apply`` path) and ``SpeedChange.to_ffmpeg_audio_filter`` (the streaming
+    :meth:`Audio.time_stretch` (the in-memory WAV round-trip used by dubbing's
+    timing alignment) and ``SpeedChange.to_ffmpeg_audio_filter`` (the streaming
     filter graph), so both stretch by exactly the same chain. Returns an empty
     list for ``speed == 1`` (a no-op the caller maps to ``anull``).
     """

--- a/src/videopython/editing/audio_ops.py
+++ b/src/videopython/editing/audio_ops.py
@@ -7,9 +7,8 @@ assembled timeline, not of any one segment. It is mixed in a FINAL ffmpeg pass
 assembled program audio plus the bed input.
 
 :class:`MusicBed` is a frozen, closed pydantic model carried on
-:attr:`VideoEdit.music_bed`. Both ``run`` and ``run_to_file`` route through the
-single :func:`build_music_bed_filter_complex` builder so the in-memory and
-file paths cannot diverge on the mix.
+:attr:`VideoEdit.music_bed`. ``run_to_file`` routes through the
+single :func:`build_music_bed_filter_complex` builder for the mix.
 
 Ducking is *transcription-derived* and deterministic: when ``duck`` is set the
 bed is lowered under the speech windows derived from the context transcription
@@ -122,7 +121,7 @@ class MusicBed(BaseModel):
 
         Mirrors :meth:`ImageOverlay.predict_metadata`: a cheap ffprobe header
         probe (no decode) catches a missing / non-audio file at validate time,
-        before ``run()`` would crash mid-stream after assembling the program.
+        before ``run_to_file()`` would crash mid-stream after assembling the program.
         """
         try:
             info = _ffmpeg.probe(self.source)
@@ -147,8 +146,8 @@ class MusicBed(BaseModel):
         bed is scaled to ``gain``, faded, ducked under ``speech`` (when given and
         ``duck`` is set), then pinned to exactly ``program_seconds`` (``atrim``
         end + ``apad`` whole_dur) so a looped bed neither truncates early nor
-        extends the output past the program. Shared by the in-memory and file
-        mix paths via :func:`build_music_bed_filter_complex`.
+        extends the output past the program. Used by the file
+        mix path via :func:`build_music_bed_filter_complex`.
         """
         stages: list[str] = [f"volume={self.gain:.6f}"]
         if self.fade_in > 0:
@@ -178,8 +177,7 @@ def build_music_bed_filter_complex(
 ) -> tuple[list[str], list[str], str]:
     """Compile the music-bed input args + ``filter_complex`` mix graph.
 
-    The single source of the bed mix, shared by ``run`` (in-memory PCM pass) and
-    ``run_to_file`` (file pass) so the two cannot diverge. Returns
+    The single source of the bed mix, used by ``run_to_file`` (file pass). Returns
     ``(input_args, graph_statements, out_label)``:
 
     - ``input_args`` are the ffmpeg ``-i`` argv for the bed: ``-stream_loop -1``

--- a/src/videopython/editing/effects.py
+++ b/src/videopython/editing/effects.py
@@ -3,16 +3,13 @@
 An ``Effect`` is an ``Operation`` that preserves video shape and frame count.
 Subclasses implement the streaming contract -- :meth:`Effect.process_frame`
 (plus :meth:`Effect.streaming_init` for any precomputed state) -- which is the
-single source of truth for the effect's pixel logic. The base
-:meth:`Effect._apply` replays that contract over the in-memory frames, so
-in-memory execution comes for free and cannot drift from streaming.
-
-A few effects override the eager path deliberately: ``FullImageOverlay`` and
-``Vignette`` keep a hand-written :meth:`Effect._apply` (extra validation /
-batched vectorisation), and the audio effects (``Fade``, ``VolumeAdjust``)
-override :meth:`Effect.apply` directly so the audio splice stays coherent with
-the window. Anchored RGBA overlays (``TextOverlay``, ``ImageOverlay``) share
-their placement and blend via :class:`_AnchoredOverlay`.
+single source of truth for the effect's pixel logic and the only execution
+path. Audio effects (``Fade``, ``VolumeAdjust``) instead express their gain
+envelope via :meth:`Effect.to_ffmpeg_audio_filter`. Effects that need
+run-time validation beyond the field constraints (``FullImageOverlay``)
+override :meth:`Effect.predict_metadata`. Anchored RGBA overlays
+(``TextOverlay``, ``ImageOverlay``) share their placement and blend via
+:class:`_AnchoredOverlay`.
 """
 
 from __future__ import annotations
@@ -26,7 +23,6 @@ import cv2
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 from pydantic import Field, PrivateAttr, model_validator
-from tqdm import tqdm
 
 from videopython.base.description import BoundingBox
 from videopython.base.exceptions import PlanError, PlanErrorCode, PlanValidationError
@@ -35,8 +31,7 @@ from videopython.editing._easing import ease, ease_out
 from videopython.editing.operation import Effect, FilterCtx
 
 if TYPE_CHECKING:
-    from videopython.audio import Audio
-    from videopython.base.video import Video, VideoMetadata
+    from videopython.base.video import VideoMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -121,24 +116,23 @@ class FullImageOverlay(Effect):
         fade_alpha = 1.0 if dist_from_end >= self._stream_fade_frames else dist_from_end / self._stream_fade_frames
         return self._overlay_frame(frame, fade_alpha)
 
-    def _apply(self, video: Video, **_context: Any) -> Video:
-        overlay = self._load_overlay()
-        if video.frame_shape != overlay[:, :, :3].shape:
-            raise ValueError(f"Mismatch of overlay shape `{overlay.shape}` with video shape: `{video.frame_shape}`!")
-        if not (0 <= 2 * self.fade_time <= video.total_seconds):
-            raise ValueError(f"Video is only {video.total_seconds}s long, but fade time is {self.fade_time}s!")
+    def predict_metadata(self, meta: VideoMetadata, **_context: Any) -> VideoMetadata:
+        """Reject an overlay that cannot composite onto this video at run time.
 
-        logger.info("Overlaying video...")
-        n = len(video.frames)
-        num_fade_frames = round(self.fade_time * video.fps) if self.fade_time > 0 else 0
-        for i in tqdm(range(n), desc="Overlaying frames"):
-            if num_fade_frames == 0:
-                video.frames[i] = self._overlay_frame(video.frames[i])
-            else:
-                dist_from_end = min(i, n - i)
-                fade_alpha = 1.0 if dist_from_end >= num_fade_frames else dist_from_end / num_fade_frames
-                video.frames[i] = self._overlay_frame(video.frames[i], fade_alpha)
-        return video
+        Two failures ``run_to_file()`` cannot survive are caught at ``validate()``
+        time instead of mid-stream: (a) the overlay's pixel dimensions must match
+        the video frame exactly (this op is full-frame, unlike
+        :class:`ImageOverlay`), and (b) the combined fade-in + fade-out cannot
+        exceed the clip length. Both checks come from the deleted eager path; the
+        overlay header is read once here (no per-frame work).
+        """
+        overlay = self._load_overlay()
+        frame_shape = (meta.height, meta.width, 3)
+        if frame_shape != overlay[:, :, :3].shape:
+            raise ValueError(f"Mismatch of overlay shape `{overlay.shape}` with video shape: `{frame_shape}`!")
+        if not (0 <= 2 * self.fade_time <= meta.total_seconds):
+            raise ValueError(f"Video is only {meta.total_seconds}s long, but fade time is {self.fade_time}s!")
+        return meta
 
 
 class Blur(Effect):
@@ -326,18 +320,6 @@ class Vignette(Effect):
         assert self._stream_mask_3d is not None
         return (frame.astype(np.float32) * self._stream_mask_3d).astype(np.uint8)
 
-    def _apply(self, video: Video, **_context: Any) -> Video:
-        logger.info("Applying vignette effect...")
-        height, width = video.frame_shape[:2]
-        if self._mask is None or self._mask.shape != (height, width):
-            self._mask = self._create_mask(height, width)
-        mask_3d = self._mask[:, :, np.newaxis]
-        batch_size = 64
-        for start in range(0, len(video.frames), batch_size):
-            end = min(start + batch_size, len(video.frames))
-            video.frames[start:end] = (video.frames[start:end].astype(np.float32) * mask_3d).astype(np.uint8)
-        return video
-
 
 class KenBurns(Effect):
     """Cinematic pan-and-zoom that smoothly animates between two crop regions.
@@ -473,29 +455,6 @@ class Fade(Effect):
             return frame
         return (frame.astype(np.float32) * a).astype(np.uint8)
 
-    def apply(self, video: Video, **context: Any) -> Video:
-        start_s, stop_s = self._resolved_window(video.total_seconds)
-        start_f = round(start_s * video.fps)
-        end_f = round(stop_s * video.fps)
-        n_effect = end_f - start_f
-        alpha = self._fade_envelope(n_effect, video.fps)
-
-        batch_size = 64
-        for batch_start in range(0, n_effect, batch_size):
-            batch_end = min(batch_start + batch_size, n_effect)
-            batch_alpha = alpha[batch_start:batch_end, np.newaxis, np.newaxis, np.newaxis]
-            if np.all(batch_alpha == 1.0):
-                continue
-            abs_start = start_f + batch_start
-            abs_end = start_f + batch_end
-            video.frames[abs_start:abs_end] = (video.frames[abs_start:abs_end].astype(np.float32) * batch_alpha).astype(
-                np.uint8
-            )
-
-        if video.audio is not None and not video.audio.is_silent:
-            self._audio_apply(video.audio, start_s, stop_s)
-        return video
-
     def _curve_expr(self, progress: str) -> str:
         """ffmpeg gain sub-expression for a 0->1 ramp ``progress``, per ``self.curve``.
 
@@ -513,8 +472,9 @@ class Fade(Effect):
         """Express the fade's gain envelope as a windowed ``volume`` expression.
 
         The audio twin of the video fade (which scales pixels by the same alpha
-        envelope). It must mirror :func:`_fade_envelope` / :meth:`_audio_apply`:
-        the ramp applies only WITHIN ``[start, stop]`` and the gain is 1.0
+        envelope in :meth:`process_frame`). It must mirror
+        :func:`_fade_envelope`: the ramp applies only WITHIN ``[start, stop]``
+        and the gain is 1.0
         everywhere else -- so a *windowed* fade-out returns to full volume after
         the window (matching the video, which resumes full brightness), instead
         of staying muted. Native ``afade`` cannot express this (it holds 0
@@ -531,8 +491,8 @@ class Fade(Effect):
         if stop_s <= start_s:
             return None
         window_len = stop_s - start_s
-        # Halve the ramp for in_out so the lead and trailing ramps cannot overlap
-        # (the eager path takes their min; a clamped half-window avoids it).
+        # Halve the ramp for in_out so the lead and trailing ramps cannot
+        # overlap; a clamped half-window keeps them disjoint.
         both = self.mode == "in_out"
         ramp = min(self.duration, window_len / 2 if both else window_len)
         if ramp <= 0:
@@ -549,19 +509,6 @@ class Fade(Effect):
         for cond, gain in reversed(terms):
             expr = f"if({cond},{gain},{expr})"
         return f"volume=volume='{expr}':eval=frame"
-
-    def _audio_apply(self, audio: Audio, start_s: float, stop_s: float) -> None:
-        """Eager (in-memory) fade for ``Video.apply``; streaming uses ``afade``."""
-        sample_rate = audio.metadata.sample_rate
-        audio_start = round(start_s * sample_rate)
-        audio_end = min(round(stop_s * sample_rate), len(audio.data))
-        alpha = self._fade_envelope(audio_end - audio_start, sample_rate)
-
-        if audio.data.ndim == 1:
-            audio.data[audio_start:audio_end] *= alpha
-        else:
-            audio.data[audio_start:audio_end] *= alpha[:, np.newaxis]
-        np.clip(audio.data, -1.0, 1.0, out=audio.data)
 
 
 class VolumeAdjust(Effect):
@@ -585,12 +532,6 @@ class VolumeAdjust(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return frame
 
-    def apply(self, video: Video, **context: Any) -> Video:
-        start_s, stop_s = self._resolved_window(video.total_seconds)
-        if video.audio is not None and not video.audio.is_silent:
-            self._audio_apply(video.audio, start_s, stop_s)
-        return video
-
     def to_ffmpeg_audio_filter(self, ctx: FilterCtx) -> str | None:
         """Apply the volume change over the window via the ``volume`` filter.
 
@@ -598,8 +539,8 @@ class VolumeAdjust(Effect):
         multiplier compiles to ``volume=<v>:enable='between(t,start,stop)'``.
         When ``ramp_duration>0`` the gain is a time-piecewise expression
         (``volume=eval=frame``) that ramps ``1 -> volume`` over the first
-        ``ramp_duration`` of the window and back over the last, mirroring the
-        eager ``1 + (volume-1)*sqrt(t)`` edge ramps. The window resolves
+        ``ramp_duration`` of the window and back over the last, following the
+        ``1 + (volume-1)*sqrt(t)`` edge-ramp shape. The window resolves
         against the segment duration (``ctx.frame_count / ctx.fps``); ``None``
         for a degenerate window or a no-op (``volume == 1`` with no ramp).
         """
@@ -632,35 +573,13 @@ class VolumeAdjust(Effect):
         )
         return f"volume=volume='{expr}':eval=frame"
 
-    def _audio_apply(self, audio: Audio, start_s: float, stop_s: float) -> None:
-        """Eager (in-memory) volume change for ``Video.apply``; streaming uses ``volume``."""
-        sample_rate = audio.metadata.sample_rate
-        start_sample = round(start_s * sample_rate)
-        end_sample = min(round(stop_s * sample_rate), len(audio.data))
-        n_samples = end_sample - start_sample
-        envelope = np.full(n_samples, self.volume, dtype=np.float32)
-
-        if self.ramp_duration > 0:
-            ramp_samples = min(round(self.ramp_duration * sample_rate), n_samples // 2)
-            if ramp_samples > 0:
-                t = np.linspace(0, 1, ramp_samples, dtype=np.float32)
-                envelope[:ramp_samples] = 1.0 + (self.volume - 1.0) * np.sqrt(t)
-                t = np.linspace(1, 0, ramp_samples, dtype=np.float32)
-                envelope[-ramp_samples:] = 1.0 + (self.volume - 1.0) * np.sqrt(t)
-
-        if audio.data.ndim == 1:
-            audio.data[start_sample:end_sample] *= envelope
-        else:
-            audio.data[start_sample:end_sample] *= envelope[:, np.newaxis]
-        np.clip(audio.data, -1.0, 1.0, out=audio.data)
-
 
 class _AnchoredOverlay(Effect):
     """Shared base for anchored RGBA overlays (:class:`TextOverlay`, :class:`ImageOverlay`).
 
-    Owns anchored placement, off-frame clipping, and alpha blending, so the
-    eager and streaming paths share one ``_blend_params`` source of truth (the
-    parity-hole class of bug fixed in 0.34.1). Subclasses declare their own
+    Owns anchored placement, off-frame clipping, and alpha blending in one
+    ``_blend_params`` source of truth (consolidated when the eager/streaming
+    parity-hole class of bug was fixed in 0.34.1). Subclasses declare their own
     ``position``/``anchor`` field defaults and implement
     :meth:`_overlay_for_frame` to produce the RGBA bitmap; everything
     downstream is shared. It declares no ``op`` ``Literal``, so it is an
@@ -723,11 +642,11 @@ class _AnchoredOverlay(Effect):
     def _blend_params(
         self, frame_w: int, frame_h: int
     ) -> tuple[np.ndarray, np.ndarray, tuple[int, int, int, int]] | None:
-        """Placement + blend inputs shared by the eager and streaming paths.
+        """Placement + blend inputs for the streaming path.
 
-        Single source of truth so the two paths cannot drift -- the eager/stream
-        parity-hole class of bug fixed in 0.34.1. Returns ``None`` when the
-        overlay lands fully off-frame (the effect is a no-op).
+        Single source of truth for placement and blending (consolidated when the
+        eager/stream parity-hole class of bug was fixed in 0.34.1). Returns
+        ``None`` when the overlay lands fully off-frame (the effect is a no-op).
         """
         overlay = self._overlay_for_frame(frame_w, frame_h)
         oh, ow = overlay.shape[:2]
@@ -942,7 +861,7 @@ class ImageOverlay(_AnchoredOverlay):
     def predict_metadata(self, meta: VideoMetadata, **_context: Any) -> VideoMetadata:
         """Reject only a missing/unreadable ``source`` (see :meth:`Operation.predict_metadata`).
 
-        An unreadable source is the one failure ``run()`` cannot survive -- it
+        An unreadable source is the one failure ``run_to_file()`` cannot survive -- it
         would raise mid-stream after expensive frame decode -- so it is caught
         at ``validate()`` time, symmetric with ``TranscriptionOverlay``.
         Geometry (oversized / off-frame) is deliberately *not* checked here: it

--- a/src/videopython/editing/operation.py
+++ b/src/videopython/editing/operation.py
@@ -2,9 +2,9 @@
 
 Every editing primitive is an ``Operation`` subclass -- a Pydantic model whose
 fields ARE the JSON wire format. Validation, schema, and serialisation come for
-free; subclasses just declare fields and implement ``apply``. Auto-registration
-via ``__pydantic_init_subclass__`` builds the ``op_id -> class`` registry as
-modules are imported.
+free; subclasses just declare fields and implement the streaming contract.
+Auto-registration via ``__pydantic_init_subclass__`` builds the
+``op_id -> class`` registry as modules are imported.
 
 Subclass contract::
 
@@ -23,7 +23,6 @@ Subclass contract::
         width: int | None = Field(None, gt=0)
         height: int | None = Field(None, gt=0)
 
-        def apply(self, video: Video) -> Video: ...
         def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata: ...
         def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None: ...
 """
@@ -38,10 +37,9 @@ from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, NamedTuple,
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, TypeAdapter
-from tqdm import tqdm
 
 if TYPE_CHECKING:
-    from videopython.base.video import Video, VideoMetadata
+    from videopython.base.video import VideoMetadata
 
 __all__ = [
     "OpCategory",
@@ -72,8 +70,9 @@ class TimeRange(BaseModel):
     *shape*; the numeric bounds (``>= 0``, ``stop >= start``, in-duration) are
     owned by :meth:`VideoEdit.validate` / :meth:`VideoEdit.check`, which report
     them as structured, collectable, repairable :class:`PlanError`s instead of
-    aborting at ``from_dict``. :meth:`Effect._resolved_window` still clamps at
-    run time, so a plan run without validation degrades rather than crashes.
+    aborting at ``from_dict``. The window is still clamped to
+    ``min(stop, total_seconds)`` at run time, so a plan run without validation
+    degrades rather than crashes.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -238,8 +237,8 @@ class Operation(BaseModel):
     wire and the registry key. Subclasses may override the ``category``,
     ``streamable``, and ``requires`` ClassVars.
 
-    The default ``apply`` raises ``NotImplementedError``; ``predict_metadata``
-    defaults to identity; ``to_ffmpeg_filter`` defaults to ``None`` (no filter compilation).
+    ``predict_metadata`` defaults to identity; ``to_ffmpeg_filter`` defaults to
+    ``None`` (no filter compilation).
     """
 
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
@@ -380,24 +379,14 @@ class Operation(BaseModel):
         """
         return _strip_llm_hidden(cls.model_json_schema())
 
-    def apply(self, video: Video) -> Video:
-        """Run this operation on ``video``.
-
-        The runner passes pipeline-context values listed in ``cls.requires``
-        as keyword arguments (e.g. ``transcription=...``). Subclasses that
-        declare ``requires`` widen the signature accordingly -- e.g.
-        ``def apply(self, video, transcription=None) -> Video``.
-        """
-        raise NotImplementedError(f"{type(self).__name__}.apply not implemented")
-
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         """Predict output metadata from input metadata. Default: identity.
 
         Run during ``VideoEdit.validate()``'s dry-run, before any frames are
         decoded. Beyond predicting shape, this is the fail-fast gate, and it
         has one contract: **reject exactly the plans that would otherwise crash
-        or do unrecoverable / expensive work in** :meth:`apply` **/** ``run()``;
-        anything ``run()`` can absorb by graceful degradation is NOT rejected.
+        or do unrecoverable / expensive work in** ``run_to_file()``;
+        anything ``run_to_file()`` can absorb by graceful degradation is NOT rejected.
         ``TranscriptionOverlay`` rejects un-fittable subtitles (they used to
         crash mid-render); ``TextOverlay``/``ImageOverlay`` do not reject
         off-frame geometry (it clips to a valid no-op). Keep the check
@@ -450,18 +439,16 @@ class Effect(Operation):
 
     Subclasses implement the streaming contract -- :meth:`process_frame` (and
     :meth:`streaming_init` for any precomputed per-stream state) -- which is the
-    single source of truth for the effect's pixel logic. The base
-    :meth:`_apply` runs that same contract over the in-memory frames, so
-    in-memory execution comes for free; the same code path feeds
-    ``editing/streaming.py`` for bounded-memory streaming. The base
-    :meth:`apply` resolves :attr:`window`, slices the video, runs ``_apply`` on
-    the slice, splices the result back, and asserts the shape-preserving
-    invariant.
+    single source of truth for the effect's pixel logic. The streaming engine
+    in ``editing/streaming.py`` drives that contract for bounded-memory
+    execution, resolving :attr:`window` against the segment timeline so frames
+    outside the window pass through untouched.
 
-    Override :meth:`_apply` only when eager execution must genuinely differ from
-    a frame-by-frame replay -- e.g. extra validation, a batched vectorisation,
-    or audio handling (``Fade``/``VolumeAdjust`` override :meth:`apply` outright
-    so the audio splice stays coherent with the window).
+    Effects that compile to a native ffmpeg filter instead set
+    :attr:`compiles_to_filter` and implement :meth:`to_ffmpeg_filter` (and, for
+    audio-coupled effects like ``Fade``/``VolumeAdjust``,
+    :meth:`to_ffmpeg_audio_filter`) so the window stays coherent across the
+    decode/encode graph.
     """
 
     category: ClassVar[OpCategory] = OpCategory.EFFECT
@@ -493,66 +480,14 @@ class Effect(Operation):
         """
         return False
 
-    def apply(self, video: Video, **context: Any) -> Video:
-        from videopython.base.video import Video as _Video
-
-        original_shape = video.video_shape
-
-        if self.window is None or (self.window.start is None and self.window.stop is None):
-            result = self._apply(video, **context)
-        else:
-            start_s, stop_s = self._resolved_window(video.total_seconds)
-            start_f = round(start_s * video.fps)
-            end_f = round(stop_s * video.fps)
-            inner = self._apply(video[start_f:end_f], **context)
-            old_audio = video.audio
-            result = _Video.from_frames(
-                np.r_["0,2", video.frames[:start_f], inner.frames, video.frames[end_f:]],
-                fps=video.fps,
-            )
-            result.audio = old_audio
-
-        if result.video_shape != original_shape:
-            raise RuntimeError(
-                f"{type(self).__name__} changed video shape from {original_shape} "
-                f"to {result.video_shape}; effects must preserve shape and frame count."
-            )
-        return result
-
     def predict_metadata(self, meta: VideoMetadata, **_context: Any) -> VideoMetadata:
         """Effects preserve shape and frame count, so the prediction is identity.
 
         Accepts ``**_context`` so requires-aware effects (``TranscriptionOverlay``)
         validate without subclasses needing to override just to widen the
-        signature. Mirrors :meth:`Effect.apply`'s ``**context`` accept-all.
+        signature. Mirrors :meth:`Effect.streaming_init`'s ``**_context`` accept-all.
         """
         return meta
-
-    def _resolved_window(self, total_seconds: float) -> tuple[float, float]:
-        win = self.window or TimeRange()
-        start_s = 0.0 if win.start is None else float(win.start)
-        stop_s = total_seconds if win.stop is None else float(win.stop)
-        start_s = min(start_s, total_seconds)
-        stop_s = min(stop_s, total_seconds)
-        if stop_s < start_s:
-            raise ValueError(f"Effect stop ({stop_s}) must be >= start ({start_s})")
-        return start_s, stop_s
-
-    def _apply(self, video: Video, **context: Any) -> Video:
-        """Apply the effect to ``video`` in memory by replaying the streaming path.
-
-        Runs :meth:`streaming_init` once, then :meth:`process_frame` over every
-        frame in order -- the same logic streaming uses, so eager and streaming
-        cannot drift. ``context`` carries resolved ``requires`` values through
-        to :meth:`streaming_init`, mirroring the streaming scheduler.
-        Subclasses that need a genuinely different eager path (extra
-        validation, batched vectorisation) override this.
-        """
-        height, width = video.frame_shape[:2]
-        self.streaming_init(len(video.frames), video.fps, width, height, **context)
-        for i in tqdm(range(len(video.frames)), desc=type(self).__name__):
-            video.frames[i] = self.process_frame(video.frames[i], i)
-        return video
 
     def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         """Hook for per-stream precomputation (per-frame alphas, sigma curves...).

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -21,7 +21,6 @@ from typing import Any, get_args
 import numpy as np
 from tqdm import tqdm
 
-from videopython.audio import Audio, AudioMetadata
 from videopython.base import _ffmpeg
 from videopython.base._dimensions import require_even
 from videopython.base.exceptions import PlanError, PlanErrorCode
@@ -125,11 +124,11 @@ def analyze_streamability(
     a transition is a native ffmpeg ``xfade``/``acrossfade`` pass over two
     realized per-segment files (each segment streams to a temp file exactly as
     it would without a transition), so it is FILTER-class by construction and
-    never forces an eager render or changes any op's class. The one transition
+    never makes a plan unstreamable or changes any op's class. The one transition
     fault that can reject a plan -- an overlap longer than an adjacent
     segment's predicted post-op duration -- is duration-dependent, so it is
     reported as ``TRANSITION_TOO_LONG`` by :meth:`VideoEdit.check` (which has
-    the predicted durations) and raised by ``run``/``run_to_file`` before
+    the predicted durations) and raised by ``run_to_file`` before
     decode, not classified structurally here.
     """
     entries: list[OpStreamability] = []
@@ -484,7 +483,7 @@ def build_audio_filter_complex(
       ``-ss start -t dur -i source`` (real audio) or ``-f lavfi -i anullsrc``
       (synthesised silence). ``input_index`` is the ffmpeg input index this
       stream lands at: ``1`` for :class:`FrameEncoder` (after the ``pipe:0``
-      video), ``0`` for the audio-only ``run()`` materialiser.
+      video), ``0`` when the audio stream is the sole input.
     - ``graph_statements`` are the ``;``-joined ``filter_complex`` statements
       wiring input ``[<i>:a]`` through ``af_filters`` then ``post_af_filters``,
       a length pin, and an ``aresample`` to a final ``[aout]``.
@@ -679,41 +678,6 @@ def segment_audio_from_plan(plan: StreamingSegmentPlan) -> SegmentAudio:
     )
 
 
-def stream_segment_audio_to_array(plan: StreamingSegmentPlan, *, sample_rate: int = 44100) -> Audio:
-    """Decode the segment's compiled audio graph into an in-memory :class:`Audio`.
-
-    The audio counterpart of :func:`stream_segment_to_frames`: ``run()`` is
-    "stream into memory", so it still produces an ``Audio`` for ``video.audio``.
-    Runs the SAME ``af_filters`` / ``post_af_filters`` graph the file path bakes
-    into the segment (so ``run()`` and ``run_to_file`` cannot diverge) and reads
-    the result back as float32 PCM -- O(output-duration) memory, materialised
-    only for the in-memory view, never for ``run_to_file``. A source with no
-    audio stream yields a native ``anullsrc`` silent track.
-    """
-    audio = segment_audio_from_plan(plan)
-    # The audio source is the ONLY input here (no video pipe), so it sits at
-    # input index 0 -- the graph builder labels [0:a] accordingly.
-    input_args, graph, out_label = build_audio_filter_complex(audio, input_index=0, sample_rate=sample_rate)
-    cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error", *input_args]
-    cmd.extend(["-filter_complex", ";".join(graph), "-map", out_label])
-    cmd.extend(["-ac", "2", "-ar", str(sample_rate), "-f", "f32le", "pipe:1"])
-    raw = _ffmpeg.run(cmd)
-
-    data = np.frombuffer(raw, dtype=np.float32)
-    if data.size % 2 != 0:
-        data = data[: data.size - 1]
-    data = data.reshape(-1, 2).copy()
-    np.clip(data, -1.0, 1.0, out=data)
-    metadata = AudioMetadata(
-        sample_rate=sample_rate,
-        channels=2,
-        sample_width=2,
-        duration_seconds=data.shape[0] / sample_rate,
-        frame_count=data.shape[0],
-    )
-    return Audio(data, metadata)
-
-
 def stream_segment(
     plan: StreamingSegmentPlan,
     output_path: Path,
@@ -818,94 +782,6 @@ def stream_segment(
         raise
 
 
-def stream_segment_to_frames(plan: StreamingSegmentPlan) -> np.ndarray:
-    """Run a segment's streaming pipeline into memory instead of a file.
-
-    The same scheduler ``stream_segment`` uses -- decode through the plan's
-    vf chain, per-frame effects in plan order, encode-stage filters via a
-    lossless rawvideo pass -- collecting RGB frames instead of encoding.
-    This is what makes ``VideoEdit.run`` a view over the streaming engine
-    rather than a second execution path.
-    """
-    total_frames = plan.output_total_frames
-    if total_frames <= 0:
-        total_frames = round((plan.end_second - plan.start_second) * plan.output_fps)
-
-    for entry in plan.effect_schedule:
-        n_effect_frames = (
-            entry.total_effect_frames if entry.total_effect_frames is not None else entry.end_frame - entry.start_frame
-        )
-        entry.effect.streaming_init(
-            n_effect_frames, plan.output_fps, plan.output_width, plan.output_height, **entry.context
-        )
-
-    frames: list[np.ndarray] = []
-    with FrameIterator(
-        plan.source_path,
-        start_second=plan.start_second,
-        end_second=plan.end_second,
-        vf_filters=plan.vf_filters,
-        output_fps=plan.output_fps,
-        output_width=plan.output_width,
-        output_height=plan.output_height,
-    ) as decoder:
-        frame_count = 0
-        for _, frame in tqdm(decoder, desc="Streaming (in-memory)", total=total_frames):
-            for entry in plan.effect_schedule:
-                open_ended = entry.end_frame >= total_frames
-                if entry.start_frame <= frame_count and (frame_count < entry.end_frame or open_ended):
-                    local_index = entry.index_offset + min(frame_count, entry.end_frame - 1) - entry.start_frame
-                    frame = entry.effect.process_frame(frame, local_index)
-            frames.append(frame)
-            frame_count += 1
-
-    stacked = np.stack(frames) if frames else np.empty((0, plan.output_height, plan.output_width, 3), dtype=np.uint8)
-    if not plan.post_vf_filters:
-        return stacked
-
-    # Encode-stage filters: a lossless rawvideo->rawvideo pass, the in-memory
-    # twin of FrameEncoder's -vf.
-    n, height, width = stacked.shape[:3]
-    cmd = [
-        "ffmpeg",
-        "-hide_banner",
-        "-loglevel",
-        "error",
-        "-f",
-        "rawvideo",
-        "-pixel_format",
-        "rgb24",
-        "-video_size",
-        f"{width}x{height}",
-        "-framerate",
-        str(plan.output_fps),
-        "-i",
-        "pipe:0",
-        "-vf",
-        ",".join(plan.post_vf_filters),
-        "-f",
-        "rawvideo",
-        "-pix_fmt",
-        "rgb24",
-        "pipe:1",
-    ]
-    out = _ffmpeg.run(cmd, stdin=stacked.tobytes())
-    return out_frames_reshape(out, plan, n)
-
-
-def out_frames_reshape(raw: bytes, plan: StreamingSegmentPlan, n_in: int) -> np.ndarray:
-    """Reshape a rawvideo byte stream using the plan's final geometry.
-
-    Encode-stage transforms may change dims/fps; the builder records the
-    folded final geometry on the plan (``final_width``/``final_height``).
-    """
-    final_w = plan.final_width or plan.output_width
-    final_h = plan.final_height or plan.output_height
-    frame_size = final_w * final_h * 3
-    n_frames = len(raw) // frame_size
-    return np.frombuffer(raw, dtype=np.uint8)[: n_frames * frame_size].reshape(n_frames, final_h, final_w, 3).copy()
-
-
 def concat_files(segment_files: list[Path], output_path: Path) -> Path:
     """Concatenate encoded video files using ffmpeg concat demuxer (no re-encode).
 
@@ -960,12 +836,11 @@ TRANSITION_TYPES: tuple[str, ...] = (
 
 
 def xfade_filter(transition_type: str, duration: float, offset: float, *, in_a: str = "0:v", in_b: str = "1:v") -> str:
-    """Build the one ``xfade`` filter expression shared by both transition paths.
+    """Build the one ``xfade`` filter expression for the transition path.
 
-    The single source of the seam pixels: ``run()``'s in-memory twin
-    (:func:`stream_transition_frames`) and ``run_to_file``'s file pass
-    (:func:`stream_transition_pair`) both route through this so they cannot
-    diverge. ``offset`` is in seconds against the LEFT input's exact (probed)
+    The single source of the seam pixels: ``run_to_file``'s file pass
+    (:func:`stream_transition_pair`) routes through this.
+    ``offset`` is in seconds against the LEFT input's exact (probed)
     duration -- the caller derives it from the realized file, never the
     prediction, to avoid a one-frame seam.
     """
@@ -1083,89 +958,3 @@ def stream_transition_pair(
             output_path.unlink()
         raise
     return output_path
-
-
-def stream_transition_frames(
-    left_frames: np.ndarray,
-    right_frames: np.ndarray,
-    transition_type: str,
-    duration: float,
-    fps: float,
-) -> np.ndarray:
-    """In-memory xfade twin: blend two RGB frame stacks over a ``duration`` overlap.
-
-    The view-over-streaming counterpart to :func:`stream_transition_pair`: a
-    lossless rawvideo->rawvideo ``filter_complex`` pass through the SAME
-    :func:`xfade_filter` builder, so ``run()`` and ``run_to_file`` produce
-    identical seam pixels. The overlap is ``round(duration * fps)`` frames; the
-    result has ``len(left) + len(right) - overlap`` frames. ``offset`` is
-    derived from the left stack's exact frame count (``(n_left - overlap) /
-    fps``), the in-memory analogue of probing the realized left file.
-    """
-    if left_frames.shape[1:] != right_frames.shape[1:]:
-        raise ValueError(
-            f"Transition inputs must share frame shape: {left_frames.shape[1:]} vs {right_frames.shape[1:]}"
-        )
-    n_left, height, width = left_frames.shape[:3]
-    n_right = right_frames.shape[0]
-    overlap = round(duration * fps)
-    if overlap >= n_left or overlap >= n_right:
-        raise ValueError(
-            f"Transition overlap ({overlap} frames) must be shorter than both segments (left={n_left}, right={n_right})"
-        )
-    # Offset from the LEFT stack's exact length, the in-memory mirror of
-    # probing the realized left file -- keeps the seam frame-aligned.
-    offset = (n_left - overlap) / fps
-    filter_expr = f"{xfade_filter(transition_type, duration, offset)}[vout]"
-
-    # ffmpeg has a single stdin, so the two raw inputs go through small temp
-    # files and the blended result comes back on stdout. run() already holds
-    # whole frame stacks in memory, so the temp files add no asymptotic cost
-    # and avoid the FIFO ordering deadlock two named pipes invite.
-    tmpdir = Path(tempfile.mkdtemp(prefix="vp_xfade_"))
-    left_path = tmpdir / "a.raw"
-    right_path = tmpdir / "b.raw"
-    try:
-        left_path.write_bytes(left_frames.tobytes())
-        right_path.write_bytes(right_frames.tobytes())
-
-        def _raw_input(path: Path) -> list[str]:
-            return [
-                "-f",
-                "rawvideo",
-                "-pixel_format",
-                "rgb24",
-                "-video_size",
-                f"{width}x{height}",
-                "-framerate",
-                str(fps),
-                "-i",
-                str(path),
-            ]
-
-        cmd = [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            *_raw_input(left_path),
-            *_raw_input(right_path),
-            "-filter_complex",
-            filter_expr,
-            "-map",
-            "[vout]",
-            "-f",
-            "rawvideo",
-            "-pix_fmt",
-            "rgb24",
-            "pipe:1",
-        ]
-        out = _ffmpeg.run(cmd)
-    finally:
-        left_path.unlink(missing_ok=True)
-        right_path.unlink(missing_ok=True)
-        tmpdir.rmdir()
-
-    frame_size = width * height * 3
-    n_frames = len(out) // frame_size
-    return np.frombuffer(out, dtype=np.uint8)[: n_frames * frame_size].reshape(n_frames, height, width, 3).copy()

--- a/src/videopython/editing/transcription_overlay.py
+++ b/src/videopython/editing/transcription_overlay.py
@@ -3,14 +3,10 @@
 The ``add_subtitles`` op consumes its transcription when the plan compiles:
 the cue transforms (``max_words_per_cue`` chunking, sentence capitalization)
 and the resolved look are baked into an ASS document, and ffmpeg's
-``subtitles=`` filter (libass) burns it in. One pixel path everywhere:
-
-* the streaming path emits one ``-vf`` entry -- decode-stage normally, or
-  encode-stage when the op follows frame effects in plan order, so
-  ``[fade, add_subtitles]`` keeps streaming in plan order;
-* the direct per-op path (:meth:`TranscriptionOverlay.apply`) pipes its
-  in-memory frames through the same filter (``VideoEdit.run`` streams them
-  in through the same compiled ``-vf`` entry).
+``subtitles=`` filter (libass) burns it in. The streaming path emits one
+``-vf`` entry -- decode-stage normally, or encode-stage when the op follows
+frame effects in plan order, so ``[fade, add_subtitles]`` keeps streaming in
+plan order.
 
 Geometry is resolution-relative (``font_scale``/``region``) and libass wraps
 long cues within the box instead of failing, so there is no fit validation:
@@ -23,16 +19,13 @@ import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal
 
-import numpy as np
 from PIL import ImageFont
 from pydantic import Field
 
-from videopython.base import _ffmpeg
 from videopython.base.fonts import BUNDLED_FONT_FAMILIES, bundled_fonts_dir, load_font
 from videopython.base.transcription import Transcription
-from videopython.base.video import Video
 from videopython.editing._ass import AnchorPoint, AssLook, build_ass, escape_filter_value
 from videopython.editing.operation import Effect, FilterCtx
 
@@ -47,7 +40,7 @@ RGBAColor = tuple[int, int, int, int]
 
 _MISSING_CONTEXT_ERROR = (
     "TranscriptionOverlay requires transcription data. "
-    "Pass it via VideoEdit.run(context={'transcription': ...}) or directly to apply()."
+    "Pass it via VideoEdit.run_to_file(context={'transcription': ...})."
 )
 
 
@@ -109,8 +102,7 @@ class TranscriptionOverlay(Effect):
     local timeline and delivered at plan-compile time through
     :class:`FilterCtx`; the op compiles to a libass ``subtitles=`` filter
     (:attr:`compiles_to_filter`), so subtitled edits run on the O(1)-memory
-    streaming path at native speed. The direct per-op ``apply`` pipes frames
-    through the same filter, so both paths share one pixel implementation.
+    streaming path at native speed.
     """
 
     op: Literal["add_subtitles"] = "add_subtitles"
@@ -299,8 +291,7 @@ class TranscriptionOverlay(Effect):
         """The full ASS document for ``transcription`` at the given frame size.
 
         ``transcription`` timestamps must be local to the timeline the frames
-        come from (the plan builder re-bases context onto the cut segment; the
-        eager path receives the video-local transcription directly). The
+        come from (the plan builder re-bases context onto the cut segment). The
         ``window`` is applied by clipping event times -- the ``subtitles``
         filter has no timeline support.
         """
@@ -334,7 +325,7 @@ class TranscriptionOverlay(Effect):
         compile time: writes a temp ``.ass`` (registered on ``ctx.owned_files``
         for the runner to delete after streaming) and emits one ``-vf`` entry.
         A missing transcription raises the op's clear context error here --
-        before any decode -- mirroring the eager path.
+        before any decode.
         """
         transcription = ctx.context.get("transcription")
         if not isinstance(transcription, Transcription):
@@ -342,57 +333,3 @@ class TranscriptionOverlay(Effect):
         ass_path = self._write_ass(self._compile_ass(transcription, ctx.width, ctx.height))
         ctx.owned_files.append(ass_path)
         return self._filter_expr(ass_path)
-
-    def apply(
-        self,
-        video: Video,
-        transcription: Transcription | None = None,
-        **_context: Any,
-    ) -> Video:
-        """Eager render: pipe the in-memory frames through the same filter.
-
-        One ffmpeg rawvideo->``subtitles=``->rawvideo roundtrip, so eager and
-        streaming output come from the same renderer. The rawvideo pipe's
-        timestamps start at zero, matching the video-local transcription the
-        caller passes (``VideoEdit.run`` re-bases per segment). Frames are
-        replaced in place, like every effect; audio is untouched.
-        """
-        if transcription is None:
-            raise ValueError(_MISSING_CONTEXT_ERROR)
-        n_frames, height, width = video.frames.shape[:3]
-        ass_path = self._write_ass(self._compile_ass(transcription, width, height))
-        try:
-            cmd = [
-                "ffmpeg",
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-f",
-                "rawvideo",
-                "-pixel_format",
-                "rgb24",
-                "-video_size",
-                f"{width}x{height}",
-                "-framerate",
-                str(video.fps),
-                "-i",
-                "pipe:0",
-                "-vf",
-                self._filter_expr(ass_path),
-                "-f",
-                "rawvideo",
-                "-pix_fmt",
-                "rgb24",
-                "pipe:1",
-            ]
-            out = _ffmpeg.run(cmd, stdin=video.frames.tobytes())
-        finally:
-            ass_path.unlink(missing_ok=True)
-        frames = np.frombuffer(out, dtype=np.uint8).reshape(-1, height, width, 3)
-        if frames.shape[0] != n_frames:
-            raise RuntimeError(
-                f"subtitles filter changed the frame count from {n_frames} to {frames.shape[0]}; "
-                "effects must preserve shape and frame count."
-            )
-        video.frames = frames.copy()  # frombuffer is read-only; effects own writable frames
-        return video

--- a/src/videopython/editing/transforms.py
+++ b/src/videopython/editing/transforms.py
@@ -7,29 +7,20 @@ See ``editing/operation.py`` for the ``Operation`` base.
 
 from __future__ import annotations
 
-import dataclasses
-import logging
 import math
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-import cv2
-import numpy as np
 from pydantic import Field, model_validator
-from tqdm import tqdm
 
-from videopython.audio import Audio
 from videopython.audio.audio import atempo_chain
 from videopython.base._dimensions import floor_to_even, round_to_even
 from videopython.base.exceptions import PlanError, PlanErrorCode, PlanValidationError
-from videopython.base.video import Video
 from videopython.editing.operation import BoundedTimeField, FilterCtx, OpCategory, Operation
 
 if TYPE_CHECKING:
     from videopython.base.transcription import Transcription
     from videopython.base.video import VideoMetadata
-
-logger = logging.getLogger(__name__)
 
 # Shared tolerance (seconds) for duration bounds checks across the editing layer,
 # so the located segment guard and the cut transforms accept the same boundary.
@@ -90,9 +81,6 @@ class CutFrames(Operation):
             raise ValueError(f"end ({self.end}) must be greater than start ({self.start})")
         return self
 
-    def apply(self, video: Video) -> Video:
-        return video[self.start : self.end]
-
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         # ints; eps inert -- DURATION_EPS is seconds-scale, never flips an int compare.
         if self.end > meta.frame_count + DURATION_EPS:
@@ -128,9 +116,6 @@ class CutSeconds(Operation):
             raise ValueError(f"end ({self.end}) must be greater than start ({self.start})")
         return self
 
-    def apply(self, video: Video) -> Video:
-        return video[round(self.start * video.fps) : round(self.end * video.fps)]
-
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         if self.end > meta.total_seconds + DURATION_EPS:
             message = f"end time ({self.end}) exceeds video duration ({meta.total_seconds})"
@@ -147,7 +132,8 @@ class CutSeconds(Operation):
                     )
                 ],
             )
-        # Mirror apply(): round both endpoints to frames before computing the duration.
+        # Round both endpoints to frames before computing the duration, matching
+        # the frame-accurate cut the compiled filter performs.
         start_f = round(self.start * meta.fps)
         end_f = round(self.end * meta.fps)
         duration = round((end_f - start_f) / meta.fps, 4)
@@ -186,15 +172,6 @@ class Resize(Operation):
             new_h = round_to_even(new_h)
         return new_w, new_h
 
-    def apply(self, video: Video) -> Video:
-        new_w, new_h = self._resolve_dims(video.video_shape[2], video.video_shape[1])
-        logger.info(f"Resizing video to: {new_w}x{new_h}!")
-        video.frames = np.asarray(
-            [cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_AREA) for frame in video.frames],
-            dtype=np.uint8,
-        )
-        return video
-
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         new_w, new_h = self._resolve_dims(meta.width, meta.height)
         return meta.with_dimensions(new_w, new_h)
@@ -212,40 +189,6 @@ class ResampleFPS(Operation):
     streamable: ClassVar[bool] = True
 
     fps: float = Field(gt=0, description="Target frames per second.")
-
-    def _downsample(self, video: Video) -> Video:
-        target = int(len(video.frames) * (self.fps / video.fps))
-        idx = np.round(np.linspace(0, len(video.frames) - 1, target)).astype(int)
-        video.frames = video.frames[idx]
-        video.fps = self.fps
-        return video
-
-    def _upsample(self, video: Video) -> Video:
-        target = int(len(video.frames) * (self.fps / video.fps))
-        positions = np.linspace(0, len(video.frames) - 1, target)
-        new_frames = []
-        for pos in tqdm(positions, desc="Interpolating frames"):
-            ratio = pos % 1
-            low = int(pos)
-            high = int(np.ceil(pos))
-            frame = (1 - ratio) * video.frames[low] + ratio * video.frames[high]
-            new_frames.append(frame.astype(np.uint8))
-        video.frames = np.array(new_frames, dtype=np.uint8)
-        video.fps = self.fps
-        return video
-
-    def apply(self, video: Video) -> Video:
-        if video.fps == self.fps:
-            return video
-        if video.fps > self.fps:
-            logger.info(f"Downsampling video from {video.fps} to {self.fps} FPS.")
-            video = self._downsample(video)
-        else:
-            logger.info(f"Upsampling video from {video.fps} to {self.fps} FPS.")
-            video = self._upsample(video)
-        if video.audio is not None:
-            video.audio = video.audio.fit_to_duration(len(video.frames) / video.fps)
-        return video
 
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         return meta.with_fps(self.fps)
@@ -296,17 +239,6 @@ class Crop(Operation):
             cy = self._to_pixels(self.y, src_h)
         return cx, cy, cw, ch
 
-    def apply(self, video: Video) -> Video:
-        src_h, src_w = video.frame_shape[:2]
-        cx, cy, cw, ch = self._resolve_box(src_w, src_h)
-        if self.mode == CropMode.CENTER:
-            mid_w, mid_h = src_w // 2, src_h // 2
-            off_w, off_h = cw // 2, ch // 2
-            video.frames = video.frames[:, mid_h - off_h : mid_h + off_h, mid_w - off_w : mid_w + off_w, :]
-        else:
-            video.frames = video.frames[:, cy : cy + ch, cx : cx + cw, :]
-        return video
-
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         _, _, cw, ch = self._resolve_box(meta.width, meta.height)
         if cw > meta.width or ch > meta.height:
@@ -324,8 +256,8 @@ class Crop(Operation):
                 ],
             )
         if self.mode == CropMode.CENTER:
-            # Mirror apply()'s `mid - cw//2 : mid + cw//2` slice, which
-            # produces 2 * (cw // 2) pixels — odd targets round down.
+            # A centered crop spans `mid - cw//2 : mid + cw//2`, i.e. 2 * (cw // 2)
+            # pixels, so odd targets round down -- match that here.
             cw = floor_to_even(cw)
             ch = floor_to_even(ch)
         return meta.with_dimensions(cw, ch)
@@ -372,16 +304,16 @@ class SpeedChange(Operation):
         forward-bias correction so the ``fps`` filter's tick rounding selects
         the same nearest source frame a per-frame sampler would.
 
-        Ramp: the eager sampler varies speed linearly across the *source*
-        timeline and renormalizes so the output spans ``frame_count / avg``
-        frames; the closed form of that curve is
+        Ramp: speed varies linearly across the *source* timeline, renormalized
+        so the output spans ``frame_count / avg`` frames; the closed form of
+        that curve is
         ``out(T) = D_out * ln(1 + (b-a)*T/(a*D_in)) / ln(b/a)``, evaluated
         per frame by ``setpts`` in double precision.
 
         With ``interpolate`` on a slowdown, the CFR resampler is the
         ``framerate`` filter (blends adjacent frames) instead of ``fps``
-        (nearest), matching the eager path's frame blending in spirit -- the
-        blend weighting is libavfilter's, not pixel-identical.
+        (nearest), for frame-blended slow motion -- the blend weighting is
+        libavfilter's.
         """
         k = self.speed
         if self.end_speed is None or self.end_speed == self.speed:
@@ -412,8 +344,8 @@ class SpeedChange(Operation):
 
         The audio twin of :meth:`to_ffmpeg_filter`: streams in the same ffmpeg
         process as the video. Ramps are approximated with a single constant
-        stretch at the average speed -- the same approximation the eager path
-        uses, so the two paths agree. ``adjust_audio=False`` leaves the audio
+        stretch at the average speed, so the audio stays aligned with the
+        retimed video. ``adjust_audio=False`` leaves the audio
         untouched (the ``atrim`` to the predicted output duration is applied by
         the encoder graph's tail). Returns ``None`` when no stretch is needed.
         """
@@ -421,60 +353,6 @@ class SpeedChange(Operation):
             return None
         filters = atempo_chain(self._eff_speed())
         return ",".join(filters) if filters else None
-
-    def _audio_apply(self, audio: Audio, output_duration: float) -> Audio:
-        """Eager (in-memory) audio time-stretch for ``Video.apply``.
-
-        The friendly ``Video`` API still mutates an in-memory ``Audio`` array;
-        the streaming engine uses :meth:`to_ffmpeg_audio_filter` instead.
-        """
-        if not audio.is_silent and self.adjust_audio:
-            audio = audio.time_stretch(self._eff_speed())
-        return audio.fit_to_duration(output_duration)
-
-    def apply(self, video: Video) -> Video:
-        n_frames = len(video.frames)
-
-        if self.end_speed is None:
-            logger.info(f"Applying {self.speed}x speed change...")
-            new_count = int(n_frames / self.speed)
-            if new_count == 0:
-                raise ValueError(f"Speed {self.speed}x would result in 0 frames!")
-            source_indices = np.linspace(0, n_frames - 1, new_count)
-        else:
-            logger.info(f"Applying speed ramp from {self.speed}x to {self.end_speed}x...")
-            num_samples = 1000
-            speeds = np.linspace(self.speed, self.end_speed, num_samples)
-            time_per_sample = 1.0 / speeds
-            cumulative_time = np.cumsum(time_per_sample)
-            cumulative_time = cumulative_time / cumulative_time[-1]
-            new_count = self._new_frame_count(n_frames)
-            if new_count == 0:
-                raise ValueError("Speed ramp would result in 0 frames!")
-            output_positions = np.linspace(0, 1, new_count)
-            source_positions = np.interp(output_positions, cumulative_time, np.linspace(0, 1, num_samples))
-            source_indices = source_positions * (n_frames - 1)
-
-        if self.interpolate and self._is_slow:
-            new_frames = []
-            for idx in tqdm(source_indices, desc="Interpolating frames"):
-                idx_low = int(idx)
-                idx_high = min(idx_low + 1, n_frames - 1)
-                ratio = idx - idx_low
-                if ratio == 0 or idx_low == idx_high:
-                    new_frames.append(video.frames[idx_low])
-                else:
-                    frame = (1 - ratio) * video.frames[idx_low] + ratio * video.frames[idx_high]
-                    new_frames.append(frame.astype(np.uint8))
-            video.frames = np.array(new_frames, dtype=np.uint8)
-        else:
-            indices = np.clip(np.round(source_indices).astype(int), 0, n_frames - 1)
-            video.frames = video.frames[indices]
-
-        target_duration = len(video.frames) / video.fps
-        if video.audio is not None:
-            video.audio = self._audio_apply(video.audio, target_duration)
-        return video
 
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         new_count = self._new_frame_count(meta.frame_count)
@@ -520,28 +398,6 @@ class FreezeFrame(Operation):
         description="'after' / 'before' inserts frames; 'replace' swaps existing frames out.",
     )
 
-    def apply(self, video: Video) -> Video:
-        if self.timestamp >= video.total_seconds:
-            raise ValueError(f"timestamp ({self.timestamp}) must be less than video duration ({video.total_seconds})")
-
-        frame_idx = min(round(self.timestamp * video.fps), len(video.frames) - 1)
-        freeze_count = round(self.duration * video.fps)
-        frozen = np.tile(video.frames[frame_idx : frame_idx + 1], (freeze_count, 1, 1, 1))
-
-        if self.position == "after":
-            insert_idx = frame_idx + 1
-            video.frames = np.concatenate([video.frames[:insert_idx], frozen, video.frames[insert_idx:]], axis=0)
-        elif self.position == "before":
-            video.frames = np.concatenate([video.frames[:frame_idx], frozen, video.frames[frame_idx:]], axis=0)
-        else:  # replace
-            replace_end = min(frame_idx + freeze_count, len(video.frames))
-            video.frames = np.concatenate([video.frames[:frame_idx], frozen, video.frames[replace_end:]], axis=0)
-
-        if video.audio is not None:
-            target_duration = len(video.frames) / video.fps
-            video.audio = self._audio_apply(video.audio, target_duration, video.fps)
-        return video
-
     def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
         """Compile to a linear ``loop``-based freeze chain.
 
@@ -553,8 +409,8 @@ class FreezeFrame(Operation):
         region), and ``setpts`` regenerates CFR timing. Needs the input
         frame count (``ctx.frame_count``); unknown -> not streamable.
 
-        Raises the same out-of-range error as the eager path when
-        ``timestamp`` lies past the clip end -- at compile, before decode.
+        Raises an out-of-range error when ``timestamp`` lies past the clip
+        end -- at compile, before decode.
         """
         if ctx.frame_count <= 0:
             return None
@@ -592,8 +448,8 @@ class FreezeFrame(Operation):
         ``filter_complex`` splice that needs no extra input -- the input is
         ``asplit`` into head / silence / tail streams, the silence stream is a
         ``duration``-long slice zeroed by ``volume=0``, and ``concat`` rejoins
-        them. ``after`` inserts at ``timestamp + 1/fps`` (mirroring the eager
-        sample math), ``before`` at ``timestamp``, ``replace`` drops the covered
+        them. ``after`` inserts at ``timestamp + 1/fps`` (matching the video
+        splice point), ``before`` at ``timestamp``, ``replace`` drops the covered
         original audio (tail starts at ``timestamp + duration``).
 
         Returns a ``;``-joined fragment using ``ctx.audio_label``-prefixed
@@ -618,37 +474,6 @@ class FreezeFrame(Operation):
             f"[{p}t]atrim=start={tail_start:.6f},asetpts=N/SR/TB[{p}tt];"
             f"[{p}hh][{p}ss][{p}tt]concat=n=3:v=0:a=1"
         )
-
-    def _audio_apply(self, audio: Audio, output_duration: float, fps: float) -> Audio:
-        """Eager (in-memory) silence splice for ``Video.apply``.
-
-        The friendly ``Video`` API still mutates an in-memory ``Audio`` array;
-        the streaming engine uses :meth:`to_ffmpeg_audio_filter` instead.
-        """
-        sample_rate = audio.metadata.sample_rate
-        channels = audio.metadata.channels
-        silence_samples = round(self.duration * sample_rate)
-        silence_shape = (silence_samples, channels) if channels > 1 else (silence_samples,)
-        silence = np.zeros(silence_shape, dtype=np.float32)
-        timestamp_sample = round(self.timestamp * sample_rate)
-
-        if self.position == "after":
-            insert_sample = min(timestamp_sample + round(sample_rate / fps), len(audio.data))
-            data = np.concatenate([audio.data[:insert_sample], silence, audio.data[insert_sample:]], axis=0)
-        elif self.position == "before":
-            data = np.concatenate([audio.data[:timestamp_sample], silence, audio.data[timestamp_sample:]], axis=0)
-        else:
-            replace_end_sample = min(timestamp_sample + silence_samples, len(audio.data))
-            data = np.concatenate([audio.data[:timestamp_sample], silence, audio.data[replace_end_sample:]], axis=0)
-        # Rebuild metadata from the new sample count: fit_to_duration trusts
-        # metadata.duration_seconds, so a raw .data mutation would leave it
-        # stale and make the fit pad the insertion a second time.
-        metadata = dataclasses.replace(
-            audio.metadata,
-            duration_seconds=data.shape[0] / sample_rate,
-            frame_count=data.shape[0],
-        )
-        return Audio(data, metadata).fit_to_duration(output_duration)
 
     def predict_metadata(self, meta: VideoMetadata) -> VideoMetadata:
         if self.timestamp >= meta.total_seconds:
@@ -702,8 +527,7 @@ class SilenceRemoval(Operation):
     padding: float = Field(0.15, ge=0, description="Seconds of breathing room around each speech boundary.")
 
     _MISSING_CONTEXT = (
-        "SilenceRemoval requires transcription data. "
-        "Pass it via VideoEdit.run(context={'transcription': ...}) or directly to apply()."
+        "SilenceRemoval requires transcription data. Pass it via VideoEdit.run_to_file(context={'transcription': ...})."
     )
 
     def _silence_ranges(self, words: list[Any], total_seconds: float) -> list[tuple[float, float]]:
@@ -726,9 +550,9 @@ class SilenceRemoval(Operation):
     ) -> list[tuple[int, int]] | None:
         """Frame ranges to keep, or ``None`` for "nothing to cut" (identity).
 
-        The single source of the cut math, shared by the eager apply, the
-        filter compile, the audio twin, and ``predict_metadata`` -- all four
-        must agree on the output timeline.
+        The single source of the cut math, shared by the filter compile, the
+        audio twin, and ``predict_metadata`` -- all three must agree on the
+        output timeline.
         """
         words = transcription.words
         if not words:
@@ -747,17 +571,6 @@ class SilenceRemoval(Operation):
         if prev_frame < n_frames:
             keep.append((prev_frame, n_frames))
         return keep or None
-
-    def apply(self, video: Video, transcription: Transcription | None = None) -> Video:
-        if transcription is None:
-            raise ValueError(self._MISSING_CONTEXT)
-        keep = self._keep_frame_ranges(transcription, video.total_seconds, video.fps, len(video.frames))
-        if keep is None:
-            return video
-        video.frames = np.concatenate([video.frames[s:e] for s, e in keep], axis=0)
-        if video.audio is not None:
-            video.audio = self._audio_apply(video.audio, len(video.frames) / video.fps, video.fps, transcription)
-        return video
 
     def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
         """Compile the cut to a ``select`` keep-window filter.
@@ -789,8 +602,8 @@ class SilenceRemoval(Operation):
         cannot reproduce the sample-accurate cut; instead the input is
         ``asplit`` into one copy per window, each ``atrim``-ed to its
         ``[start, end)`` time span (``atrim`` cuts on the sample boundary), then
-        ``concat``-ed in order -- the audio analogue of the frame-slice the
-        eager path does. No silences -> ``None`` (identity).
+        ``concat``-ed in order -- the audio analogue of the kept frame ranges.
+        No silences -> ``None`` (identity).
         """
         from videopython.base.transcription import Transcription as _Transcription
 
@@ -813,28 +626,6 @@ class SilenceRemoval(Operation):
         joined = "".join(f"[{p}k{i}]" for i in range(n))
         stmts.append(f"{joined}concat=n={n}:v=0:a=1")
         return ";".join(stmts)
-
-    def _audio_apply(self, audio: Audio, output_duration: float, fps: float, transcription: Any) -> Audio:
-        """Eager (in-memory) keep-window cut for ``Video.apply``.
-
-        The friendly ``Video`` API still mutates an in-memory ``Audio`` array;
-        the streaming engine uses :meth:`to_ffmpeg_audio_filter` instead.
-        """
-        if transcription is None:
-            raise ValueError(self._MISSING_CONTEXT)
-        total_seconds = audio.metadata.duration_seconds
-        keep = self._keep_frame_ranges(transcription, total_seconds, fps, round(total_seconds * fps))
-        if keep is None:
-            return audio
-        sample_rate = audio.metadata.sample_rate
-        chunks = [audio.data[round(s / fps * sample_rate) : round(e / fps * sample_rate)] for s, e in keep]
-        data = np.concatenate(chunks, axis=0)
-        metadata = dataclasses.replace(
-            audio.metadata,
-            duration_seconds=data.shape[0] / sample_rate,
-            frame_count=data.shape[0],
-        )
-        return Audio(data, metadata).fit_to_duration(output_duration)
 
     def predict_metadata(self, meta: VideoMetadata, transcription: Transcription | None = None) -> VideoMetadata:
         """Predict the cut duration; identity when no transcription is in the

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -25,10 +25,8 @@ import tempfile
 from pathlib import Path
 from typing import Annotated, Any, Literal, Protocol, get_args, runtime_checkable
 
-import numpy as np
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, SerializeAsAny
 
-from videopython.audio import Audio, AudioMetadata
 from videopython.base import _ffmpeg
 from videopython.base.exceptions import PlanError, PlanErrorCode, PlanRepair, PlanValidationError
 from videopython.base.video import ALLOWED_VIDEO_FORMATS, ALLOWED_VIDEO_PRESETS, Video, VideoMetadata
@@ -44,9 +42,6 @@ from videopython.editing.streaming import (
     concat_files,
     source_has_audio_stream,
     stream_segment,
-    stream_segment_audio_to_array,
-    stream_segment_to_frames,
-    stream_transition_frames,
     stream_transition_pair,
 )
 from videopython.editing.transforms import DURATION_EPS, CutSeconds, Resize, speech_windows
@@ -336,7 +331,7 @@ def _window_errors(op: Operation, duration: float, location: str) -> list[_Locat
     moved off the (now permissive) ``TimeRange`` model: negative ``start``,
     negative ``stop``, ``stop < start``, ``start`` past duration, ``stop`` past
     duration. A ``stop`` clamped to ``duration`` by ``clamp_windows`` no longer
-    overruns, so the final check stays silent for it (matching ``run()``).
+    overruns, so the final check stays silent for it (matching ``run_to_file()``).
     """
     if not isinstance(op, Effect) or op.window is None:
         return []
@@ -485,10 +480,9 @@ def _transition_duration_errors(
     the left segment's predicted post-op output and the START of the right's,
     so the overlap must be *strictly fewer frames* than either adjacent
     segment. The constraint is frame-based to match the streaming pass exactly
-    (:func:`videopython.editing.streaming.stream_transition_frames` raises on
+    (:func:`videopython.editing.streaming.stream_transition_pair` raises on
     ``overlap >= n_frames``); a seconds comparison rounds differently and
-    admits a near-full-overlap sliver that crashes ``run`` while
-    ``run_to_file`` degrades. A clean ``check`` guarantees the xfade pass will
+    admits a near-full-overlap sliver that crashes ``run_to_file``. A clean ``check`` guarantees the xfade pass will
     not fail at decode. ``repair`` clamps the same boundary mechanically.
     """
     out: list[_LocatedError] = []
@@ -523,8 +517,8 @@ def _transition_overlap_frames(spec: TransitionSpec, fps: float) -> int:
     """The number of frames a transition overlaps two segments: ``round(D*fps)``.
 
     The single source of the overlap frame count, used by the timeline math
-    (:func:`_assemble_timeline`), the per-boundary streaming pass, and the
-    in-memory twin, so they cannot disagree on how much the seam shortens.
+    (:func:`_assemble_timeline`) and the per-boundary streaming pass, so they
+    cannot disagree on how much the seam shortens.
     """
     return round(spec.duration * fps)
 
@@ -537,7 +531,7 @@ def _assemble_timeline(
 
     Segment 0 fixes height/width/fps (matching/normalization already made them
     uniform). Without transitions ``frame_count`` and ``total_seconds`` simply
-    sum -- the prediction-side model of ``run()``'s ``result + video`` concat.
+    sum -- the prediction-side model of ``run_to_file()``'s ``result + video`` concat.
     With transitions (``transitions[i]`` is segment ``i``'s ``transition_in``),
     each boundary overlaps ``round(D*fps)`` frames, so the assembled total is
     ``sum(durations) - sum(overlaps)``: every post-op window, ``predict``,
@@ -576,8 +570,9 @@ def _relocate(errors: list[PlanError], location: str) -> None:
 def _clamp_effect_window(op: Operation, duration: float) -> Operation:
     """Return ``op`` with its ``Effect.window.stop`` clamped to ``duration``.
 
-    Mirrors :meth:`Effect._resolved_window`'s run-time ``min(stop, total_seconds)``
-    so a stop overrunning a duration-shrunk chain validates instead of raising.
+    Mirrors the run-time ``min(stop, total_seconds)`` window clamp the streaming
+    engine applies, so a stop overrunning a duration-shrunk chain validates
+    instead of raising.
     This is the narrow ``clamp_windows`` repair: ``window.start`` and negative
     bounds are deliberately left untouched (still reported by ``_window_errors``).
     :meth:`VideoEdit.repair` uses the broader :func:`_repair_effect_window`.
@@ -979,9 +974,9 @@ class VideoEdit(BaseModel):
         When ``clamp_windows`` is True, an :class:`Effect`'s ``window.stop`` that
         overruns the running predicted duration (e.g. after a duration-shrinking
         op like ``speed_change``/``cut``) is clamped to that duration -- the same
-        value :meth:`Effect._resolved_window` uses at run time -- instead of
-        raising. Only ``window.stop`` is clamped: a ``window.start`` past the
-        duration still hard-raises (a residual divergence from ``run()``, which
+        ``min(stop, total_seconds)`` value the streaming engine applies at run
+        time -- instead of raising. Only ``window.stop`` is clamped: a ``window.start`` past the
+        duration still hard-raises (a residual divergence from ``run_to_file()``, which
         degrades it to a zero-width no-op).
         """
         source_metas = [VideoMetadata.from_path(str(seg.source)) for seg in self.segments]
@@ -1137,7 +1132,7 @@ class VideoEdit(BaseModel):
         # `limit_frames - 1` overlap frames so the repaired plan satisfies the
         # strict `overlap < min(frames)` streaming constraint and actually runs
         # (a seconds clamp to the segment length lands on `overlap == frames`,
-        # which passes check but crashes run). Only fires when both adjacent
+        # which passes check but crashes run_to_file). Only fires when both adjacent
         # segments predicted; a segment too short for any transition
         # (limit_frames <= 1) is left for check. A first-segment transition is a
         # structural fault, deliberately left for check.
@@ -1322,7 +1317,7 @@ class VideoEdit(BaseModel):
         return out
 
     def _assert_post_ops_supported(self, context: dict[str, Any] | None) -> None:
-        """Raising guard used by ``run``/``run_to_file`` (see :meth:`_post_op_context_errors`)."""
+        """Raising guard used by ``run_to_file`` (see :meth:`_post_op_context_errors`)."""
         errs = self._post_op_context_errors(context)
         if errs:
             message, err = errs[0]
@@ -1366,7 +1361,7 @@ class VideoEdit(BaseModel):
         return out
 
     def _assert_music_bed_supported(self) -> None:
-        """Raising guard used by ``run``/``run_to_file`` (see :meth:`_music_bed_errors`)."""
+        """Raising guard used by ``run_to_file`` (see :meth:`_music_bed_errors`)."""
         errs = self._music_bed_errors()
         if errs:
             message, err = errs[0]
@@ -1468,7 +1463,7 @@ class VideoEdit(BaseModel):
 
         # `_apply_matching` runs over the cuttable subset only; an uncuttable
         # segment isolates and is already reported, so the (now-invalid) plan's
-        # matched dims may differ from run()'s all-segments matching -- harmless,
+        # matched dims may differ from run_to_file()'s all-segments matching -- harmless,
         # since that plan can't run until the bad segment is fixed.
         seg_outputs: dict[int, VideoMetadata] = {}
         for i, seg in enumerate(self.segments):
@@ -1580,147 +1575,6 @@ class VideoEdit(BaseModel):
             result = [m.with_dimensions(min_w, min_h) if (m.width, m.height) != (min_w, min_h) else m for m in result]
         return result
 
-    # -------------------------------------------------------------------- run
-
-    def run(self, context: dict[str, Any] | None = None) -> Video:
-        """Execute the plan and return the final ``Video`` in memory.
-
-        A view over the streaming engine -- the same compiled plans
-        ``run_to_file`` streams to disk are streamed into memory (lossless
-        rawvideo, no encode round-trip), so the two entry points cannot
-        diverge. Plans with unstreamable shapes raise the same structured
-        ``STREAMING_FALLBACK`` errors as :meth:`run_to_file`.
-        """
-        plans = self._compile_streaming_plans(context)
-        self._assert_music_bed_supported()
-        try:
-            self._assert_transitions_runnable(plans)
-            videos: list[Video] = []
-            for plan in plans:
-                frames = stream_segment_to_frames(plan)
-                video = Video.from_frames(frames, fps=plan.final_fps or plan.output_fps)
-                # run() is "stream into memory": decode the SAME compiled audio
-                # graph the file path bakes into the segment to a PCM buffer
-                # (O(output-duration) memory, only for the in-memory view) so
-                # run()/run_to_file cannot diverge.
-                video.audio = stream_segment_audio_to_array(plan)
-                videos.append(video)
-            result = videos[0]
-            for i in range(1, len(videos)):
-                spec = self.segments[i].transition_in
-                if spec is None:
-                    result = result + videos[i]
-                else:
-                    # Decide crossfade-vs-butt-join by source-stream presence, the
-                    # SAME heuristic run_to_file uses (the entering segments'
-                    # sources), so the two paths cannot disagree on the seam audio.
-                    both_audible = source_has_audio_stream(plans[i - 1].source_path) and source_has_audio_stream(
-                        plans[i].source_path
-                    )
-                    result = self._join_transition_in_memory(result, videos[i], spec, both_audible)
-            if self.music_bed is not None:
-                # Final post-assembly bed mix, the in-memory twin of
-                # run_to_file's: route the assembled program audio + the bed
-                # through the SAME build_music_bed_filter_complex builder.
-                speech = self._music_bed_speech_windows(context)
-                result.audio = self._mix_music_bed_in_memory(result, speech)
-            return result
-        finally:
-            for plan in plans:
-                for f in plan.owned_temp_files:
-                    f.unlink(missing_ok=True)
-
-    def _mix_music_bed_in_memory(self, result: Video, speech: list[tuple[float, float]] | None) -> Audio:
-        """Mix the music bed under the assembled program audio for ``run()``.
-
-        The in-memory twin of :meth:`_mix_music_bed_to_file`: the assembled
-        program's PCM audio is written to a temp WAV (input 0), the bed added as
-        a second ``-i`` input, and :func:`build_music_bed_filter_complex` (the
-        SAME builder the file path uses) compiles the ``amix`` graph, decoded
-        back to a float32 :class:`Audio`. The program duration is the assembled
-        video's exact timeline so the bed's loop/trim pin matches.
-        """
-        bed = self.music_bed
-        assert bed is not None
-        program_seconds = result.total_seconds
-        bed_inputs, graph, out_label = build_music_bed_filter_complex(
-            bed, program_seconds, speech=speech, bed_input_index=1, prog_label="0:a"
-        )
-        sample_rate = result.audio.metadata.sample_rate
-        tmpdir = Path(tempfile.mkdtemp(prefix="vp_bed_"))
-        prog_wav = tmpdir / "prog.wav"
-        try:
-            result.audio.save(prog_wav, format="wav")
-            cmd = [
-                "ffmpeg",
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-i",
-                str(prog_wav),
-                *bed_inputs,
-                "-filter_complex",
-                ";".join(graph),
-                "-map",
-                out_label,
-                "-ac",
-                "2",
-                "-ar",
-                str(sample_rate),
-                "-f",
-                "f32le",
-                "pipe:1",
-            ]
-            raw = _ffmpeg.run(cmd)
-        finally:
-            prog_wav.unlink(missing_ok=True)
-            tmpdir.rmdir()
-
-        data = np.frombuffer(raw, dtype=np.float32)
-        if data.size % 2 != 0:
-            data = data[: data.size - 1]
-        data = data.reshape(-1, 2).copy()
-        np.clip(data, -1.0, 1.0, out=data)
-        metadata = AudioMetadata(
-            sample_rate=sample_rate,
-            channels=2,
-            sample_width=2,
-            duration_seconds=data.shape[0] / sample_rate,
-            frame_count=data.shape[0],
-        )
-        return Audio(data, metadata)
-
-    def _join_transition_in_memory(self, left: Video, right: Video, spec: TransitionSpec, both_audible: bool) -> Video:
-        """xfade ``right`` onto the running ``left`` video for ``run()``.
-
-        The in-memory twin of the file path's :func:`stream_transition_pair`:
-        blends the frames through the SAME shared :func:`xfade_filter` builder
-        (so the seam pixels match ``run_to_file``), then joins the audio --
-        ``acrossfade`` when ``both_audible`` and ``spec.audio`` is set, else a
-        hard butt-join over the same overlap -- and fits it to the shortened
-        video duration so the mux cannot drift. ``both_audible`` is the caller's
-        source-stream-presence decision (the same heuristic ``run_to_file``
-        uses), so the two paths agree even for a silent-but-present audio
-        stream. xfade requires matching geometry/fps; the per-segment realize
-        already normalized both to the matched targets.
-        """
-        fps = left.fps
-        blended = stream_transition_frames(left.frames, right.frames, spec.type, spec.duration, fps)
-        out = Video.from_frames(blended, fps=fps)
-
-        if spec.audio and both_audible:
-            # Crossfade over the overlap (acrossfade twin). The transition guard
-            # ensured each side is at least `duration` long, so this is safe.
-            joined_audio = left.audio.concat(right.audio, crossfade=spec.duration)
-        else:
-            # Hard butt-join over the same overlap, mirroring the file path:
-            # drop the left tail's `duration` seconds, then append the full
-            # right, so the audio tracks the shortened video timeline.
-            left_keep = max(0.0, left.audio.metadata.duration_seconds - spec.duration)
-            joined_audio = left.audio.slice(0.0, left_keep).concat(right.audio)
-        out.audio = joined_audio.fit_to_duration(out.total_seconds)
-        return out
-
     def run_to_file(
         self,
         output_path: str | Path,
@@ -1810,9 +1664,9 @@ class VideoEdit(BaseModel):
     ) -> Path:
         """Mix the music bed under an assembled program file in one ffmpeg pass.
 
-        The file half of the bed mix: the assembled program is input 0, the bed
-        a second ``-i`` input, and :func:`build_music_bed_filter_complex` (shared
-        with ``run()``) compiles the ``amix`` graph. The program duration is the
+        The bed mix: the assembled program is input 0, the bed
+        a second ``-i`` input, and :func:`build_music_bed_filter_complex`
+        compiles the ``amix`` graph. The program duration is the
         assembled file's PROBED length so the bed's loop/trim pin matches the
         realized timeline exactly. The video stream is copied (``-c:v copy`` --
         the bed touches only audio); the mixed audio is re-encoded to AAC.
@@ -1875,7 +1729,7 @@ class VideoEdit(BaseModel):
         Each transition then xfade-joins the running tail with the next group:
         ``offset`` is derived from the realized TAIL's PROBED duration (not the
         prediction) so the seam is frame-aligned, the video blend goes through
-        the shared :func:`xfade_filter` builder (matching ``run()``), and the
+        the shared :func:`xfade_filter` builder (matching ``run_to_file()``), and the
         audio is ``acrossfade``-d when ``spec.audio`` and both boundary
         segments are audible, else hard butt-joined.
 
@@ -1915,8 +1769,7 @@ class VideoEdit(BaseModel):
                 right_meta = VideoMetadata.from_path(str(right_file))
                 # Offset from the realized tail's PROBED frame count (matching
                 # the xfade input trim), not the prediction, so the seam is
-                # frame-aligned -- the file mirror of the in-memory twin's
-                # ``(n_left - overlap) / fps``.
+                # frame-aligned -- ``(n_left - overlap) / fps``.
                 overlap = _transition_overlap_frames(spec, meta.fps)
                 offset = round((meta.frame_count - overlap) / meta.fps, 6)
                 crossfade_audio = bool(spec.audio and tail_left_audible and audible[first_idx])
@@ -1962,8 +1815,7 @@ class VideoEdit(BaseModel):
     def _compile_streaming_plans(self, context: dict[str, Any] | None) -> list[StreamingSegmentPlan]:
         """Compile every segment plan and fold the post-ops, or raise.
 
-        The single admission point for both :meth:`run` and
-        :meth:`run_to_file`. Unstreamable shapes raise
+        The single admission point for :meth:`run_to_file`. Unstreamable shapes raise
         :class:`PlanValidationError` with the streamability report's
         structured errors; a builder/report drift (e.g. a third-party
         transform whose ``streamable`` flag does not match its
@@ -2086,10 +1938,9 @@ class VideoEdit(BaseModel):
 
         # Resolve requires-context onto the segment's local timeline once; each
         # context-requiring effect gets its keys on the schedule entry, which
-        # stream_segment forwards to streaming_init (the streaming twin of
-        # _apply_with_context). Like _segment_context's eager consumers, a
-        # missing/empty key is passed as absent so the effect raises its own
-        # clear "requires ..." error -- before that segment's decode.
+        # stream_segment forwards to streaming_init. A missing/empty key is
+        # passed as absent so the effect raises its own clear "requires ..."
+        # error -- before that segment's decode.
         seg_context = _segment_context(context, str(segment.source), segment.start, segment.end)
 
         owned_files: list[Path] = []
@@ -2306,8 +2157,8 @@ class VideoEdit(BaseModel):
         :func:`_transition_duration_errors` but measures each segment against
         its compiled plan's predicted post-op duration -- the exact length the
         per-segment realize pass produces -- so a plan that passes here cannot
-        fail the xfade pass at decode. Called by both ``run`` and
-        ``run_to_file`` after plan compilation (no frames decoded yet).
+        fail the xfade pass at decode. Called by ``run_to_file`` after plan
+        compilation (no frames decoded yet).
         ``repair`` clamps these mechanically; here they hard-raise.
         """
         for message, err in _transition_structure_errors(list(self.segments)):

--- a/uv.lock
+++ b/uv.lock
@@ -4491,7 +4491,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.43.1"
+version = "0.44.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Breaking: the eager/in-memory editing path is gone. Streaming-to-file (VideoEdit.run_to_file) is now the only execution engine -- nothing runs in memory.

Removed VideoEdit.run() and its in-memory machinery (stream_segment_to_frames, stream_segment_audio_to_array, stream_transition_frames, out_frames_reshape). Callers needing a Video use Video.from_path(str(edit.run_to_file(...))).

Removed the eager Operation.apply(video) path entirely: Operation.apply, Effect.apply/_apply/_resolved_window, all Transform.apply/_audio_apply numpy implementations, the Fade/VolumeAdjust/FullImageOverlay/Vignette overrides, TranscriptionOverlay.apply, and FaceTrackingCrop.apply. An Operation is now defined only by its streaming contract (to_ffmpeg_filter / to_ffmpeg_audio_filter / streaming_init+process_frame / predict_metadata).

FullImageOverlay's shape/fade-time validation moves to predict_metadata. AI consumers (video_analysis, dubbing) slice Video directly instead of CutSeconds(...).apply(video). Tests migrated to a render fixture and rewritten to assert against process_frame / predict_metadata / compiled filter strings; stale eager-path references purged from docstrings, comments, and docs. Bump to 0.44.0.