### PR TITLE
feat(editing)!: retire the "fallback" vocabulary -- STREAMING_UNSUPPO…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,25 @@
 # Release Notes
 
-## 0.44.1
+## 0.45.0
+
+Breaking: the "fallback" vocabulary is retired. Since the in-memory path was
+removed in 0.44.0 there is nothing to fall back *to* -- an op that cannot stream
+is a hard rejection, not a fallback -- so the names now say so.
+
+### Renamed `STREAMING_FALLBACK` -> `STREAMING_UNSUPPORTED`
+
+`PlanErrorCode.STREAMING_FALLBACK` (value `"streaming_fallback"`) is now
+`PlanErrorCode.STREAMING_UNSUPPORTED` (value `"streaming_unsupported"`). This is
+the only breaking change: consumers matching on the error code -- e.g. LLM refine
+loops reading `StreamabilityReport.errors()` or `VideoEdit.check()` output -- must
+update to the new name/value.
+
+### Renamed `StreamabilityReport.fallbacks` -> `.unstreamable`
+
+The property listing the ops that cannot stream is now `.unstreamable`, aligned
+with the existing `StreamingClass.UNSTREAMABLE`. `.errors()`, `.streamable`, and
+the rest of the report are unchanged. Docstrings and docs no longer explain why a
+"fallback" doesn't fall back -- the surface is self-describing.
 
 Confirmed cleanups surfaced by the 0.44.0 streaming-only removal -- all additive
 or internal refactors, no public behavior change.

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -97,7 +97,7 @@ ordered after frame effects -- or a per-frame streaming `Effect`
 streaming strategy (the remaining cases: a frame effect ordered after
 encode-stage filters, time-based context after a duration-changing
 transform, a few post-op shapes) are rejected with structured
-`STREAMING_FALLBACK` errors before any decode.
+`STREAMING_UNSUPPORTED` errors before any decode.
 
 **Filter transforms**: `resize`, `crop`, `resample_fps`, the
 duration-changing `speed_change` and `freeze_frame` (predicted metadata is
@@ -127,11 +127,11 @@ reason and a reorder hint on the entry):
 ```python
 report = edit.streamability()
 report.streamable        # will the plan run?
-report.fallbacks         # the offending ops, with reasons
-report.errors()          # the same as structured STREAMING_FALLBACK PlanErrors
+report.unstreamable      # the offending ops, with reasons
+report.errors()          # the same as structured STREAMING_UNSUPPORTED PlanErrors
 ```
 
-`edit.check(meta)` reports the same `STREAMING_FALLBACK` errors after the
+`edit.check(meta)` reports the same `STREAMING_UNSUPPORTED` errors after the
 regular validity errors, and `run()`/`run_to_file()` raise them before any
 decode. Streamability is purely structural (op classes, order, plan
 shape), so a consumer can gate job admission on the report before

--- a/docs/examples/large-videos.md
+++ b/docs/examples/large-videos.md
@@ -48,7 +48,7 @@ edit.run_to_file("output.mp4", crf=20, preset="medium")
 Streaming is the only execution engine: every op compiles to an ffmpeg
 filter or a per-frame effect, and frames are never accumulated in memory.
 A plan shape with no streaming strategy (e.g. a frame effect ordered after
-burned-in subtitles) is rejected with structured `STREAMING_FALLBACK`
+burned-in subtitles) is rejected with structured `STREAMING_UNSUPPORTED`
 errors before any decode. `edit.streamability()` returns the per-op
 classification without touching the disk; `edit.check(meta)` reports the
 same errors alongside the validity checks.

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -186,9 +186,9 @@ for err in errors:
 # Re-prompt once with the full structured list instead of one-at-a-time
 ```
 
-Streaming is the only execution engine, so ops that cannot stream at
-their plan position are real plan errors: `check()` reports one
-`STREAMING_FALLBACK` error per offending op, with the actionable cause in
+Ops that cannot stream at their plan position are real plan errors:
+`check()` reports one `STREAMING_UNSUPPORTED` error per offending op, with
+the actionable cause in
 `err.detail` (e.g. "move the op before the duration-changing transform to
 stream"), and the refine loop treats "won't stream" like any other
 violation. The full per-op classification (including the ops that do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.44.1"
+version = "0.45.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/base/test_plan_error_prompt_line.py
+++ b/src/tests/base/test_plan_error_prompt_line.py
@@ -54,13 +54,13 @@ def test_window_error_includes_op_and_detail():
     )
 
 
-def test_streaming_fallback_detail_only():
-    """STREAMING_FALLBACK carries only ``detail``; it appends after the code name."""
+def test_streaming_unsupported_detail_only():
+    """STREAMING_UNSUPPORTED carries only ``detail``; it appends after the code name."""
     err = PlanError(
-        code=PlanErrorCode.STREAMING_FALLBACK,
+        code=PlanErrorCode.STREAMING_UNSUPPORTED,
         detail="text overlay cannot stream at this plan position",
     )
-    assert err.to_prompt_line() == ("STREAMING_FALLBACK -- text overlay cannot stream at this plan position")
+    assert err.to_prompt_line() == ("STREAMING_UNSUPPORTED -- text overlay cannot stream at this plan position")
 
 
 def test_field_without_value_renders_bare_field():

--- a/src/tests/editing/test_streamability.py
+++ b/src/tests/editing/test_streamability.py
@@ -57,7 +57,7 @@ class TestStreamabilityReport:
             "segments[0].operations[2]",
         ]
         assert report.streamable
-        assert report.fallbacks == ()
+        assert report.unstreamable == ()
         assert report.errors() == []
         assert all(e.reason is None for e in report.entries)
 
@@ -142,7 +142,7 @@ class TestStreamabilityReport:
         errors = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}]).streamability().errors()
 
         (err,) = errors
-        assert err.code is PlanErrorCode.STREAMING_FALLBACK
+        assert err.code is PlanErrorCode.STREAMING_UNSUPPORTED
         assert err.location == "segments[0].operations[2]"
         assert err.op == "color_adjust"
         assert err.detail is not None and "encode-stage" in err.detail
@@ -223,7 +223,7 @@ class TestCheckStrictStreaming:
         errors = plan.check(SMALL_VIDEO_METADATA)
 
         (err,) = errors
-        assert err.code is PlanErrorCode.STREAMING_FALLBACK
+        assert err.code is PlanErrorCode.STREAMING_UNSUPPORTED
         assert err.location == "segments[0].operations[2]"
         assert err.op == "color_adjust"
 
@@ -231,14 +231,14 @@ class TestCheckStrictStreaming:
         plan = _plan([RESIZE, FADE])
         assert plan.check(SMALL_VIDEO_METADATA) == []
 
-    def test_fallback_errors_append_after_validity_errors(self):
+    def test_unstreamable_errors_append_after_validity_errors(self):
         bad_window = {"op": "fade", "mode": "in", "duration": 0.5, "window": {"start": 50.0, "stop": 60.0}}
         plan = _plan([bad_window, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
         errors = plan.check(SMALL_VIDEO_METADATA)
 
         assert len(errors) >= 2
-        assert errors[0].code is not PlanErrorCode.STREAMING_FALLBACK
-        assert errors[-1].code is PlanErrorCode.STREAMING_FALLBACK
+        assert errors[0].code is not PlanErrorCode.STREAMING_UNSUPPORTED
+        assert errors[-1].code is PlanErrorCode.STREAMING_UNSUPPORTED
 
 
 class TestRunToFileRejection:
@@ -268,7 +268,7 @@ class TestRunToFileRejection:
 
         assert not out_path.exists()
         (err,) = exc_info.value.errors
-        assert err.code is PlanErrorCode.STREAMING_FALLBACK
+        assert err.code is PlanErrorCode.STREAMING_UNSUPPORTED
         assert err.op == "color_adjust"
 
     def test_builder_drift_raises_instead_of_silent_fallback(self, tmp_path, monkeypatch: pytest.MonkeyPatch):

--- a/src/tests/editing/test_transitions.py
+++ b/src/tests/editing/test_transitions.py
@@ -554,5 +554,5 @@ class TestStreamability:
         )
         report = plan.streamability()
         assert report.streamable is False
-        assert report.fallbacks[0].streaming_class is StreamingClass.UNSTREAMABLE
-        assert "transition" in report.fallbacks[0].reason
+        assert report.unstreamable[0].streaming_class is StreamingClass.UNSTREAMABLE
+        assert "transition" in report.unstreamable[0].reason

--- a/src/videopython/base/exceptions.py
+++ b/src/videopython/base/exceptions.py
@@ -96,7 +96,7 @@ class PlanErrorCode(str, Enum):
     TRANSITION_TOO_LONG = "transition_too_long"
     MUSIC_BED_DUCK_MULTISEGMENT = "music_bed_duck_multisegment"
     # Streaming: unstreamable op at its plan position (always reported).
-    STREAMING_FALLBACK = "streaming_fallback"
+    STREAMING_UNSUPPORTED = "streaming_unsupported"
 
 
 @dataclass

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -36,8 +36,8 @@ class StreamingClass(str, Enum):
 
     ``FILTER`` and ``FRAME_EFFECT`` stream in O(1) memory w.r.t. video
     length. ``UNSTREAMABLE`` means the op (or its plan position) has no
-    streaming strategy; since streaming is the only engine, such plans are
-    rejected with structured ``STREAMING_FALLBACK`` errors instead of run.
+    streaming strategy; such plans are rejected with structured
+    ``STREAMING_UNSUPPORTED`` errors.
     """
 
     FILTER = "filter"
@@ -85,19 +85,19 @@ class StreamabilityReport:
         return all(e.streams for e in self.entries)
 
     @property
-    def fallbacks(self) -> tuple[OpStreamability, ...]:
+    def unstreamable(self) -> tuple[OpStreamability, ...]:
         """The unstreamable ops, in plan order."""
         return tuple(e for e in self.entries if not e.streams)
 
     def errors(self) -> list[PlanError]:
-        """The fallbacks as structured ``STREAMING_FALLBACK`` plan errors.
+        """The unstreamable ops as structured ``STREAMING_UNSUPPORTED`` plan errors.
 
         The same shape :meth:`VideoEdit.check` returns, so an LLM refine loop
         can treat "would not stream" exactly like any other plan violation.
         """
         return [
-            PlanError(code=PlanErrorCode.STREAMING_FALLBACK, location=e.location, op=e.op, detail=e.reason)
-            for e in self.fallbacks
+            PlanError(code=PlanErrorCode.STREAMING_UNSUPPORTED, location=e.location, op=e.op, detail=e.reason)
+            for e in self.unstreamable
         ]
 
 
@@ -115,7 +115,7 @@ def analyze_streamability(
     ``streamable`` ClassVar as the authoritative declaration (a flag-False
     transform never streams, even with a working ``to_ffmpeg_filter``); the
     one divergence the flag cannot express -- flag True but the filter
-    compiles to ``None`` -- is caught at runtime by the ``STREAMING_FALLBACK``
+    compiles to ``None`` -- is caught at runtime by the ``STREAMING_UNSUPPORTED``
     raise in ``_compile_streaming_plans``, and a registry test pins flag-True
     transforms to an actual ``to_ffmpeg_filter`` override. Purely structural:
     no disk access and no runtime context.

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -1036,7 +1036,7 @@ class VideoEdit(BaseModel):
         :meth:`validate`: a clampable ``window.stop`` overrun is not reported.
 
         Streaming is the only engine, so ops that cannot stream at their
-        plan position are real plan errors: one ``STREAMING_FALLBACK`` per
+        plan position are real plan errors: one ``STREAMING_UNSUPPORTED`` per
         offending op is appended after the validity errors, in plan order,
         with the actionable cause in :attr:`PlanError.detail`. See
         :meth:`streamability` for the full per-op report including the ops
@@ -1056,7 +1056,7 @@ class VideoEdit(BaseModel):
         admitted. ``report.streamable`` answers "will :meth:`run_to_file`
         stream this plan in O(1) memory, or is an op unstreamable at its
         plan position?"; each entry carries the op's memory class and, for
-        fallbacks, the reason.
+        unstreamable ops, the reason.
         """
         return analyze_streamability(
             [list(seg.operations) for seg in self.segments],
@@ -1603,7 +1603,7 @@ class VideoEdit(BaseModel):
         Memory usage is O(1) w.r.t. video length (video; segment audio is
         in-memory). Streaming is the only engine: a plan with an unstreamable
         shape raises :class:`PlanValidationError` carrying one
-        ``STREAMING_FALLBACK`` :class:`PlanError` per offending op -- before
+        ``STREAMING_UNSUPPORTED`` :class:`PlanError` per offending op -- before
         any decode. Gate plans early with :meth:`check` or
         :meth:`streamability`, which report the same errors without running
         anything.
@@ -1834,16 +1834,16 @@ class VideoEdit(BaseModel):
         :class:`PlanValidationError` with the streamability report's
         structured errors; a builder/report drift (e.g. a third-party
         transform whose ``streamable`` flag does not match its
-        ``to_ffmpeg_filter``) raises with a generic ``STREAMING_FALLBACK``.
+        ``to_ffmpeg_filter``) raises with a generic ``STREAMING_UNSUPPORTED``.
         On raise, any compile-time temp files already created are deleted;
         on success the caller owns ``plan.owned_temp_files``.
         """
         self._assert_post_ops_supported(context)
         report = self.streamability()
         if not report.streamable:
-            causes = "; ".join(f"{e.location} '{e.op}': {e.reason}" for e in report.fallbacks)
+            causes = "; ".join(f"{e.location} '{e.op}': {e.reason}" for e in report.unstreamable)
             message = (
-                f"Plan cannot stream: {len(report.fallbacks)} op(s) have no streaming "
+                f"Plan cannot stream: {len(report.unstreamable)} op(s) have no streaming "
                 f"strategy at their plan position -- {causes}"
             )
             raise PlanValidationError(message, report.errors())
@@ -1851,7 +1851,7 @@ class VideoEdit(BaseModel):
         def drift(detail: str) -> PlanValidationError:
             return PlanValidationError(
                 f"plan stopped streaming despite a clean streamability report ({detail})",
-                [PlanError(code=PlanErrorCode.STREAMING_FALLBACK, detail=detail)],
+                [PlanError(code=PlanErrorCode.STREAMING_UNSUPPORTED, detail=detail)],
             )
 
         target_fps, target_w, target_h = self._matching_targets_from_disk()
@@ -2090,7 +2090,7 @@ class VideoEdit(BaseModel):
                 # flag-False transform is classified UNSTREAMABLE even if it has
                 # a working to_ffmpeg_filter. The remaining drift class (flag
                 # True, filter compiles to None) is caught by the
-                # STREAMING_FALLBACK raise in _compile_streaming_plans.
+                # STREAMING_UNSUPPORTED raise in _compile_streaming_plans.
                 if not op.streamable:
                     abandon()
                     return None

--- a/uv.lock
+++ b/uv.lock
@@ -4491,7 +4491,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.44.1"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
…RTED (0.45.0)

Breaking. Since the in-memory path was removed in 0.44.0 there is nothing to fall back *to*: an op that cannot stream is a hard rejection, not a fallback. The names now say so.

- `PlanErrorCode.STREAMING_FALLBACK` (value "streaming_fallback") -> `STREAMING_UNSUPPORTED` (value "streaming_unsupported"). This is the only behavioral break: consumers matching on the error code -- LLM refine loops reading `StreamabilityReport.errors()` / `VideoEdit.check()` -- must update.
- `StreamabilityReport.fallbacks` -> `.unstreamable`, aligned with the existing `StreamingClass.UNSTREAMABLE`. `.errors()` / `.streamable` are unchanged.
- Reworded the misnomer docstrings, comments, and live docs that only existed to explain why a "fallback" doesn't fall back.

Scope: base/exceptions.py, editing/streaming.py, editing/video_edit.py, the streamability/transition/prompt-line tests, and docs (api/editing, llm-integration, large-videos). Unrelated `fallback` tokens (ai/* fields, the exceptions.py "consumer substring fallbacks" docstring) and historical release notes are left untouched.