### PR TITLE
feat(editing)!: single-mechanism filter-first engine (0.46.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See the [LLM Integration Guide](https://videopython.com/guides/llm-integration/)
 
 - **`videopython.base`** — `Video`, `VideoMetadata`, `FrameIterator`, `Transcription`, and shared result types (`BoundingBox`, `FaceTrack`, `SceneBoundary`, ...). No AI dependencies.
 - **`videopython.audio`** — `Audio` with overlay, concat, normalize, time-stretch, silence detection, segment classification.
-- **`videopython.editing`** — `Operation`/`Effect` foundation, `VideoEdit` plan runner with JSON Schema + streaming execution. Transforms (cut, resize, crop, fps, speed, freeze, silence removal) and effects (blur, zoom, color grading, vignette, Ken Burns, fade, overlays, animated subtitles).
+- **`videopython.editing`** — `Operation`/`Effect` foundation, `VideoEdit` plan runner with JSON Schema + streaming execution. Transforms (resize, crop, fps, speed, freeze, silence removal; cutting is the segment's own start/end) and effects (blur, zoom, color grading, vignette, Ken Burns, fade, overlays, animated subtitles).
 - **`videopython.ai`** *(install with `[ai]`)* — generation (`TextToVideo`, `ImageToVideo`, `TextToImage`, `TextToSpeech`, `TextToMusic`), understanding (`AudioToText`, `AudioClassifier`, `SceneVLM`, `FaceTracker`, `ObjectDetector`, `SemanticSceneDetector`), the `FaceTrackingCrop` transform, the `ObjectDetectionOverlay` effect (per-frame bounding boxes + labels), and the full-pipeline `VideoAnalyzer`.
 - **`videopython.ai.dubbing`** — `VideoDubber` for voice-cloned revoicing with timing sync.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,76 @@
 # Release Notes
 
+## 0.46.0
+
+A faster, single-mechanism editing engine. Filter-only segments render in one
+ffmpeg invocation, nine effects became native ffmpeg filters, and
+`post_operations` run as a real pass over the assembled program. The net effect
+is fewer rejected plans and less per-frame Python.
+
+Breaking: the streamability *classification* of several plan shapes changed (more
+shapes stream; nine effects move from `frame_effect` to `filter`), and
+`cut`/`cut_frames` are no longer chain ops. Consumers that gate on
+`edit.streamability()` / `edit.check()` should expect those reclassifications. No
+public method signature changed.
+
+### Single-invocation fast path for filter-only segments
+
+A segment with no scheduled per-frame effect now renders in ONE ffmpeg process
+(`stream_segment_filtergraph`) instead of decode -> rawvideo pipe -> Python loop
+-> rawvideo pipe -> encode. Segments carrying frame effects still use the
+per-frame pipeline; both emit identical encode params so their outputs
+concat-copy together. Also fixed a latent `Crop` center-mode bug: the compiled
+`crop=` filter now floors to even dimensions and re-centers, matching
+`predict_metadata` (libx264/yuv420p reject odd dimensions).
+
+### Nine effects are now native ffmpeg filters
+
+`vignette`, `mirror_flip`, `chromatic_aberration`, `kaleidoscope`, `color_adjust`
+(geq/hflip/rgbashift), `sharpen` (unsharp), `text_overlay` (drawtext), `zoom`
+(zoompan), and monochrome `film_grain` (noise) compile to native filters in their
+common forms and take the fast path. Output is a faithful visual twin
+re-baselined to ffmpeg (verified in-pipeline against the numpy `process_frame`
+twins), not pixel-identical -- `film_grain` in particular is a different but
+statistically-matched grain. Windowed/large-kernel/per-channel/no-font variants,
+and the remaining effects (blur, glitch, pixelate, ken_burns, punch_in, shake,
+flash, the overlays), stay on the per-frame path. `process_frame` is retained on
+every migrated effect.
+
+A new `Effect.filter_needs_rgb24: ClassVar[bool]` declares that a decode-stage
+`to_ffmpeg_filter` reads RGB channels (geq r/g/b, rgbashift); the builder
+prepends `format=rgb24` to the decode chain so it does not read the native yuv
+stream. Default `False` (geometry/overlay filters like `hflip`/`drawtext`/
+`subtitles=` are format-agnostic).
+
+### `post_operations` run as a pass over the assembled program
+
+`post_operations` no longer fold into per-segment frame schedules. The assembled
+program is treated as one synthetic segment and run back through the same engine,
+so previously-rejected shapes now stream: transforms as post-ops; filter-class
+effects as post-ops; `post_operations` combined with segment transitions; and
+audio-coupled post-ops (`fade`/`volume_adjust`) over a multi-segment program (the
+envelope now spans the whole timeline instead of restarting at each boundary).
+The only post-op shape still rejected is a context-requiring (time-based) post-op
+on a multi-segment plan -- `POST_OP_REQUIRES_CONTEXT` from `check()` (source-
+absolute context cannot re-base onto a concat). Single-segment context post-ops
+stream fine.
+
+### Only streamable ops in the registry
+
+`cut`/`cut_frames` were the only non-streamable ops; trimming is the segment's own
+`start`/`end` mechanism, so they are now `internal_only` -- constructed directly
+by the engine but kept OUT of the op registry and the LLM schema. They can no
+longer appear in a plan's `operations` list (rejected at parse). Every registered
+op is now streamable -- it compiles to an ffmpeg filter or is a per-frame effect.
+A new `Operation.internal_only: ClassVar[bool]` gates registration.
+
+### Unified segment compatibility
+
+The min-fps/min-resolution concat policy now lives in one resolver
+(`_resolve_matching_target`), shared by the prediction and execution passes so
+they cannot drift, and `normalize_dimensions` gained a `"match"` target that
+materializes the same policy as explicit resize ops. Additive.
+
 ## 0.45.0
 
 Breaking: the "fallback" vocabulary is retired. Since the in-memory path was

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -85,37 +85,45 @@ results, then applies `post_operations` to the assembled output.
 
 ## The Streaming Engine
 
-Streaming is the **only** execution engine. `run_to_file()` pipes ffmpeg
-decode → per-frame effect chain → ffmpeg encode, keeping memory constant
-(~250 MB) regardless of video length; `run()` is a view over the same
-engine that streams into memory (lossless rawvideo) instead of encoding.
+`run_to_file()` is the only execution engine. It streams ffmpeg decode →
+filter/effect chain → ffmpeg encode, so memory stays constant (~a frame at a
+time) regardless of video length.
 
-Each operation compiles to one of: an ffmpeg filter
-(`op.to_ffmpeg_filter(ctx)`) -- the decode chain, or the encode chain when
-ordered after frame effects -- or a per-frame streaming `Effect`
-(`op.streamable == True` plus `process_frame`). Plans whose shape has no
-streaming strategy (the remaining cases: a frame effect ordered after
-encode-stage filters, time-based context after a duration-changing
-transform, a few post-op shapes) are rejected with structured
-`STREAMING_UNSUPPORTED` errors before any decode.
+Each operation is one of two kinds:
 
-**Filter transforms**: `resize`, `crop`, `resample_fps`, the
-duration-changing `speed_change` and `freeze_frame` (predicted metadata is
-folded through the chain so effect windows and audio follow the new
-timeline), the transcription-consuming `silence_removal`, and `face_crop`
-(ai extra; compile-time detection pass driving a per-frame crop track).
-**Streaming effects**: every `Effect`, including the context-requiring
-`add_subtitles` (pass `context=` to `run_to_file`).
+- a **filter** — compiles to a native ffmpeg filter (`op.to_ffmpeg_filter(ctx)`).
+  All transforms (`resize`, `crop`, `resample_fps`, the duration-changing
+  `speed_change`/`freeze_frame`, the transcription-consuming `silence_removal`,
+  and `face_crop` from the ai extra) and most effects (`add_subtitles`,
+  `vignette`, `color_adjust`, `chromatic_aberration`, `kaleidoscope`,
+  `mirror_flip`, `sharpen`, `text_overlay`, `zoom`, monochrome `film_grain`).
+- a **per-frame effect** — shape-preserving Python over each decoded frame
+  (`streaming_init` + `process_frame`). The effects with no faithful ffmpeg form
+  (`blur`, `glitch`, `pixelate`, `ken_burns`, `punch_in`, `shake`, `flash`, the
+  image overlays) stay here.
 
-`add_subtitles` renders via libass: the transcription is compiled to an
-ASS document at plan-compile time and burned in by ffmpeg's `subtitles=`
-filter — native speed, zero per-frame Python, classified as a `filter` in
-the streamability report. It joins the filter chain at its plan position:
-the decode chain normally (so transforms may follow it in plan order), or
-the encode chain when frame effects precede it (so `[fade, add_subtitles]`
-streams too). In memory, `run()` pipes the streamed-in frames through the same filter
-via a lossless rawvideo roundtrip — one pixel path everywhere. Requires an ffmpeg built with
-libass.
+A segment whose ops are all filters renders in a **single ffmpeg invocation** —
+no rawvideo round-trip, no Python loop. A per-frame effect switches that segment
+to the decode → Python → encode pipeline, where filters before the effect join
+the decode chain and filters after it the encode chain (so `[fade, add_subtitles]`
+streams). Duration-changing transforms fold their predicted metadata through the
+chain, so later effect windows and the audio follow the new timeline. An effect
+whose filter reads RGB pixels (`geq`/`rgbashift`) sets `filter_needs_rgb24` so the
+decode chain is converted to `rgb24` first.
+
+`post_operations` run as a second pass over the assembled program, so any op —
+filter, effect, or transform — applies to the whole concatenated timeline.
+
+A few plan *shapes* have no streaming strategy and are rejected with structured
+`STREAMING_UNSUPPORTED` errors before any decode: a per-frame effect ordered after
+encode-stage filters, a context-requiring op after a duration-changing transform,
+`face_crop` behind per-frame effects, and a time-based-context post-op on a
+multi-segment plan (its source-absolute context can't re-base onto the concat).
+Reorder the ops, or move the op into a segment, to fix.
+
+`add_subtitles` renders via libass — the transcription is compiled to an ASS
+document at plan-compile time and burned in by ffmpeg's `subtitles=` filter
+(needs an ffmpeg built with libass). Pass `context=` to `run_to_file`.
 
 ### Streamability report
 
@@ -132,7 +140,7 @@ report.errors()          # the same as structured STREAMING_UNSUPPORTED PlanErro
 ```
 
 `edit.check(meta)` reports the same `STREAMING_UNSUPPORTED` errors after the
-regular validity errors, and `run()`/`run_to_file()` raise them before any
+regular validity errors, and `run_to_file()` raises them before any
 decode. Streamability is purely structural (op classes, order, plan
 shape), so a consumer can gate job admission on the report before
 downloading sources.
@@ -208,15 +216,16 @@ unambiguous cases:
 It never invents intent — a concat mismatch or `end <= start` is left for
 `check()` / re-prompting — and never raises on an unrepairable op. A
 clampable `window.stop` overrun (a duration-shrinking op before a windowed
-effect) is the case `run()` already tolerates; `validate(clamp_windows=True)`
+effect) is the case `run_to_file()` already tolerates; `validate(clamp_windows=True)`
 and `check(..., clamp_windows=True)` won't report it either.
 
 ### Normalizing concat geometry (`normalize_dimensions`)
 
 `normalize_dimensions(source_metadata, target, context=...)` appends a
 per-segment `resize` to a common canvas — `target` is an explicit
-`(width, height)`, `"first"`, or `"largest"` — so the "all segments share
-dimensions" concat invariant holds by construction. Best-effort and
+`(width, height)`, `"first"`, `"largest"`, or `"match"` (the lowest common
+resolution, the same policy `match_to_lowest_resolution` applies in-stream) — so
+the "all segments share dimensions" concat invariant holds by construction. Best-effort and
 non-raising like `repair()`/`check()`: a segment it can't yet predict is
 left untouched for `check()` to report. Returns `(normalized_edit, repairs)`.
 
@@ -231,7 +240,7 @@ When multiple segments draw from sources with different fps/resolution,
   the lowest source resolution.
 
 Set either flag to `false` to require sources match natively; otherwise
-`validate()` / `run()` raises.
+`validate()` / `run_to_file()` raises.
 
 ## JSON Schema (`json_schema`)
 

--- a/docs/api/effects.md
+++ b/docs/api/effects.md
@@ -84,11 +84,16 @@ context, passed to the runner: `run_to_file(..., context={"transcription": ...})
 ## Available Effects
 
 Every effect is streamable (compatible with `VideoEdit.run_to_file()` for
-constant-memory processing). Context-requiring ops (`add_subtitles`) stream
-too: pass `context=` to `run_to_file` and the runner re-bases it onto each
-segment's local timeline. `add_subtitles` is special: it compiles to a
-libass `subtitles=` ffmpeg filter at plan-compile time instead of running
-per-frame Python.
+constant-memory processing). Many effects compile to a native ffmpeg filter at
+plan-compile time (faster, no per-frame Python) in their common forms:
+`add_subtitles` (libass `subtitles=`), `vignette` / `color_adjust` /
+`kaleidoscope` (geq), `chromatic_aberration` (rgbashift/geq), `mirror_flip`
+(hflip/vflip/geq), `sharpen` (unsharp), `text_overlay` (drawtext), `zoom`
+(zoompan), and monochrome `film_grain` (noise); the rest run per-frame Python via
+`process_frame`. An effect whose filter reads RGB sets `filter_needs_rgb24` so
+the builder converts the decode chain to `rgb24` first. Context-requiring ops
+(`add_subtitles`) stream too: pass `context=` to `run_to_file` and the runner
+re-bases it onto each segment's local timeline.
 
 | op | Class | Description |
 |---|---|---|

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -59,9 +59,13 @@ Notes:
 - `category` is `OpCategory.TRANSFORM`, `OpCategory.EFFECT`, or
   `OpCategory.SPECIAL`.
 - `streamable: ClassVar[bool] = True` lets `VideoEdit.run_to_file()`
-  treat this op as streaming-compatible. For transforms that means
-  implementing `to_ffmpeg_filter`; for effects that means implementing
-  `process_frame` and `streaming_init`.
+  treat this op as streaming-compatible. Transforms implement
+  `to_ffmpeg_filter`; effects implement either `process_frame` +
+  `streaming_init` (a frame effect) or `to_ffmpeg_filter` + `compiles_to_filter`
+  (a filter effect). Every registered op is streamable.
+- `internal_only: ClassVar[bool] = False`, when `True`, keeps an op OUT of the
+  registry — constructed directly by the engine, never a chain op. `cut`/
+  `cut_frames` use it, since trimming is the segment's own `start`/`end`.
 - Context-dependent ops declare
   `requires: ClassVar[tuple[str, ...]] = ("transcription",)`. The runner
   picks the matching keys out of the `context` dict passed to
@@ -79,12 +83,10 @@ frames outside the window untouched. A frame effect implements the
 `streaming_init` / `process_frame` pair:
 
 ```python
-class ColorGrading(Effect):
-    op: Literal["color_adjust"] = "color_adjust"
+class Glitch(Effect):  # a frame effect: no faithful ffmpeg form
+    op: Literal["glitch"] = "glitch"
     streamable: ClassVar[bool] = True
-
-    brightness: float = Field(0.0, ge=-1, le=1)
-    # ... more fields ...
+    # ... fields ...
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray: ...
 ```
@@ -92,15 +94,18 @@ class ColorGrading(Effect):
 The `window` field on the wire:
 
 ```json
-{"op": "color_adjust", "brightness": 0.1, "window": {"start": 1.0, "stop": 3.0}}
+{"op": "blur_effect", "mode": "constant", "iterations": 2, "window": {"start": 1.0, "stop": 3.0}}
 ```
 
-An effect can instead compile to a native ffmpeg filter by setting the
-`compiles_to_filter` property and implementing `to_ffmpeg_filter` (and,
-for audio-coupled effects like `Fade`/`VolumeAdjust`,
-`to_ffmpeg_audio_filter`). `TranscriptionOverlay` (`add_subtitles`) takes
-this path: it compiles its transcription to an ASS document and emits one
-libass `subtitles=` filter entry.
+Most effects instead compile to a native ffmpeg filter (faster, no per-frame
+Python) by setting the `compiles_to_filter` property and implementing
+`to_ffmpeg_filter`: `add_subtitles`, `vignette`, `color_adjust`,
+`chromatic_aberration`, `kaleidoscope`, `mirror_flip`, `sharpen`, `text_overlay`,
+`zoom`, and monochrome `film_grain`. Audio-coupled effects (`Fade`,
+`VolumeAdjust`) add `to_ffmpeg_audio_filter`; an effect whose filter reads RGB
+(`geq`/`rgbashift`) sets `filter_needs_rgb24` so the decode chain is converted to
+`rgb24` first. `compiles_to_filter` may depend on field values — a windowed
+`sharpen`/`zoom` or a per-channel `film_grain` stays a frame effect.
 
 ## Registry API
 
@@ -189,10 +194,12 @@ llm_schema = cls.llm_json_schema()       # LLM-facing (llm_hidden dropped)
 
 ### Base (no AI dependencies)
 
+`cut`/`cut_frames` are internal-only: the engine trims each segment via its
+`start`/`end`, so they are not chain ops and do not appear here. Every registered
+op below is streamable (it compiles to an ffmpeg filter or is a per-frame effect).
+
 | ID | Class | Category | Streamable |
 |---|---|---|---|
-| `cut_frames` | `CutFrames` | transform | no |
-| `cut` | `CutSeconds` | transform | no |
 | `resize` | `Resize` | transform | yes |
 | `resample_fps` | `ResampleFPS` | transform | yes |
 | `crop` | `Crop` | transform | yes |

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -39,10 +39,11 @@ plan = {
 
 ## Available Transforms
 
+Cutting is the segment's own `start`/`end`; `cut`/`cut_frames` are internal-only
+(constructed by the engine, not usable as chain ops), so they are omitted here.
+
 | op | Class | Streamable | Notes |
 |---|---|---|---|
-| `cut_frames` | `CutFrames` | no | Cut by frame range |
-| `cut` | `CutSeconds` | no | Cut by time range |
 | `resize` | `Resize` | yes | Resize, optional aspect-preserving |
 | `resample_fps` | `ResampleFPS` | yes | Change frame rate |
 | `crop` | `Crop` | yes | Pixel or normalized 0–1 fractions |

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -254,9 +254,9 @@ to re-prompt; pass `clamp_segment_end=True` if you'd rather clamp it to the sour
 end and keep the loop raise-free. `source_metadata` leads each call for a
 consistent signature across the family.
 
-A clampable `window.stop` overrun (a duration-shrinking op like `cut` /
-`speed_change` ordered before a windowed effect leaves the stop past the
-now-shorter clip) is the one case `run()` already tolerates by clamping.
+A clampable `window.stop` overrun (a duration-shrinking op like `speed_change` /
+`freeze_frame` ordered before a windowed effect leaves the stop past the
+now-shorter clip) is the one case `run_to_file()` already tolerates by clamping.
 `validate(clamp_windows=True)` / `check(..., clamp_windows=True)` won't
 report it either; `repair()` clamps it in the returned plan.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.45.0"
+version = "0.46.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/editing/test_ass_subtitles.py
+++ b/src/tests/editing/test_ass_subtitles.py
@@ -241,7 +241,7 @@ class TestLibassStreamability:
             [
                 {"op": "fade", "mode": "in", "duration": 0.5},
                 SUBTITLES,
-                {"op": "color_adjust", "brightness": 0.2},
+                {"op": "glitch"},
             ]
         ).streamability()
         trailing = report.entries[2]
@@ -276,7 +276,10 @@ class TestLibassExecution:
     def test_rejected_plan_leaks_no_ass_file(self, tmp_path):
         """A plan rejected for an unstreamable op must not leak temp files."""
         before = set(glob.glob(tempfile.gettempdir() + "/*.ass"))
-        plan = _plan([SUBTITLES, {"op": "cut", "start": 0.0, "end": 1.0}])
+        # Unstreamable: a frame effect (glitch) after the encode-stage subtitles
+        # filter. The plan still carries add_subtitles, so this guards that a
+        # rejected plan does not leak the .ass temp file.
+        plan = _plan([{"op": "fade", "mode": "in", "duration": 0.5}, SUBTITLES, {"op": "glitch"}])
         with pytest.raises(PlanValidationError, match="cannot stream"):
             plan.run_to_file(tmp_path / "out.mp4", context={"transcription": _transcription()})
         assert set(glob.glob(tempfile.gettempdir() + "/*.ass")) == before

--- a/src/tests/editing/test_effects.py
+++ b/src/tests/editing/test_effects.py
@@ -119,6 +119,55 @@ def test_effect_window(render):
     assert in_diff > pre_diff * 3, f"in-window frame not blurred: in={in_diff}, pre={pre_diff}"
 
 
+def test_filter_effect_matches_numpy_in_pipeline(render):
+    """A migrated filter-effect renders through ``run_to_file`` faithfully.
+
+    ``vignette`` compiles to a ``geq`` whose ``r``/``g``/``b`` accessors read
+    garbage on the native yuv decode stream, so the builder must convert to
+    ``rgb24`` first (``filter_needs_rgb24``). This renders the effect end-to-end
+    and asserts it tracks its numpy ``process_frame`` twin within an x264
+    tolerance -- a guard a standalone PNG check (rgb in, rgb out) cannot give.
+    """
+    seg = {"source": SMALL_VIDEO_PATH, "start": 0.0, "end": 2.0}
+    base = render(VideoEdit.from_dict({"segments": [{**seg, "operations": []}]}), name="base.mp4")
+    vig = render(
+        VideoEdit.from_dict({"segments": [{**seg, "operations": [{"op": "vignette", "strength": 0.5}]}]}),
+        name="vig.mp4",
+    )
+    eff = Vignette(strength=0.5)
+    n, h, w = base.frames.shape[:3]
+    eff.streaming_init(n, base.fps, w, h)
+    ref = np.stack([eff.process_frame(base.frames[i].copy(), i) for i in range(n)])
+    m = min(len(ref), len(vig.frames))
+    mean_diff = np.abs(ref[:m].astype(int) - vig.frames[:m].astype(int)).mean()
+    assert mean_diff < 6, f"vignette filter diverges from its numpy twin in-pipeline: mean={mean_diff}"
+
+
+def test_zoom_filter_preserves_frame_count(render):
+    """zoom compiles to ``zoompan``, which reinterprets PTS at its own framerate.
+
+    The trailing ``setpts=N/(fps*TB)`` is load-bearing: without it the
+    decode-stage ``fps=`` resampler multiplies the frame count (a 48-frame cut
+    rendered as tens of thousands of frames). Guards that exact regression.
+    """
+    out = render(
+        VideoEdit.from_dict(
+            {
+                "segments": [
+                    {
+                        "source": SMALL_VIDEO_PATH,
+                        "start": 0.0,
+                        "end": 2.0,
+                        "operations": [{"op": "zoom_effect", "mode": "in", "zoom_factor": 2}],
+                    }
+                ]
+            }
+        ),
+        name="zoom.mp4",
+    )
+    assert abs(len(out.frames) - 48) <= 2, f"zoom changed the frame count: {len(out.frames)}"
+
+
 class TestColorGrading:
     def test_default_no_change(self, small_video):
         out = _stream(ColorGrading(), small_video)

--- a/src/tests/editing/test_native_transform_streaming.py
+++ b/src/tests/editing/test_native_transform_streaming.py
@@ -332,7 +332,11 @@ class TestEncodeStageTransforms:
         assert video.audio is not None
         assert abs(video.audio.metadata.duration_seconds - len(video.frames) / video.fps) < 0.15
 
-    def test_post_ops_behind_encode_stage_are_rejected(self, tmp_path):
+    def test_post_op_runs_independent_of_segment_encode_stage(self):
+        # post_operations run as a SEPARATE pass over the assembled program, so a
+        # frame-effect post-op is not blocked by a segment's encode-stage filters
+        # (here the crop after the fade). The segment's own [fade, crop] is the
+        # supported decode->frame->encode sandwich; the glitch post-op streams.
         plan = VideoEdit.model_validate(
             {
                 "segments": [
@@ -346,15 +350,14 @@ class TestEncodeStageTransforms:
                         ],
                     }
                 ],
-                "post_operations": [{"op": "color_adjust", "brightness": 0.2}],
+                "post_operations": [{"op": "glitch"}],
             }
         )
         report = plan.streamability()
         post = report.entries[-1]
-        assert post.streaming_class is StreamingClass.UNSTREAMABLE
-        assert post.reason is not None and "encode-stage" in post.reason
-        with pytest.raises(PlanValidationError, match="cannot stream"):
-            plan.run_to_file(tmp_path / "out.mp4")
+        assert post.op == "glitch"
+        assert post.streaming_class is StreamingClass.FRAME_EFFECT
+        assert report.streamable
 
 
 class TestMultiSegmentPostOps:
@@ -373,15 +376,38 @@ class TestMultiSegmentPostOps:
         )
 
     def test_pixel_post_op_streams_across_segments(self, tmp_path):
-        plan = self._plan([{"op": "vignette"}])
+        # A per-frame (frame-effect) post-op folds into BOTH segments' schedules.
+        # blur stays a frame effect (it has no faithful ffmpeg filter), so it
+        # exercises the fold; a filter-class effect (e.g. vignette) is a separate
+        # assembled-timeline path (see TODO Point 3).
+        plan = self._plan([{"op": "blur_effect", "mode": "constant", "iterations": 25}])
         assert plan.streamability().streamable
 
+        blurred = _stream(plan, tmp_path, name="blurred.mp4")
+        plain = _stream(self._plan([]), tmp_path, name="plain.mp4")
+        assert abs(len(blurred.frames) - 144) <= 2
+
+        def gradient(frame: np.ndarray) -> float:
+            return float(np.abs(np.diff(frame.astype(np.float32), axis=1)).mean())
+
+        # The blur softens frames in BOTH segments (frames 36 and 108): the
+        # horizontal gradient drops vs the un-blurred render.
+        for idx in (36, 108):
+            assert gradient(blurred.frames[idx]) < gradient(plain.frames[idx])
+
+    def test_filter_class_post_op_streams_across_segments(self, tmp_path):
+        # A FILTER-class effect (vignette) as a post-op applies over the whole
+        # assembled program via the post-op pass (Point 3) -- the regression that
+        # motivated it. It darkens corners in BOTH segments (frames 36 and 108).
+        plan = self._plan([{"op": "vignette", "strength": 0.5}])
+        assert plan.streamability().streamable
         video = _stream(plan, tmp_path)
         assert abs(len(video.frames) - 144) <= 2
-        # The vignette darkens corners in BOTH segments.
+        plain = _stream(self._plan([]), tmp_path, name="plain.mp4")
         for idx in (36, 108):
-            frame = video.frames[idx].astype(np.float32)
-            assert frame[:30, :30].mean() < frame[235:265, 385:415].mean()
+            vig_corner = video.frames[idx][:30, :30].astype(float).mean()
+            plain_corner = plain.frames[idx][:30, :30].astype(float).mean()
+            assert vig_corner < plain_corner, f"frame {idx} corner not darkened: {vig_corner} vs {plain_corner}"
 
     def test_windowed_post_op_envelope_continues_across_boundary(self, tmp_path):
         """A fade-to-black VIDEO envelope spanning the concat boundary must
@@ -405,13 +431,17 @@ class TestMultiSegmentPostOps:
         unzoomed_mae = np.abs(seg2_first - source2.frames[1].astype(np.float32)).mean()
         assert unzoomed_mae > 10, "zoom envelope restarted at the concat boundary"
 
-    def test_audio_coupled_post_op_is_rejected(self, tmp_path):
+    def test_audio_coupled_post_op_streams_over_program(self, tmp_path):
+        # An audio-coupled fade post-op applies as ONE pass over the assembled
+        # multi-segment program (Point 3): it streams, renders, and fades the
+        # whole program to black at the end rather than restarting per segment.
         plan = self._plan([{"op": "fade", "mode": "out", "duration": 1.0}])
         report = plan.streamability()
-        assert report.entries[-1].streaming_class is StreamingClass.UNSTREAMABLE
-        assert "audio-coupled" in (report.entries[-1].reason or "")
-        with pytest.raises(PlanValidationError, match="cannot stream"):
-            plan.run_to_file(tmp_path / "out.mp4")
+        assert report.entries[-1].streaming_class is StreamingClass.FRAME_EFFECT
+        assert report.streamable
+        video = _stream(plan, tmp_path)
+        assert abs(len(video.frames) - 144) <= 2
+        assert video.frames[-1].mean() < 30
 
     def test_single_segment_fade_post_op_still_folds(self, tmp_path):
         plan = VideoEdit.model_validate(

--- a/src/tests/editing/test_plan_repair.py
+++ b/src/tests/editing/test_plan_repair.py
@@ -376,6 +376,24 @@ class TestNormalizeDimensions:
         meta = norm.validate_with_metadata(SMALL_VIDEO_METADATA)
         assert (meta.width, meta.height) == (1280, 720)
 
+    def test_match_target_uses_lowest_resolution(self):
+        # "match" materializes the engine's match_to_lowest_resolution policy via
+        # the shared resolver: both segments land at the lowest common res.
+        edit = VideoEdit.from_dict(
+            {
+                "segments": [
+                    _segment(start=0.0, end=5.0, operations=[{"op": "resize", "width": 640, "height": 360}]),
+                    _segment(start=0.0, end=5.0, operations=[{"op": "resize", "width": 1280, "height": 720}]),
+                ],
+            }
+        )
+        norm, repairs = edit.normalize_dimensions(SMALL_VIDEO_METADATA, "match")
+        # Segment 0 is already at the min (640x360); only segment 1 is rewritten.
+        assert [r.location for r in repairs] == ["segments[1]"]
+        assert repairs[0].new == "640x360"
+        meta = norm.validate_with_metadata(SMALL_VIDEO_METADATA)
+        assert (meta.width, meta.height) == (640, 360)
+
     def test_already_uniform_plan_is_unchanged(self):
         edit = VideoEdit.from_dict({"segments": [_segment(start=0.0, end=5.0), _segment(start=5.0, end=10.0)]})
         norm, repairs = edit.normalize_dimensions(SMALL_VIDEO_METADATA, "first")

--- a/src/tests/editing/test_streamability.py
+++ b/src/tests/editing/test_streamability.py
@@ -17,7 +17,6 @@ from videopython.editing.video_edit import VideoEdit
 FADE = {"op": "fade", "mode": "in", "duration": 0.5}
 RESIZE = {"op": "resize", "width": 640, "height": 480}
 SUBTITLES = {"op": "add_subtitles", "font_scale": 0.1}
-CUT = {"op": "cut", "start": 0.0, "end": 1.0}
 SILENCE = {"op": "silence_removal"}
 
 
@@ -72,7 +71,7 @@ class TestStreamabilityReport:
         assert report.streamable
 
     def test_effect_after_encode_stage_is_unstreamable(self):
-        report = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}]).streamability()
+        report = _plan([FADE, RESIZE, {"op": "glitch"}]).streamability()
 
         trailing = report.entries[2]
         assert trailing.streaming_class is StreamingClass.UNSTREAMABLE
@@ -94,10 +93,22 @@ class TestStreamabilityReport:
         assert silence.streaming_class is StreamingClass.UNSTREAMABLE
         assert silence.reason is not None and "duration-changing" in silence.reason
 
-    def test_unfilterable_transform_is_unstreamable(self):
-        report = _plan([CUT]).streamability()
+    def test_streamable_false_transform_classifies_unstreamable(self):
+        # Defensive: no built-in op is non-streamable anymore (cut/cut_frames are
+        # internal-only), but a hypothetical custom transform with no filter
+        # compilation must still be flagged unstreamable. Exercised directly on
+        # the classifier to avoid registering a junk op.
+        from videopython.editing.streaming import _classify_op_list
 
-        (entry,) = report.entries
+        class _NoFilterTransform:
+            op = "fake_transform"
+            streamable = False
+            requires: tuple[str, ...] = ()
+            compiles_from_source = False
+            changes_duration = False
+
+        entries = _classify_op_list([_NoFilterTransform()], "segments[0].operations")
+        (entry,) = entries
         assert entry.streaming_class is StreamingClass.UNSTREAMABLE
         assert entry.reason is not None and "no ffmpeg filter" in entry.reason
 
@@ -117,43 +128,48 @@ class TestStreamabilityReport:
         assert entry.streaming_class is StreamingClass.FRAME_EFFECT
         assert report.streamable
 
-    def test_audio_coupled_post_op_on_multi_segment_plan_is_unstreamable(self):
+    def test_audio_coupled_post_op_on_multi_segment_plan_streams(self):
+        # Post-ops run as ONE pass over the assembled program, so an
+        # audio-coupled fade applies over the whole concatenated audio (Point 3).
         report = _plan([], post_operations=[FADE], n_segments=2).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
-        assert entry.reason is not None and "multi-segment" in entry.reason
+        assert entry.streaming_class is StreamingClass.FRAME_EFFECT
+        assert report.streamable
 
-    def test_context_requiring_post_op_is_unstreamable(self):
+    def test_context_requiring_post_op_on_single_segment_streams(self):
+        # On a single-segment plan the assembled timeline IS that segment's, so a
+        # context-requiring post-op (add_subtitles) re-bases and streams (FILTER).
+        # The multi-segment case is rejected by check() as POST_OP_REQUIRES_CONTEXT.
         report = _plan([], post_operations=[SUBTITLES]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
-        assert entry.reason is not None and "transcription" in entry.reason
+        assert entry.streaming_class is StreamingClass.FILTER
+        assert report.streamable
 
-    def test_transform_post_op_is_unstreamable(self):
+    def test_transform_post_op_streams(self):
+        # A transform post-op (resize) applies to the assembled program (FILTER).
         report = _plan([], post_operations=[RESIZE]).streamability()
 
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
-        assert entry.reason is not None and "post-operations" in entry.reason
+        assert entry.streaming_class is StreamingClass.FILTER
+        assert report.streamable
 
     def test_errors_carry_location_op_and_detail(self):
-        errors = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}]).streamability().errors()
+        errors = _plan([FADE, RESIZE, {"op": "glitch"}]).streamability().errors()
 
         (err,) = errors
         assert err.code is PlanErrorCode.STREAMING_UNSUPPORTED
         assert err.location == "segments[0].operations[2]"
-        assert err.op == "color_adjust"
+        assert err.op == "glitch"
         assert err.detail is not None and "encode-stage" in err.detail
 
 
 class TestTransitionStreamability:
     """A transition is FILTER-class by construction; it does not appear as an op.
 
-    But a post-operation cannot fold across a plan that has transitions (the
-    overlapped seam re-encodes in a separate xfade pass), so that combination
-    is rejected.
+    Post-operations run as a separate pass over the assembled program, so they
+    are unaffected by transitions (the seam is already baked before the pass).
     """
 
     def _transition_plan(self, post_operations: list[dict[str, Any]] | None = None) -> VideoEdit:
@@ -178,20 +194,14 @@ class TestTransitionStreamability:
         assert report.entries == ()
         assert report.streamable is True
 
-    def test_post_op_with_transition_is_unstreamable(self):
+    def test_post_op_with_transition_streams(self):
+        # A post-op runs over the assembled program AFTER the transition is
+        # baked, so the combination streams (the blur post-op is FRAME_EFFECT).
         plan = self._transition_plan(post_operations=[{"op": "blur_effect", "mode": "constant", "iterations": 5}])
         report = plan.streamability()
         (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
-        assert entry.reason is not None and "transition" in entry.reason
-        assert report.streamable is False
-
-    def test_has_transitions_flag_rejects_post_ops_directly(self):
-        from videopython.editing.streaming import analyze_streamability
-
-        report = analyze_streamability([[], []], [Fade(mode="in", duration=0.3)], has_transitions=True)
-        (entry,) = report.entries
-        assert entry.streaming_class is StreamingClass.UNSTREAMABLE
+        assert entry.streaming_class is StreamingClass.FRAME_EFFECT
+        assert report.streamable is True
 
 
 class TestRegistryAlignment:
@@ -215,17 +225,31 @@ class TestRegistryAlignment:
                 f"{'overrides' if overrides_filter else 'does not override'} to_ffmpeg_filter"
             )
 
+    def test_cut_ops_are_internal_only(self):
+        """cut/cut_frames trim via the segment's own start/end, so they are kept
+        OUT of the registry (not chain ops, not LLM-exposed) while staying
+        directly constructible by the engine -- the only non-streamable ops, now
+        removed from the op set so every registered op is streamable."""
+        from videopython.editing.transforms import CutFrames, CutSeconds
+
+        assert "cut" not in Operation.registry()
+        assert "cut_frames" not in Operation.registry()
+        assert "cut" not in Operation.llm_registry()
+        assert CutSeconds.internal_only and CutFrames.internal_only
+        # Direct construction still works (the engine trims segments this way).
+        assert CutSeconds(start=0.0, end=2.0).end == 2.0
+
 
 class TestCheckStrictStreaming:
     def test_check_reports_unstreamable_ops(self):
         # Streaming is the only engine: unstreamable shapes are plan errors.
-        plan = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
+        plan = _plan([FADE, RESIZE, {"op": "glitch"}])
         errors = plan.check(SMALL_VIDEO_METADATA)
 
         (err,) = errors
         assert err.code is PlanErrorCode.STREAMING_UNSUPPORTED
         assert err.location == "segments[0].operations[2]"
-        assert err.op == "color_adjust"
+        assert err.op == "glitch"
 
     def test_check_on_streamable_plan_is_clean(self):
         plan = _plan([RESIZE, FADE])
@@ -233,7 +257,7 @@ class TestCheckStrictStreaming:
 
     def test_unstreamable_errors_append_after_validity_errors(self):
         bad_window = {"op": "fade", "mode": "in", "duration": 0.5, "window": {"start": 50.0, "stop": 60.0}}
-        plan = _plan([bad_window, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
+        plan = _plan([bad_window, RESIZE, {"op": "glitch"}])
         errors = plan.check(SMALL_VIDEO_METADATA)
 
         assert len(errors) >= 2
@@ -260,7 +284,7 @@ class TestRunToFileRejection:
         assert out.exists()
 
     def test_unstreamable_plan_raises(self, tmp_path):
-        plan = _plan([FADE, RESIZE, {"op": "color_adjust", "brightness": 0.2}])
+        plan = _plan([FADE, RESIZE, {"op": "glitch"}])
         out_path = tmp_path / "out.mp4"
 
         with pytest.raises(PlanValidationError, match="cannot stream") as exc_info:
@@ -269,7 +293,7 @@ class TestRunToFileRejection:
         assert not out_path.exists()
         (err,) = exc_info.value.errors
         assert err.code is PlanErrorCode.STREAMING_UNSUPPORTED
-        assert err.op == "color_adjust"
+        assert err.op == "glitch"
 
     def test_builder_drift_raises_instead_of_silent_fallback(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
         """A streamable-flagged transform that fails to compile must not slip through."""

--- a/src/tests/editing/test_transitions.py
+++ b/src/tests/editing/test_transitions.py
@@ -537,7 +537,9 @@ class TestStreamability:
         report = plan.streamability()
         assert report.streamable is True
 
-    def test_post_op_with_transition_is_unstreamable(self, clips):
+    def test_post_op_with_transition_streams(self, clips):
+        # Post-ops run over the assembled program after the transition is baked,
+        # so the combination streams (Point 3).
         plan = VideoEdit.from_dict(
             {
                 "segments": [
@@ -553,6 +555,5 @@ class TestStreamability:
             }
         )
         report = plan.streamability()
-        assert report.streamable is False
-        assert report.unstreamable[0].streaming_class is StreamingClass.UNSTREAMABLE
-        assert "transition" in report.unstreamable[0].reason
+        assert report.streamable is True
+        assert report.entries[-1].streaming_class is StreamingClass.FRAME_EFFECT

--- a/src/tests/editing/test_video_edit.py
+++ b/src/tests/editing/test_video_edit.py
@@ -386,14 +386,15 @@ class TestExecution:
         result = render(VideoEdit.from_dict(plan))
         assert result.frames[-1].mean() < 5
 
-    def test_transform_post_op_is_rejected(self, render):
-        # Streaming is the only engine; transforms cannot stream as post-ops.
+    def test_transform_post_op_resizes_program(self, render):
+        # A transform post-op applies to the whole assembled program (Point 3):
+        # it runs as a pass over the assembled file rather than being rejected.
         plan = {
             "segments": [_segment(start=0.0, end=2.0)],
             "post_operations": [{"op": "resize", "width": 200, "height": 100}],
         }
-        with pytest.raises(PlanValidationError, match="move the transform into the segment"):
-            render(VideoEdit.from_dict(plan))
+        result = render(VideoEdit.from_dict(plan))
+        assert result.frames.shape[1:3] == (100, 200)
 
     def test_run_with_image_overlay(self, tmp_path, render):
         logo = tmp_path / "logo.png"
@@ -591,15 +592,16 @@ class TestClampWindows:
         # run() silently clamps the same window, so the output is the post-speed length.
         assert result.total_seconds == pytest.approx(post_dur, abs=0.25)
 
-    def test_cut_then_window_parity(self):
-        # cut to 6s, then a blur with window.stop=9 overruns the post-cut length.
+    def test_duration_shrink_then_window_parity(self):
+        # A duration-shrinking transform (speed 2x: 12s -> 6s) makes a later blur
+        # with window.stop=9 overrun the post-op length; repair clamps it to 6s.
         plan = {
             "segments": [
                 _segment(
                     start=0.0,
                     end=12.0,
                     operations=[
-                        {"op": "cut", "start": 0.0, "end": 6.0},
+                        {"op": "speed_change", "speed": 2.0, "adjust_audio": False},
                         {
                             "op": "blur_effect",
                             "mode": "constant",
@@ -1134,7 +1136,7 @@ class TestStreamingRequiresGuard:
                         source=SMALL_VIDEO_PATH,
                         start=4.0,
                         end=8.0,
-                        operations=[{"op": "color_adjust", "brightness": 0.2}],
+                        operations=[{"op": "glitch"}],
                     )
                 ]
             }
@@ -1161,7 +1163,7 @@ class TestStreamingRequiresGuard:
                         source=SMALL_VIDEO_PATH,
                         start=0.0,
                         end=1.0,
-                        operations=[{"op": "color_adjust", "brightness": 0.2}],
+                        operations=[{"op": "glitch"}],
                     )
                 ]
             }
@@ -1197,7 +1199,7 @@ class TestStreamingRequiresGuard:
                         source=SMALL_VIDEO_PATH,
                         start=0.0,
                         end=1.0,
-                        operations=[{"op": "color_adjust", "brightness": 0.2}],
+                        operations=[{"op": "glitch"}],
                     )
                 ]
             }
@@ -1242,7 +1244,7 @@ class TestStreamingOpOrderGuard:
             [
                 {"op": "fade", "mode": "in", "duration": 0.5},
                 {"op": "resize", "width": 64, "height": 64},
-                {"op": "color_adjust", "brightness": 0.2},
+                {"op": "glitch"},
             ]
         )
         assert plan._build_streaming_plan(plan.segments[0], None, None, None) is None
@@ -1405,17 +1407,6 @@ class TestPlanValidationErrors:
         assert err.code is PlanErrorCode.EFFECT_WINDOW_EXCEEDS_DURATION
         assert err.location == "segments[0].operations[0]"
         assert err.field == "window.stop"
-
-    def test_cut_exceeds_duration_enriched_with_segment_location(self):
-        plan = {"segments": [_segment(start=0.0, end=2.0, operations=[{"op": "cut", "start": 0.0, "end": 99.0}])]}
-        with pytest.raises(PlanValidationError) as exc:
-            VideoEdit.from_dict(plan).validate_with_metadata(SMALL_VIDEO_METADATA)
-        # The cut runs against the post-cut segment metadata (2.0s).
-        assert str(exc.value) == "end time (99.0) exceeds video duration (2.0)"
-        err = exc.value.errors[0]
-        assert err.code is PlanErrorCode.CUT_EXCEEDS_DURATION
-        assert err.location == "segments[0].operations[0]"
-        assert err.op == "cut"
 
     def test_concat_mismatch_fps(self):
         meta_a = VideoMetadata(width=320, height=240, fps=30.0, frame_count=60, total_seconds=2.0)

--- a/src/videopython/editing/effects.py
+++ b/src/videopython/editing/effects.py
@@ -15,6 +15,8 @@ override :meth:`Effect.predict_metadata`. Anchored RGBA overlays
 from __future__ import annotations
 
 import logging
+import math
+import tempfile
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -24,6 +26,7 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 from pydantic import Field, PrivateAttr, model_validator
 
+from videopython.base._ffmpeg import escape_filter_value
 from videopython.base.description import BoundingBox
 from videopython.base.exceptions import PlanError, PlanErrorCode, PlanValidationError
 from videopython.base.fonts import load_font
@@ -225,12 +228,47 @@ class Zoom(Effect):
         cropped = frame[round(y) : round(y + h), round(x) : round(x + w)]
         return cv2.resize(cropped, (width, height))
 
+    @property
+    def compiles_to_filter(self) -> bool:
+        # Only an unwindowed, whole-clip zoom is a single comma-join-safe -vf
+        # entry. A windowed zoom (frames outside the window pass through) cannot
+        # be one zoompan, so it stays frame-only.
+        return self.window is None
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Whole-clip center zoom via ffmpeg ``zoompan``.
+
+        Matches the numpy twin: the crop SIZE ramps linearly between the full
+        frame and ``width // zoom_factor`` and the frame is rescaled to the
+        original size, so the per-frame zoom is ``iw/crop_w``. The trailing
+        ``setpts=N/(fps*TB)`` is LOAD-BEARING: zoompan reinterprets PTS at its
+        own framerate, and without re-deriving PTS from the output frame number
+        the decode-stage ``fps=`` resampler multiplies the frame count. yuv-safe.
+        """
+        if ctx.frame_count <= 0:
+            return None
+        n = ctx.frame_count
+        w, h = ctx.width, ctx.height
+        small_w = w // self.zoom_factor
+        if self.mode == "out":
+            cw0, cw1 = float(small_w), float(w)
+        else:  # in
+            cw0, cw1 = float(w), float(small_w)
+        denom = max(n - 1, 1)
+        z_expr = f"iw/({cw0:.6f}+({cw1 - cw0:.6f})*on/{denom})"
+        return (
+            f"zoompan=z='{z_expr}'"
+            f":x='iw/2-iw/zoom/2':y='ih/2-ih/zoom/2'"
+            f":d=1:s={w}x{h}:fps={ctx.fps},setpts=N/({ctx.fps}*TB)"
+        )
+
 
 class ColorGrading(Effect):
     """Adjusts color properties: brightness, contrast, saturation, and temperature."""
 
     op: Literal["color_adjust"] = "color_adjust"
     streamable: ClassVar[bool] = True
+    filter_needs_rgb24: ClassVar[bool] = True
 
     brightness: float = Field(
         0.0,
@@ -278,12 +316,80 @@ class ColorGrading(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._grade_frame(frame)
 
+    @property
+    def _is_noop(self) -> bool:
+        return self.brightness == 0.0 and self.contrast == 1.0 and self.saturation == 1.0 and self.temperature == 0.0
+
+    def _channel_expr(self, src: str, temp_offset: float) -> str:
+        """Per-channel ``geq`` expression mirroring :meth:`_grade_frame`.
+
+        ``src`` is the geq accessor for the channel being computed
+        (``r(X,Y)``/``g(X,Y)``/``b(X,Y)``); ``temp_offset`` is the additive
+        temperature shift for this channel (``+t`` on red, ``0`` on green, ``-t``
+        on blue). The pipeline runs on normalised 0..1 values: brightness add,
+        contrast about 0.5 (unclipped, matching numpy), a cv2-equivalent HSV
+        "toward-max" saturation scale, the temperature shift, then a final clamp.
+        """
+        norm = {"r": "(r(X,Y)/255)", "g": "(g(X,Y)/255)", "b": "(b(X,Y)/255)"}
+
+        def bc(v: str) -> str:
+            return f"((({v}+{self.brightness:g})-0.5)*{self.contrast:g}+0.5)"
+
+        graded = bc(f"({src}/255)")
+        if self.saturation != 1.0:
+            # cv2 RGB->HSV scales saturation toward V=max(R,G,B), clipping S at 1:
+            # each channel C maps to V-(V-C)*ratio with ratio=min(sat, V/chroma).
+            # The HSV roundtrip clips inputs to 0..1 first.
+            rc = f"clip({bc(norm['r'])},0,1)"
+            gc = f"clip({bc(norm['g'])},0,1)"
+            bcl = f"clip({bc(norm['b'])},0,1)"
+            src_c = f"clip({graded},0,1)"
+            v = f"max(max({rc},{gc}),{bcl})"
+            mn = f"min(min({rc},{gc}),{bcl})"
+            chroma = f"({v}-{mn})"
+            ratio = f"if(gt({chroma},0),min({self.saturation:g},{v}/{chroma}),1)"
+            graded = f"({v}-({v}-{src_c})*({ratio}))"
+        if temp_offset != 0.0:
+            graded = f"({graded}+({temp_offset:g}))"
+        return f"clip(({graded})*255,0,255)"
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the colour grade to a single ``geq`` ``-vf`` entry.
+
+        Mirrors :meth:`_grade_frame` per channel (brightness, contrast,
+        cv2-equivalent HSV saturation, temperature) on normalised RGB, faithful
+        to the numpy path to within uint8 rounding (geq rounds; numpy truncates).
+        All commas live inside single-quoted per-channel expressions, so the
+        entry is comma-join safe. A no-op grade returns ``None``. ``self.window``
+        appends a timeline ``enable='between(t,start,stop)'``.
+        """
+        if self._is_noop:
+            return None
+        temp_shift = self.temperature * 0.1
+        r = self._channel_expr("r(X,Y)", temp_shift)
+        g = self._channel_expr("g(X,Y)", 0.0)
+        b = self._channel_expr("b(X,Y)", -temp_shift)
+        expr = f"geq=r='{r}':g='{g}':b='{b}'"
+        if self.window is not None:
+            stop = ctx.frame_count / ctx.fps if ctx.fps > 0 and ctx.frame_count > 0 else None
+            start_s = 0.0 if self.window.start is None else float(self.window.start)
+            stop_s = stop if self.window.stop is None else float(self.window.stop)
+            if stop_s is not None:
+                expr += f":enable='between(t,{start_s:g},{stop_s:g})'"
+        return expr
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        """A no-op grade emits no filter; any active field compiles to one ``geq`` entry."""
+        return not self._is_noop
+
 
 class Vignette(Effect):
     """Darkens the edges of the frame, drawing attention to the center."""
 
     op: Literal["vignette"] = "vignette"
     streamable: ClassVar[bool] = True
+    filter_needs_rgb24: ClassVar[bool] = True
 
     strength: float = Field(
         0.5,
@@ -320,6 +426,38 @@ class Vignette(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         assert self._stream_mask_3d is not None
         return (frame.astype(np.float32) * self._stream_mask_3d).astype(np.uint8)
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        return True
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the radial darkening to a per-channel ``geq`` expression.
+
+        Reproduces :meth:`_create_mask` exactly in ffmpeg's expression language:
+        ``geq`` exposes per-pixel ``X``/``Y`` and the plane size ``W``/``H``, so
+        the normalized coordinates ``Xn = 2*X/(W-1) - 1`` / ``Yn = 2*Y/(H-1) - 1``
+        mirror ``np.linspace(-1, 1, ...)``, and the mask is
+        ``1 - clip(hypot(Xn, Yn)/radius - 0.5, 0, 1) * 2*strength`` applied to every
+        channel. ``clip`` is spelled with ``min``/``max`` and explicit products so
+        the expression carries no commas of its own -- only the quoted ``r(X,Y)``
+        lookups and the ``enable`` clause do, and those quotes survive the runner's
+        comma-join of the ``-vf`` chain. ``geq`` has native timeline support, so a
+        windowed vignette gates on ``enable`` and passes other frames through.
+        """
+        xn = "((2*X/(W-1))-1)"
+        yn = "((2*Y/(H-1))-1)"
+        falloff = 2.0 * self.strength
+        mask = f"(1-min(max(sqrt({xn}*{xn}+{yn}*{yn})/{self.radius:.6f}-0.5,0),1)*{falloff:.6f})"
+        r = f"r='r(X,Y)*{mask}'"
+        g = f"g='g(X,Y)*{mask}'"
+        b = f"b='b(X,Y)*{mask}'"
+        filt = f"geq={r}:{g}:{b}"
+        if self.window is not None:
+            start_s = 0.0 if self.window.start is None else float(self.window.start)
+            stop_s = ctx.frame_count / ctx.fps if self.window.stop is None else float(self.window.stop)
+            filt += f":enable='between(t,{start_s:.6f},{stop_s:.6f})'"
+        return filt
 
 
 class KenBurns(Effect):
@@ -791,6 +929,91 @@ class TextOverlay(_AnchoredOverlay):
             self._rendered = self._render_text_image(frame_width, frame_height)
         return self._rendered
 
+    def _resolve_fontfile(self) -> Path | None:
+        """Filesystem path to the .ttf ``drawtext`` should render with, or ``None``.
+
+        Mirrors :func:`load_font`'s resolution down to a real file: a bundled
+        NAME -> its bundled .ttf; an explicit ``font_filename`` path that exists;
+        else the bundled DejaVu Sans default. ``None`` only when even DejaVu is
+        unreachable -- then ``load_font`` falls back to PIL's built-in bitmap
+        font, which ``drawtext`` cannot consume, so the op stays frame-only.
+        """
+        from videopython.base.fonts import BUNDLED_FONTS, DEFAULT_FONT_FILENAME, bundled_fonts_dir
+
+        name = self.font_filename or self.font
+        fonts_dir = bundled_fonts_dir()
+        if name:
+            bundled = BUNDLED_FONTS.get(name)
+            if bundled is not None:
+                candidate = fonts_dir / bundled
+                if candidate.is_file():
+                    return candidate
+            candidate = Path(name)
+            if candidate.is_file():
+                return candidate
+        default = fonts_dir / DEFAULT_FONT_FILENAME
+        return default if default.is_file() else None
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        """Compile to ``drawtext`` when a real TrueType file resolves, else frame-only."""
+        return self._resolve_fontfile() is not None
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the anchored, word-wrapped text overlay to one ``drawtext`` entry.
+
+        The text is pre-wrapped with the SAME PIL metrics (:meth:`_wrap_text`)
+        the numpy twin uses and written to a ``textfile`` (registered on
+        ``ctx.owned_files`` for the runner to delete), so line breaks match
+        exactly -- drawtext has no pixel word-wrap. The box is
+        ``box=1:boxcolor=...:boxborderw=<padding>`` placed at the anchored
+        position :meth:`_compute_position` computes. Faithful *visual* twin
+        (freetype vs PIL metrics diverge a few px), re-baselined to ffmpeg.
+        Comma-join safe: every comma-bearing value is wrapped via
+        :func:`escape_filter_value`. yuv-safe (drawtext needs no rgb24).
+        """
+        fontfile = self._resolve_fontfile()
+        if fontfile is None:
+            return None
+
+        font = self._get_font()
+        max_px = int(self.max_width * ctx.width)
+        wrapped = self._wrap_text(self.text, font, max_px)
+
+        bbox = ImageDraw.Draw(Image.new("RGBA", (1, 1))).multiline_textbbox((0, 0), wrapped, font=font)
+        text_w = bbox[2] - bbox[0]
+        text_h = bbox[3] - bbox[1]
+        pad = self.background_padding
+        box_x, box_y = self._compute_position(ctx.width, ctx.height, text_w + 2 * pad, text_h + 2 * pad)
+
+        tmp = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf-8")
+        try:
+            tmp.write(wrapped)
+        finally:
+            tmp.close()
+        textfile = Path(tmp.name)
+        ctx.owned_files.append(textfile)
+
+        r, g, b = self.text_color
+        parts = [
+            f"textfile={escape_filter_value(str(textfile))}",
+            f"fontfile={escape_filter_value(str(fontfile))}",
+            f"fontsize={self.font_size}",
+            f"fontcolor={escape_filter_value(f'0x{r:02x}{g:02x}{b:02x}')}",
+            f"x={box_x + pad}",
+            f"y={box_y + pad}",
+        ]
+        if self.background_color is not None:
+            br, bg, bb, ba = self.background_color
+            parts.append("box=1")
+            parts.append(f"boxcolor={escape_filter_value(f'0x{br:02x}{bg:02x}{bb:02x}@{ba / 255:.4f}')}")
+            parts.append(f"boxborderw={pad}")
+        if self.window is not None:
+            start = 0.0 if self.window.start is None else float(self.window.start)
+            stop = ctx.frame_count / ctx.fps if self.window.stop is None else float(self.window.stop)
+            parts.append(f"enable={escape_filter_value(f'between(t,{start:g},{stop:g})')}")
+        return "drawtext=" + ":".join(parts)
+
 
 class ImageOverlay(_AnchoredOverlay):
     """Composites a scaled image at an anchored position on every frame in the window.
@@ -1129,6 +1352,7 @@ class ChromaticAberration(Effect):
 
     op: Literal["chromatic_aberration"] = "chromatic_aberration"
     streamable: ClassVar[bool] = True
+    filter_needs_rgb24: ClassVar[bool] = True
 
     shift_px: int = Field(
         gt=0,
@@ -1185,6 +1409,52 @@ class ChromaticAberration(Effect):
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._aberrate(frame)
+
+    def _enable_suffix(self, ctx: FilterCtx) -> str:
+        """``:enable='between(t,START,STOP)'`` for a windowed effect, else ``""``.
+
+        START defaults to 0.0 and STOP to the segment duration
+        (``ctx.frame_count / ctx.fps``); an unset window yields no suffix. The
+        clause is single-quoted, so its inner comma survives the runner's
+        ``",".join`` into the ``-vf`` chain.
+        """
+        if self.window is None:
+            return ""
+        total_seconds = ctx.frame_count / ctx.fps if ctx.fps > 0 and ctx.frame_count > 0 else 0.0
+        start_s = 0.0 if self.window.start is None else float(self.window.start)
+        stop_s = total_seconds if self.window.stop is None else float(self.window.stop)
+        return f":enable='between(t,{start_s:.6f},{stop_s:.6f})'"
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the channel split to a single native ``-vf`` entry.
+
+        ``horizontal``/``vertical`` become ``rgbashift`` (R by ``+shift_px``,
+        B by ``-shift_px`` along the axis, ``edge=smear`` == BORDER_REPLICATE).
+        ``radial`` becomes one ``geq`` sampling R/B from a scale about the frame
+        center (matches bilinear ``cv2.remap`` to ~4/255). Green is untouched.
+        Every inner comma sits inside single-quoted ``geq`` expressions or the
+        ``enable`` clause, so the entry is comma-join-safe.
+        """
+        enable = self._enable_suffix(ctx)
+        if self.mode == "horizontal":
+            return f"rgbashift=rh={self.shift_px}:bh={-self.shift_px}:edge=smear{enable}"
+        if self.mode == "vertical":
+            return f"rgbashift=rv={self.shift_px}:bv={-self.shift_px}:edge=smear{enable}"
+        # radial: reproduce the cv2.remap scale about the center via geq.
+        cx, cy = ctx.width / 2.0, ctx.height / 2.0
+        max_d = float(max(ctx.width, ctx.height))
+        scale_r = 1.0 - self.shift_px / max_d
+        scale_b = 1.0 + self.shift_px / max_d
+        rx = f"((X-{cx:.6f})*{scale_r:.9f}+{cx:.6f})"
+        ry = f"((Y-{cy:.6f})*{scale_r:.9f}+{cy:.6f})"
+        bx = f"((X-{cx:.6f})*{scale_b:.9f}+{cx:.6f})"
+        by = f"((Y-{cy:.6f})*{scale_b:.9f}+{cy:.6f})"
+        return f"geq=r='r({rx}\\,{ry})':b='b({bx}\\,{by})'{enable}"
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        """Every mode compiles to a single, comma-join-safe ``-vf`` entry."""
+        return True
 
 
 class Glitch(Effect):
@@ -1288,6 +1558,31 @@ class FilmGrain(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._grain_frame(frame, frame_index)
 
+    @property
+    def compiles_to_filter(self) -> bool:
+        # Only unwindowed monochrome (luma-only) grain compiles to a single
+        # comma-join-safe `noise` entry. The per-channel variant and any windowed
+        # grain stay on the numpy frame path.
+        return self.monochrome and self.window is None
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile luma-only grain to ffmpeg's temporal ``noise`` filter.
+
+        A statistical (NOT pixel-identical) twin of :meth:`process_frame`:
+        ffmpeg's RNG differs from numpy's, so the grain is a different but
+        distributionally-matched draw -- equivalent in look for a random grain.
+        ``c0_flags=t`` adds fresh temporal noise to component 0 (Y in the
+        pipeline's yuv420p) each frame; ``c0_strength`` is ffmpeg's 0-100 scale,
+        which the numpy std (``intensity*255``) maps onto by the empirically-fit
+        ``strength = intensity * 255 / 0.57`` (clamped to [1, 100]) so the
+        injected per-pixel std matches in the real yuv pipeline. yuv-safe.
+        """
+        if not self.monochrome:
+            return None
+        strength = int(round(self.intensity * 255.0 / 0.57))
+        strength = max(1, min(100, strength))
+        return f"noise=c0_seed={self.seed}:c0_strength={strength}:c0_flags=t"
+
 
 class Sharpen(Effect):
     """Unsharp-mask sharpening: blur the frame and subtract from itself with weight.
@@ -1329,6 +1624,29 @@ class Sharpen(Effect):
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._sharpen_frame(frame)
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        # The whole-frame, windowless case maps cleanly to a single comma-join
+        # safe `unsharp` -vf entry. A `window` would need an enable= gate that
+        # `unsharp` does not support, so windowed sharpening stays frame-only;
+        # `unsharp` also caps the combined matrix, so kernel_size > 13 stays too.
+        return self.window is None and self.kernel_size <= 13
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Native unsharp-mask sharpening via ffmpeg's ``unsharp`` filter.
+
+        The numpy twin blends ``out = in + amount*(in - gaussian_blur(in))``.
+        ``unsharp=lx:ly:la`` is the same unsharp-mask form with the same
+        ``amount`` (``la``) weighting; its kernel is a box rather than a Gaussian,
+        so the result is a faithful visual twin (re-baseline-to-ffmpeg), not
+        bit-identical. ``amount == 0`` is a no-op (``None`` -> the runner keeps
+        the frame). ``unsharp`` is yuv-safe, so no ``format=rgb24`` is needed.
+        """
+        if self.amount == 0:
+            return None
+        k = self.kernel_size
+        return f"unsharp={k}:{k}:{self.amount:.6f}:{k}:{k}:{self.amount:.6f}"
 
 
 class Pixelate(Effect):
@@ -1379,6 +1697,22 @@ class Pixelate(Effect):
         return self._pixelate_frame(frame, self._stream_region_px)
 
 
+def _mirror_geq(coord: str, src_x: str, src_y: str) -> str:
+    """One comma-join-safe ``geq`` entry that reflects a half-frame.
+
+    ``coord`` is the per-pixel predicate (e.g. ``gte(X,W/2)``); where it holds
+    the pixel samples its mirror ``(src_x, src_y)``, elsewhere it keeps
+    ``(X, Y)``. Per-channel (r/g/b) so geq runs in RGB. The function-call commas
+    live inside single-quoted plane expressions, so the whole entry survives
+    ``",".join`` into the ``-vf`` chain.
+    """
+
+    def plane(channel: str) -> str:
+        return f"if({coord},{channel}({src_x},{src_y}),{channel}(X,Y))"
+
+    return f"geq=r='{plane('r')}':g='{plane('g')}':b='{plane('b')}'"
+
+
 class MirrorFlip(Effect):
     """Flip frames or reflect one half onto the other.
 
@@ -1389,6 +1723,7 @@ class MirrorFlip(Effect):
 
     op: Literal["mirror_flip"] = "mirror_flip"
     streamable: ClassVar[bool] = True
+    filter_needs_rgb24: ClassVar[bool] = True
 
     mode: Literal[
         "horizontal",
@@ -1432,6 +1767,54 @@ class MirrorFlip(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._flip_frame(frame)
 
+    def _enable_suffix(self, ctx: FilterCtx) -> str:
+        """``enable='between(t,START,STOP)'`` for the window, or '' when full-clip.
+
+        START defaults to 0.0 and STOP to the segment duration
+        (``ctx.frame_count / ctx.fps``). Returns the bare ``key=value`` (no
+        leading separator); the caller joins it with the right separator.
+        """
+        win = self.window
+        if win is None:
+            return ""
+        stop = ctx.frame_count / ctx.fps if win.stop is None else float(win.stop)
+        start = 0.0 if win.start is None else float(win.start)
+        return f"enable='between(t,{start:.6f},{stop:.6f})'"
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile to one comma-join-safe ``-vf`` entry mirroring :meth:`process_frame`.
+
+        ``horizontal`` / ``vertical`` map to native ``hflip`` / ``vflip``
+        (bit-exact). The ``mirror_*`` modes reflect one half onto the other via a
+        single per-channel ``geq`` expression: each output pixel samples its
+        mirror (``W-1-X`` / ``H-1-Y``) on the reflected half and itself on the
+        kept half, matching the numpy ``w//2`` / ``h//2`` split for both even and
+        odd dimensions. A window appends an ``enable=`` option (``=`` for the
+        option-less flips, ``:`` after the ``geq`` options).
+        """
+        if self.mode == "horizontal":
+            base, sep = "hflip", "="
+        elif self.mode == "vertical":
+            base, sep = "vflip", "="
+        else:
+            sep = ":"
+            if self.mode == "mirror_left":
+                coord, src_x, src_y = "gte(X,W/2)", "W-1-X", "Y"
+            elif self.mode == "mirror_right":
+                coord, src_x, src_y = "lt(X,W/2)", "W-1-X", "Y"
+            elif self.mode == "mirror_top":
+                coord, src_x, src_y = "gte(Y,H/2)", "X", "H-1-Y"
+            else:  # mirror_bottom
+                coord, src_x, src_y = "lt(Y,H/2)", "X", "H-1-Y"
+            base = _mirror_geq(coord, src_x, src_y)
+
+        enable = self._enable_suffix(ctx)
+        return f"{base}{sep}{enable}" if enable else base
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        return True
+
 
 class Kaleidoscope(Effect):
     """N-way radial mirror around the frame center.
@@ -1443,6 +1826,7 @@ class Kaleidoscope(Effect):
 
     op: Literal["kaleidoscope"] = "kaleidoscope"
     streamable: ClassVar[bool] = True
+    filter_needs_rgb24: ClassVar[bool] = True
 
     segments: int = Field(
         6,
@@ -1491,3 +1875,58 @@ class Kaleidoscope(Effect):
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._kaleidoscope_frame(frame)
+
+    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
+        """Compile the radial mirror to a single per-pixel ``geq`` remap.
+
+        Mirrors :meth:`_build_maps`/:meth:`process_frame`. For each output pixel
+        ``geq`` recovers polar coordinates about ``((W-1)/2, (H-1)/2)``, folds
+        the angle into one wedge (``2*pi/segments``) the same way the numpy path
+        does (``mod`` then reflect across the half-wedge), and samples with
+        ``interpolation=bilinear``. Out-of-frame sample coordinates are reflected
+        back in-bounds (registers 8/9) to reproduce ``cv2.BORDER_REFLECT``. One
+        ``-vf`` node, comma-join-safe.
+        """
+        if ctx.width <= 0 or ctx.height <= 0:
+            return None
+        width, height = ctx.width, ctx.height
+        cx = (width - 1) / 2.0
+        cy = (height - 1) / 2.0
+        wedge = 2.0 * math.pi / self.segments
+        half = wedge * 0.5
+        pw = 2 * width
+        ph = 2 * height
+        ao = self.angle_offset
+
+        common = (
+            f"st(1,X-{cx:.8f});"
+            f"st(2,Y-{cy:.8f});"
+            f"st(3,hypot(ld(1),ld(2)));"
+            f"st(4,atan2(ld(2),ld(1))-{ao:.8f});"
+            f"st(5,mod(ld(4),{wedge:.10f}));"
+            f"st(5,if(lt(ld(5),0),ld(5)+{wedge:.10f},ld(5)));"
+            f"st(6,if(gt(ld(5),{half:.10f}),{wedge:.10f}-ld(5),ld(5)));"
+            f"st(7,ld(6)+{ao:.8f});"
+            f"st(8,mod({cx:.8f}+ld(3)*cos(ld(7)),{pw}));"
+            f"st(8,if(lt(ld(8),0),ld(8)+{pw},ld(8)));"
+            f"st(8,if(gte(ld(8),{width}),{pw - 1}-ld(8),ld(8)));"
+            f"st(9,mod({cy:.8f}+ld(3)*sin(ld(7)),{ph}));"
+            f"st(9,if(lt(ld(9),0),ld(9)+{ph},ld(9)));"
+            f"st(9,if(gte(ld(9),{height}),{ph - 1}-ld(9),ld(9)));"
+        )
+        expr = (
+            f"geq=interpolation=bilinear:"
+            f"r='{common}r(ld(8),ld(9))':"
+            f"g='{common}g(ld(8),ld(9))':"
+            f"b='{common}b(ld(8),ld(9))'"
+        )
+        if self.window is not None:
+            stop = ctx.frame_count / ctx.fps if ctx.fps > 0 and ctx.frame_count > 0 else 0.0
+            start_s = self.window.start if self.window.start is not None else 0.0
+            stop_s = self.window.stop if self.window.stop is not None else stop
+            expr += f":enable='between(t,{start_s:.6f},{stop_s:.6f})'"
+        return expr
+
+    @property
+    def compiles_to_filter(self) -> bool:
+        return True

--- a/src/videopython/editing/operation.py
+++ b/src/videopython/editing/operation.py
@@ -265,6 +265,16 @@ class Operation(BaseModel):
     mirrors the same rule.
     """
     llm_exposed: ClassVar[bool] = True
+    internal_only: ClassVar[bool] = False
+    """Whether this op is engine-internal and must NOT be a chain op.
+
+    ``CutSeconds``/``CutFrames`` trim a segment, but trimming is the segment's own
+    ``start``/``end`` mechanism -- the engine constructs them directly. They are
+    non-streamable (no ffmpeg filter, no ``process_frame``), so to honor
+    "every registered op is streamable" they set this flag and are kept OUT of
+    the registry: they cannot appear in a plan's ``operations`` list or the LLM
+    schema, while direct construction (``CutSeconds(start=..., end=...)``) still
+    works. Default False (a normal, streamable chain op)."""
     time_fields: ClassVar[tuple[BoundedTimeField, ...]] = ()
     """Time-valued (seconds) fields :meth:`VideoEdit.repair` may clamp into range.
 
@@ -292,6 +302,12 @@ class Operation(BaseModel):
         if len(literal_values) != 1 or not isinstance(literal_values[0], str):
             raise TypeError(f"{cls.__name__}.op must be Literal of a single str, got {literal_values!r}")
         op_id = literal_values[0]
+
+        if cls.internal_only:
+            # Engine-internal op (CutSeconds/CutFrames): the op Literal is still
+            # validated above, but the op is kept out of the registry so it
+            # cannot be resolved as a chain op or exposed to the LLM.
+            return
 
         existing = Operation._registry.get(op_id)
         if existing is not None and existing is not cls:
@@ -453,13 +469,18 @@ class Effect(Operation):
 
     category: ClassVar[OpCategory] = OpCategory.EFFECT
     audio_coupled: ClassVar[bool] = False
-    """Whether the effect mutates audio alongside pixels (``afade``/``volume``).
+    """Whether the effect mutates audio alongside pixels (``afade``/``volume``)."""
+    filter_needs_rgb24: ClassVar[bool] = False
+    """Whether :meth:`to_ffmpeg_filter` reads RGB pixel values and so needs the
+    decode chain converted to ``rgb24`` first.
 
-    Audio-coupled effects cannot fold as post-operations across segment
-    boundaries: each segment's audio is processed independently, so a gain
-    envelope spanning a concat boundary would restart mid-ramp. The plan
-    builder and the streamability report both consult this.
-    """
+    ``geq``'s ``r``/``g``/``b`` accessors and ``rgbashift`` read RGB channels;
+    on the native yuv decode stream they read garbage. When a decode-stage
+    effect sets this, the plan builder prepends ``format=rgb24`` to the segment's
+    decode filter chain (encode-stage effects already receive rgb24 from the
+    frame pipe). Default False -- geometry/overlay filters (``hflip``,
+    ``subtitles=``) work in any pixel format. Mirrors the rgb24 frames the numpy
+    ``process_frame`` twin operated on."""
 
     window: TimeRange | None = Field(
         None,

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -101,253 +101,163 @@ class StreamabilityReport:
         ]
 
 
-def analyze_streamability(
-    segment_operations: Sequence[Sequence[Operation]],
-    post_operations: Sequence[Operation],
-    *,
-    has_transitions: bool = False,
-) -> StreamabilityReport:
-    """Classify every op in a plan by streaming class, in plan order.
+def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[OpStreamability]:
+    """Classify one ordered op list by streaming class, in plan order.
 
-    Mirrors the decision points of ``VideoEdit._build_streaming_plan`` and the
-    post-op folding in ``VideoEdit.run_to_file`` exactly -- this function is
-    the single documented source of those rules. Both deciders treat the
-    ``streamable`` ClassVar as the authoritative declaration (a flag-False
-    transform never streams, even with a working ``to_ffmpeg_filter``); the
-    one divergence the flag cannot express -- flag True but the filter
-    compiles to ``None`` -- is caught at runtime by the ``STREAMING_UNSUPPORTED``
-    raise in ``_compile_streaming_plans``, and a registry test pins flag-True
-    transforms to an actual ``to_ffmpeg_filter`` override. Purely structural:
-    no disk access and no runtime context.
+    Shared by every segment's ``operations`` and by the plan's
+    ``post_operations``: post-ops run as a single pass over the assembled
+    program (a synthetic final segment), so the same per-op rules apply.
+    ``location_prefix`` is the plan path entries are stamped under
+    (``segments[i].operations`` or ``post_operations``).
 
-    Segment transitions (``SegmentConfig.transition_in``) do not appear here:
-    a transition is a native ffmpeg ``xfade``/``acrossfade`` pass over two
-    realized per-segment files (each segment streams to a temp file exactly as
-    it would without a transition), so it is FILTER-class by construction and
-    never makes a plan unstreamable or changes any op's class. The one transition
-    fault that can reject a plan -- an overlap longer than an adjacent
-    segment's predicted post-op duration -- is duration-dependent, so it is
-    reported as ``TRANSITION_TOO_LONG`` by :meth:`VideoEdit.check` (which has
-    the predicted durations) and raised by ``run_to_file`` before
-    decode, not classified structurally here.
+    ``streamable`` is the authoritative declaration (a flag-False transform
+    never streams, even with a working ``to_ffmpeg_filter``); the one divergence
+    the flag cannot express -- flag True but the filter compiles to ``None`` --
+    is caught at runtime by the ``STREAMING_UNSUPPORTED`` raise in
+    ``_compile_streaming_plans``. Purely structural: no disk access, no context.
     """
     entries: list[OpStreamability] = []
-    segment_has_encode_stage: list[bool] = []
-    for i, ops in enumerate(segment_operations):
-        seen_effect = False
-        seen_encode_stage = False
-        seen_duration_change = False
-        for j, op in enumerate(ops):
-            location = f"segments[{i}].operations[{j}]"
-            if isinstance(op, Effect):
-                if op.streamable and op.requires and seen_duration_change:
-                    # The builder rejects context-consuming ops behind a
-                    # duration-changing transform: segment-local context is
-                    # not re-mapped through the time warp yet.
-                    entries.append(
-                        OpStreamability(
-                            location,
-                            op.op,
-                            StreamingClass.UNSTREAMABLE,
-                            reason=(
-                                "context-requiring op follows a duration-changing transform "
-                                "(speed_change/freeze_frame); time-based context is not re-mapped "
-                                "through the warp yet -- move the op before it to stream"
-                            ),
-                        )
-                    )
-                    continue
-                if op.streamable and op.compiles_to_filter:
-                    # Filter-class effect (add_subtitles): joins the decode
-                    # filter chain at this plan position -- or the encode
-                    # chain when frame effects precede it -- so it streams in
-                    # plan order either way and does not block later
-                    # transforms the way a scheduled frame effect does. The
-                    # builder mirrors this exactly.
-                    entries.append(OpStreamability(location, op.op, StreamingClass.FILTER))
-                    if seen_effect:
-                        seen_encode_stage = True
-                    continue
-                if not op.streamable:
-                    entries.append(
-                        OpStreamability(
-                            location,
-                            op.op,
-                            StreamingClass.UNSTREAMABLE,
-                            reason="effect has no streaming implementation (streamable=False)",
-                        )
-                    )
-                elif seen_encode_stage:
-                    entries.append(
-                        OpStreamability(
-                            location,
-                            op.op,
-                            StreamingClass.UNSTREAMABLE,
-                            reason=(
-                                "frame effect follows encode-stage filters (subtitles or transforms "
-                                "ordered after effects) in plan order; those filters run after every "
-                                "frame effect, so plan order cannot be preserved -- move the effect "
-                                "earlier to stream"
-                            ),
-                        )
-                    )
-                else:
-                    entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
-                seen_effect = True
-            elif op.requires and seen_duration_change:
+    seen_effect = False
+    seen_encode_stage = False
+    seen_duration_change = False
+    for j, op in enumerate(ops):
+        location = f"{location_prefix}[{j}]"
+        if isinstance(op, Effect):
+            if op.streamable and op.requires and seen_duration_change:
+                # The builder rejects context-consuming ops behind a
+                # duration-changing transform: segment-local context is
+                # not re-mapped through the time warp yet.
                 entries.append(
                     OpStreamability(
                         location,
                         op.op,
                         StreamingClass.UNSTREAMABLE,
                         reason=(
-                            "context-requiring transform follows a duration-changing transform; "
-                            "time-based context is not re-mapped through the warp yet -- move it "
-                            "before the duration change to stream"
+                            "context-requiring op follows a duration-changing transform "
+                            "(speed_change/freeze_frame); time-based context is not re-mapped "
+                            "through the warp yet -- move the op before it to stream"
                         ),
                     )
                 )
-            elif op.requires and not op.streamable:
-                entries.append(
-                    OpStreamability(
-                        location,
-                        op.op,
-                        StreamingClass.UNSTREAMABLE,
-                        reason=(
-                            f"transform requires runtime context {sorted(op.requires)} and has no streaming strategy"
-                        ),
-                    )
-                )
-            elif op.streamable and op.compiles_from_source and (seen_effect or seen_encode_stage):
-                entries.append(
-                    OpStreamability(
-                        location,
-                        op.op,
-                        StreamingClass.UNSTREAMABLE,
-                        reason=(
-                            "the op's compile-time detection pass cannot reproduce frames behind "
-                            "per-frame Python effects -- move it before the effects to stream"
-                        ),
-                    )
-                )
-            elif op.streamable:
-                # Transforms compile to filters at any plan position: the
-                # decode chain normally, the encode chain (after every
-                # process_frame) when frame effects precede them.
+                continue
+            if op.streamable and op.compiles_to_filter:
+                # Filter-class effect (add_subtitles, vignette, ...): joins the
+                # decode filter chain at this plan position -- or the encode
+                # chain when frame effects precede it -- so it streams in plan
+                # order either way and does not block later transforms the way
+                # a scheduled frame effect does. The builder mirrors this.
                 entries.append(OpStreamability(location, op.op, StreamingClass.FILTER))
-                if seen_effect or seen_encode_stage:
+                if seen_effect:
                     seen_encode_stage = True
-                if op.changes_duration:
-                    seen_duration_change = True
-            else:
+                continue
+            if not op.streamable:
                 entries.append(
                     OpStreamability(
                         location,
                         op.op,
                         StreamingClass.UNSTREAMABLE,
-                        reason="transform has no ffmpeg filter compilation",
+                        reason="effect has no streaming implementation (streamable=False)",
                     )
                 )
-
-        segment_has_encode_stage.append(seen_encode_stage)
-
-    multi_segment = len(segment_operations) > 1
-    any_encode_stage = any(segment_has_encode_stage)
-    for j, op in enumerate(post_operations):
-        location = f"post_operations[{j}]"
-        if has_transitions:
-            # Post-operations fold into the per-segment frame schedules, but a
-            # transition re-encodes the overlapped seam in a SEPARATE xfade
-            # pass after those schedules run -- so a post-op envelope spanning
-            # the seam cannot be represented (it would be applied to the
-            # pre-blend frames and then doubled at the overlap). Reject the
-            # combination rather than mis-time it; move the op into a segment.
+            elif seen_encode_stage:
+                entries.append(
+                    OpStreamability(
+                        location,
+                        op.op,
+                        StreamingClass.UNSTREAMABLE,
+                        reason=(
+                            "frame effect follows encode-stage filters (subtitles or transforms "
+                            "ordered after effects) in plan order; those filters run after every "
+                            "frame effect, so plan order cannot be preserved -- move the effect "
+                            "earlier to stream"
+                        ),
+                    )
+                )
+            else:
+                entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
+            seen_effect = True
+        elif op.requires and seen_duration_change:
             entries.append(
                 OpStreamability(
                     location,
                     op.op,
                     StreamingClass.UNSTREAMABLE,
                     reason=(
-                        "post-operations cannot fold across a plan that has segment transitions: the "
-                        "overlapped seam is re-encoded in a separate xfade pass, so an envelope across "
-                        "it cannot be represented -- move the op into a segment or drop the transition"
+                        "context-requiring transform follows a duration-changing transform; "
+                        "time-based context is not re-mapped through the warp yet -- move it "
+                        "before the duration change to stream"
                     ),
                 )
             )
-        elif op.requires:
+        elif op.requires and not op.streamable:
+            entries.append(
+                OpStreamability(
+                    location,
+                    op.op,
+                    StreamingClass.UNSTREAMABLE,
+                    reason=(f"transform requires runtime context {sorted(op.requires)} and has no streaming strategy"),
+                )
+            )
+        elif op.streamable and op.compiles_from_source and (seen_effect or seen_encode_stage):
             entries.append(
                 OpStreamability(
                     location,
                     op.op,
                     StreamingClass.UNSTREAMABLE,
                     reason=(
-                        f"post-operation requires runtime context {sorted(op.requires)}, which is not "
-                        "re-based onto the assembled timeline -- move it into the segment to stream"
+                        "the op's compile-time detection pass cannot reproduce frames behind "
+                        "per-frame Python effects -- move it before the effects to stream"
                     ),
                 )
             )
-        elif isinstance(op, Effect) and op.streamable and op.compiles_to_filter:
-            entries.append(
-                OpStreamability(
-                    location,
-                    op.op,
-                    StreamingClass.UNSTREAMABLE,
-                    reason=(
-                        "filter-class post-operations cannot fold into the segment schedule -- "
-                        "move the op into the segment to stream"
-                    ),
-                )
-            )
-        elif isinstance(op, Effect) and op.streamable and any_encode_stage:
-            entries.append(
-                OpStreamability(
-                    location,
-                    op.op,
-                    StreamingClass.UNSTREAMABLE,
-                    reason=(
-                        "post-operations fold into the per-segment frame-effect schedules, which run "
-                        "before a segment's encode-stage filters -- move the op into the segments "
-                        "(before the encode-stage ops) to stream"
-                    ),
-                )
-            )
-        elif isinstance(op, Effect) and op.streamable and op.audio_coupled and multi_segment:
-            entries.append(
-                OpStreamability(
-                    location,
-                    op.op,
-                    StreamingClass.UNSTREAMABLE,
-                    reason=(
-                        "audio-coupled post-operations (fade/volume_adjust) cannot fold across a "
-                        "multi-segment concat: each segment's audio is processed independently, so "
-                        "the gain envelope would restart at every boundary -- apply it per segment "
-                        "or use a single-segment plan"
-                    ),
-                )
-            )
-        elif isinstance(op, Effect) and op.streamable:
-            # Folds into the per-segment schedules with globally-rebased
-            # frame offsets (multi-segment included since 0.42.0).
-            entries.append(OpStreamability(location, op.op, StreamingClass.FRAME_EFFECT))
-        elif isinstance(op, Effect):
-            entries.append(
-                OpStreamability(
-                    location,
-                    op.op,
-                    StreamingClass.UNSTREAMABLE,
-                    reason="effect has no streaming implementation (streamable=False)",
-                )
-            )
+        elif op.streamable:
+            # Transforms compile to filters at any plan position: the decode
+            # chain normally, the encode chain (after every process_frame) when
+            # frame effects precede them.
+            entries.append(OpStreamability(location, op.op, StreamingClass.FILTER))
+            if seen_effect or seen_encode_stage:
+                seen_encode_stage = True
+            if op.changes_duration:
+                seen_duration_change = True
         else:
             entries.append(
                 OpStreamability(
                     location,
                     op.op,
                     StreamingClass.UNSTREAMABLE,
-                    reason="transforms cannot stream as post-operations -- move the transform into the segment",
+                    reason="transform has no ffmpeg filter compilation",
                 )
             )
+    return entries
 
+
+def analyze_streamability(
+    segment_operations: Sequence[Sequence[Operation]],
+    post_operations: Sequence[Operation],
+) -> StreamabilityReport:
+    """Classify every op in a plan by streaming class, in plan order.
+
+    The single documented source of ``VideoEdit._build_streaming_plan``'s rules.
+    Each segment's ``operations`` are classified by :func:`_classify_op_list`;
+    ``post_operations`` are classified the same way because they run as ONE pass
+    over the assembled program (``VideoEdit._apply_post_operations`` builds a
+    synthetic single segment over the assembled file), so a filter-class effect,
+    a frame effect, or a transform all stream as a post-op exactly as they would
+    inside a segment. Purely structural: no disk access, no runtime context.
+
+    Segment transitions do not appear here: a transition is a native
+    ``xfade``/``acrossfade`` pass over two realized per-segment files, so it is
+    FILTER-class by construction. Its one duration-dependent fault is reported as
+    ``TRANSITION_TOO_LONG`` by :meth:`VideoEdit.check`. The one post-op fault
+    this structural pass cannot see -- a context-requiring post-op on a
+    multi-segment plan, whose source-absolute context cannot be re-based onto the
+    concatenated timeline -- is reported as ``POST_OP_REQUIRES_CONTEXT`` by
+    :meth:`VideoEdit.check`.
+    """
+    entries: list[OpStreamability] = []
+    for i, ops in enumerate(segment_operations):
+        entries.extend(_classify_op_list(ops, f"segments[{i}].operations"))
+    entries.extend(_classify_op_list(list(post_operations), "post_operations"))
     return StreamabilityReport(entries=tuple(entries))
 
 
@@ -679,6 +589,121 @@ def segment_audio_from_plan(plan: StreamingSegmentPlan) -> SegmentAudio:
 
 
 def stream_segment(
+    plan: StreamingSegmentPlan,
+    output_path: Path,
+    with_audio: bool = True,
+    format: str = "mp4",
+    preset: str = "medium",
+    crf: int = 23,
+) -> Path:
+    """Render one segment, dispatching on whether it needs per-frame Python.
+
+    Filter-only segments (no scheduled frame effects) render in a SINGLE ffmpeg
+    invocation via :func:`stream_segment_filtergraph` -- no rawvideo round-trip
+    and no Python frame loop. Segments carrying frame effects fall to the
+    per-frame pipeline (:func:`_stream_segment_framewise`). Both runners emit
+    identical encode params, so their outputs concat-copy together.
+    """
+    if not plan.effect_schedule:
+        return stream_segment_filtergraph(
+            plan, output_path, with_audio=with_audio, format=format, preset=preset, crf=crf
+        )
+    return _stream_segment_framewise(plan, output_path, with_audio=with_audio, format=format, preset=preset, crf=crf)
+
+
+def stream_segment_filtergraph(
+    plan: StreamingSegmentPlan,
+    output_path: Path,
+    with_audio: bool = True,
+    format: str = "mp4",
+    preset: str = "medium",
+    crf: int = 23,
+) -> Path:
+    """Render a filter-only segment in ONE ffmpeg process (no rawvideo pipe).
+
+    Requires an empty ``plan.effect_schedule``. The source is read input-side
+    trimmed (``-ss start -t dur -i source``); the segment's video filter chain
+    and the audio ``filter_complex`` (:func:`build_audio_filter_complex`) ride
+    the same invocation. Encode params match :class:`FrameEncoder` exactly, so
+    the output concat-copies with any framewise-rendered sibling segment.
+    """
+    if format not in get_args(ALLOWED_VIDEO_FORMATS):
+        raise ValueError(f"Unsupported format: {format}")
+    if preset not in get_args(ALLOWED_VIDEO_PRESETS):
+        raise ValueError(f"Unsupported preset: {preset}")
+    assert not plan.effect_schedule, "filtergraph runner requires an empty effect schedule"
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    final_width = plan.final_width or plan.output_width
+    final_height = plan.final_height or plan.output_height
+    final_fps = plan.final_fps or plan.output_fps
+    require_even(final_width, final_height)
+
+    duration = plan.end_second - plan.start_second
+
+    cmd = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error"]
+    if plan.start_second > 0:
+        cmd += ["-ss", f"{plan.start_second:.6f}"]
+    cmd += ["-t", f"{duration:.6f}", "-i", str(plan.source_path)]  # video: input 0
+
+    audio = segment_audio_from_plan(plan) if with_audio else None
+    graph: list[str] = []
+    maps: list[str] = []
+
+    # Reproduce the framewise path's pixel pipeline exactly so a fast-path render
+    # is byte-comparable with a framewise sibling (mixed-mechanism concat, and
+    # cross-path test comparisons). The framewise decoder (FrameIterator) applies
+    # vf_filters, then conforms to CFR with `fps=output_fps` (only if no fps=
+    # filter is already present), and emits rgb24; the framewise encoder then
+    # re-encodes rgb24 -> yuv420p. We mirror all three: vf_filters (+ the empty
+    # post_vf chain), the fps conform, and the rgb24 round-trip.
+    video_chain = [*plan.vf_filters, *plan.post_vf_filters]
+    if not any(f.startswith("fps=") for f in video_chain):
+        video_chain.append(f"fps={plan.output_fps:.10g}")
+    video_chain.append("format=rgb24")
+    graph.append(f"[0:v]{','.join(video_chain)}[vout]")
+    maps += ["-map", "[vout]"]
+
+    if audio is not None:
+        audio_inputs, audio_graph, audio_map = build_audio_filter_complex(audio, input_index=1)
+        cmd += audio_inputs  # audio: input 1
+        graph += audio_graph
+        maps += ["-map", audio_map]
+
+    if graph:
+        cmd += ["-filter_complex", ";".join(graph)]
+    cmd += maps
+    cmd += [
+        "-c:v",
+        "libx264",
+        "-preset",
+        preset,
+        "-crf",
+        str(crf),
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        "-vsync",
+        "cfr",
+        "-r",
+        f"{final_fps:.10g}",
+    ]
+    cmd += ["-c:a", "aac", "-b:a", "192k"] if audio is not None else ["-an"]
+    cmd += [str(output_path)]
+
+    try:
+        _ffmpeg.run(cmd)
+    except Exception:
+        if output_path.exists():
+            output_path.unlink()
+        raise
+    return output_path
+
+
+def _stream_segment_framewise(
     plan: StreamingSegmentPlan,
     output_path: Path,
     with_audio: bool = True,

--- a/src/videopython/editing/transforms.py
+++ b/src/videopython/editing/transforms.py
@@ -71,6 +71,7 @@ class CutFrames(Operation):
 
     op: Literal["cut_frames"] = "cut_frames"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
+    internal_only: ClassVar[bool] = True
 
     start: int = Field(ge=0, description="Start frame index (inclusive).")
     end: int = Field(ge=0, description="End frame index (exclusive).")
@@ -106,6 +107,7 @@ class CutSeconds(Operation):
 
     op: Literal["cut"] = "cut"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
+    internal_only: ClassVar[bool] = True
 
     start: float = Field(ge=0, description="Start time in seconds.")
     end: float = Field(ge=0, description="End time in seconds.")
@@ -263,6 +265,13 @@ class Crop(Operation):
 
     def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
         cx, cy, cw, ch = self._resolve_box(ctx.width, ctx.height)
+        if self.mode == CropMode.CENTER:
+            # Match predict_metadata: a centered crop floors to even dimensions
+            # (libx264/yuv420p rejects odd), re-centered on the floored box, so
+            # the compiled filter emits exactly the declared output dims.
+            cw, ch = floor_to_even(cw), floor_to_even(ch)
+            cx = (ctx.width - cw) // 2
+            cy = (ctx.height - ch) // 2
         return f"crop={cw}:{ch}:{cx}:{cy}"
 
 

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -721,6 +721,32 @@ def _repair_op_chain(
     return new_ops, repairs, running
 
 
+@dataclasses.dataclass(frozen=True)
+class _MatchTarget:
+    """The resolved concat-compatibility target for a set of segment metas.
+
+    Produced by :meth:`VideoEdit._resolve_matching_target` and consumed by BOTH
+    the prediction pass (:meth:`VideoEdit._apply_matching`) and the execution
+    pass (:meth:`VideoEdit._matching_targets_from_disk`), so the
+    min-fps/min-resolution policy lives in one place and the two cannot drift. A
+    ``None`` axis means that axis is not matched (its ``match_to_lowest_*`` flag
+    is off, or there is nothing to match): callers leave that axis untouched.
+    """
+
+    fps: float | None
+    width: int | None
+    height: int | None
+
+    def apply(self, meta: VideoMetadata) -> VideoMetadata:
+        """Return ``meta`` conformed to this target on every non-``None`` axis."""
+        out = meta
+        if self.width is not None and self.height is not None and (out.width, out.height) != (self.width, self.height):
+            out = out.with_dimensions(self.width, self.height)
+        if self.fps is not None and out.fps != self.fps:
+            out = out.with_fps(self.fps)
+        return out
+
+
 class TransitionSpec(BaseModel):
     """How one segment enters from the previous one: a native ffmpeg crossfade.
 
@@ -1061,7 +1087,6 @@ class VideoEdit(BaseModel):
         return analyze_streamability(
             [list(seg.operations) for seg in self.segments],
             list(self.post_operations),
-            has_transitions=any(seg.transition_in is not None for seg in self.segments),
         )
 
     def repair(
@@ -1202,7 +1227,7 @@ class VideoEdit(BaseModel):
     def normalize_dimensions(
         self,
         source_metadata: VideoMetadata | dict[str, VideoMetadata],
-        target: tuple[int, int] | Literal["first", "largest"],
+        target: tuple[int, int] | Literal["first", "largest", "match"],
         context: dict[str, Any] | None = None,
     ) -> tuple[VideoEdit, list[PlanRepair]]:
         """Make every segment concat-compatible by resizing to a common canvas.
@@ -1261,6 +1286,15 @@ class VideoEdit(BaseModel):
         elif target == "largest":
             biggest = max(known, key=lambda m: m.width * m.height)
             tw, th = biggest.width, biggest.height
+        elif target == "match":
+            # The same min-resolution policy the engine's
+            # match_to_lowest_resolution applies in-stream, materialized as
+            # resize ops so it survives serialization. Degrades to "first" when
+            # the flag is off (resolved.width is None), keeping the
+            # always-produce-a-compatible-plan contract.
+            resolved = self._resolve_matching_target(known)
+            tw = resolved.width if resolved.width is not None else known[0].width
+            th = resolved.height if resolved.height is not None else known[0].height
         else:
             tw, th = target
 
@@ -1577,18 +1611,30 @@ class VideoEdit(BaseModel):
         present = [(i, m) for i, m in enumerate(cut_metas) if m is not None]
         return dict(zip((i for i, _ in present), self._apply_matching([m for _, m in present])))
 
+    def _resolve_matching_target(self, metas: list[VideoMetadata]) -> _MatchTarget:
+        """The one place the min-fps/min-resolution concat policy is decided.
+
+        Reduces per-segment metas to a single :class:`_MatchTarget` honoring
+        ``match_to_lowest_fps`` / ``match_to_lowest_resolution``. An axis is
+        ``None`` (left untouched) when its flag is off or there is nothing to
+        match (``<= 1`` meta). Shared verbatim by the prediction pass
+        (:meth:`_apply_matching`) and the execution pass
+        (:meth:`_matching_targets_from_disk`), and reused by
+        :meth:`normalize_dimensions` for its ``"match"`` target, so all three
+        agree by construction. Pure: no disk, no mutation of the inputs.
+        """
+        if len(metas) <= 1:
+            return _MatchTarget(fps=None, width=None, height=None)
+        fps = min(m.fps for m in metas) if self.match_to_lowest_fps else None
+        width = min(m.width for m in metas) if self.match_to_lowest_resolution else None
+        height = min(m.height for m in metas) if self.match_to_lowest_resolution else None
+        return _MatchTarget(fps=fps, width=width, height=height)
+
     def _apply_matching(self, metas: list[VideoMetadata]) -> list[VideoMetadata]:
         if len(metas) <= 1:
             return metas
-        result = metas
-        if self.match_to_lowest_fps:
-            min_fps = min(m.fps for m in result)
-            result = [m.with_fps(min_fps) if m.fps != min_fps else m for m in result]
-        if self.match_to_lowest_resolution:
-            min_w = min(m.width for m in result)
-            min_h = min(m.height for m in result)
-            result = [m.with_dimensions(min_w, min_h) if (m.width, m.height) != (min_w, min_h) else m for m in result]
-        return result
+        target = self._resolve_matching_target(metas)
+        return [target.apply(m) for m in metas]
 
     def run_to_file(
         self,
@@ -1613,19 +1659,29 @@ class VideoEdit(BaseModel):
 
         plans = self._compile_streaming_plans(context)
         self._assert_music_bed_supported()
-        # With a music bed, segment assembly writes to an intermediate file and
-        # the bed is mixed into `output_path` in a final post-assembly pass;
-        # without one, assembly writes straight to `output_path`.
-        bed_tmp: Path | None = None
-        if self.music_bed is not None:
+
+        # The program flows through up to three stages, each writing to its own
+        # temp file: assemble segments -> apply post_operations -> mix music bed.
+        # Only the final active stage writes straight to `output_path`.
+        has_post = bool(self.post_operations)
+        has_bed = self.music_bed is not None
+        intermediates: list[Path] = []
+
+        def _stage_target(*, is_last: bool) -> Path:
+            if is_last:
+                return output_path
             tmp = tempfile.NamedTemporaryFile(suffix=f".{format}", delete=False)
             tmp.close()
-            bed_tmp = Path(tmp.name)
-        assemble_target = bed_tmp if bed_tmp is not None else output_path
+            p = Path(tmp.name)
+            intermediates.append(p)
+            return p
+
         try:
             self._assert_transitions_runnable(plans)
+            # Stage 1: assemble the segments.
+            target = _stage_target(is_last=not (has_post or has_bed))
             if len(plans) == 1:
-                assembled = stream_segment(plans[0], assemble_target, format=format, preset=preset, crf=crf)
+                assembled = stream_segment(plans[0], target, format=format, preset=preset, crf=crf)
             else:
                 # Realize each segment to its own temp file (effects + audio
                 # already baked by stream_segment's filter_complex), capturing
@@ -1646,26 +1702,89 @@ class VideoEdit(BaseModel):
                         temp_files.append(Path(tmp.name))
 
                     if all(seg.transition_in is None for seg in self.segments):
-                        assembled = concat_files(temp_files, assemble_target)
+                        assembled = concat_files(temp_files, target)
                     else:
                         assembled = self._assemble_with_transitions(
-                            temp_files, audible, assemble_target, format=format, preset=preset, crf=crf
+                            temp_files, audible, target, format=format, preset=preset, crf=crf
                         )
                 finally:
                     for f in temp_files:
                         f.unlink(missing_ok=True)
 
-            if self.music_bed is None:
-                return assembled
-            # Final post-assembly pass: mix the bed under the assembled program.
-            speech = self._music_bed_speech_windows(context)
-            return self._mix_music_bed_to_file(assembled, output_path, speech, format=format, preset=preset, crf=crf)
+            # Stage 2: apply post_operations as ONE pass over the assembled
+            # program (a synthetic single segment), so filter-class effects,
+            # frame effects, and transforms all apply on the assembled timeline.
+            if has_post:
+                target = _stage_target(is_last=not has_bed)
+                assembled = self._apply_post_operations(
+                    assembled, target, context, format=format, preset=preset, crf=crf
+                )
+
+            # Stage 3: mix the music bed under the assembled program.
+            if has_bed:
+                speech = self._music_bed_speech_windows(context)
+                assembled = self._mix_music_bed_to_file(
+                    assembled, output_path, speech, format=format, preset=preset, crf=crf
+                )
+
+            return assembled
         finally:
-            if bed_tmp is not None:
-                bed_tmp.unlink(missing_ok=True)
+            for p in intermediates:
+                p.unlink(missing_ok=True)
             for plan in plans:
                 for f in plan.owned_temp_files:
                     f.unlink(missing_ok=True)
+
+    def _apply_post_operations(
+        self,
+        assembled: Path,
+        output_path: Path,
+        context: dict[str, Any] | None,
+        *,
+        format: str,
+        preset: str,
+        crf: int,
+    ) -> Path:
+        """Apply ``post_operations`` as one pass over the assembled program.
+
+        The assembled file is treated as a single synthetic segment whose
+        ``operations`` are the ``post_operations``, then run through the same
+        streaming engine as any segment -- so filter-class effects (vignette,
+        color_adjust, ...), frame effects, and transforms all apply uniformly to
+        the whole program on the assembled timeline, with each effect ``window``
+        resolving against the assembled file's own frame count. No per-segment
+        fold and no cross-boundary re-basing.
+
+        Runtime context: a single-segment plan's assembled timeline IS that
+        segment's, so a rebaseable value (e.g. a ``Transcription``) is re-based
+        onto it exactly as a per-segment op would see it. Multi-segment context
+        post-ops are rejected up front by :meth:`_assert_post_ops_supported`
+        (source-absolute context cannot be re-based across a concat), so only
+        broadcast (non-time) context reaches a multi-segment post-op pass.
+        """
+        meta = VideoMetadata.from_path(str(assembled))
+        seg = SegmentConfig(
+            source=assembled,
+            start=0.0,
+            end=round(meta.total_seconds, 6),
+            operations=list(self.post_operations),
+        )
+        if len(self.segments) == 1:
+            src = self.segments[0]
+            post_context = _segment_context(context, str(src.source), src.start, src.end)
+        else:
+            post_context = context
+        plan = self._build_streaming_plan(seg, None, None, None, post_context)
+        if plan is None:
+            raise PlanValidationError(
+                "post_operations did not compile to a streaming plan",
+                [PlanError(code=PlanErrorCode.STREAMING_UNSUPPORTED, location="post_operations")],
+            )
+        try:
+            return stream_segment(plan, output_path, format=format, preset=preset, crf=crf)
+        finally:
+            for f in plan.owned_temp_files:
+                f.unlink(missing_ok=True)
 
     def _mix_music_bed_to_file(
         self,
@@ -1828,7 +1947,10 @@ class VideoEdit(BaseModel):
                     f.unlink(missing_ok=True)
 
     def _compile_streaming_plans(self, context: dict[str, Any] | None) -> list[StreamingSegmentPlan]:
-        """Compile every segment plan and fold the post-ops, or raise.
+        """Compile every per-segment streaming plan, or raise.
+
+        Post-operations are NOT compiled here -- they run as a separate pass over
+        the assembled program (:meth:`_apply_post_operations`).
 
         The single admission point for :meth:`run_to_file`. Unstreamable shapes raise
         :class:`PlanValidationError` with the streamability report's
@@ -1862,46 +1984,6 @@ class VideoEdit(BaseModel):
                 if plan is None:
                     raise drift(f"segments[{i}] did not compile to a streaming plan")
                 plans.append(plan)
-
-            if self.post_operations:
-                # Post-op effects fold into the per-segment schedules with
-                # globally-rebased frame offsets: each segment's entries get
-                # the window slice that falls inside it, with index_offset /
-                # total_effect_frames carrying the assembled-timeline window
-                # so envelopes continue across the concat boundary. The
-                # unsupported shapes were rejected by the report gate above;
-                # reaching one here is drift.
-                if any(p.post_vf_filters for p in plans):
-                    raise drift("post-operations behind encode-stage filters")
-                seg_counts = [p.output_total_frames for p in plans]
-                offsets = [0]
-                for count in seg_counts[:-1]:
-                    offsets.append(offsets[-1] + count)
-                total_frames = sum(seg_counts)
-                post_fps = plans[0].output_fps
-                for op in self.post_operations:
-                    if op.requires:
-                        raise drift(f"post-operation '{op.op}' requires runtime context")
-                    if not isinstance(op, Effect) or not op.streamable or op.compiles_to_filter:
-                        raise drift(f"post-operation '{op.op}' cannot fold into the segment schedule")
-                    if op.audio_coupled and len(plans) > 1:
-                        raise drift(f"audio-coupled post-operation '{op.op}' cannot fold across segments")
-                    g_start, g_end = _effect_frame_range(op, post_fps, total_frames)
-                    g_open = g_end >= total_frames
-                    for offset, count, plan in zip(offsets, seg_counts, plans):
-                        local_start = max(g_start, offset)
-                        local_end = count + offset if g_open else min(g_end, offset + count)
-                        if local_start >= local_end:
-                            continue
-                        plan.effect_schedule.append(
-                            EffectScheduleEntry(
-                                op,
-                                local_start - offset,
-                                local_end - offset,
-                                index_offset=max(0, offset - g_start),
-                                total_effect_frames=g_end - g_start,
-                            )
-                        )
         except BaseException:
             for plan in plans:
                 for f in plan.owned_temp_files:
@@ -1915,10 +1997,8 @@ class VideoEdit(BaseModel):
         if len(self.segments) <= 1 or (not self.match_to_lowest_fps and not self.match_to_lowest_resolution):
             return None, None, None
         metas = [VideoMetadata.from_path(str(seg.source)) for seg in self.segments]
-        fps = min(m.fps for m in metas) if self.match_to_lowest_fps else None
-        w = min(m.width for m in metas) if self.match_to_lowest_resolution else None
-        h = min(m.height for m in metas) if self.match_to_lowest_resolution else None
-        return fps, w, h
+        target = self._resolve_matching_target(metas)
+        return target.fps, target.width, target.height
 
     def _build_streaming_plan(
         self,
@@ -1993,6 +2073,7 @@ class VideoEdit(BaseModel):
         post_af_filters: list[str] = []
         audio_idx = 0
         duration_changed = False
+        decode_needs_rgb = False
 
         def compile_audio_twin(op: Operation, ctx: FilterCtx, encode_stage: bool) -> None:
             """Append the op's audio-domain filter at the same stage the video
@@ -2048,6 +2129,7 @@ class VideoEdit(BaseModel):
                                 post_vf_filters.append(filter_expr)
                             else:
                                 vf_filters.append(filter_expr)
+                                decode_needs_rgb = decode_needs_rgb or op.filter_needs_rgb24
                             # Audio twin at the same stage (add_subtitles has
                             # none today; kept coupled for extensibility).
                             compile_audio_twin(op, ctx, encode_stage_effect)
@@ -2130,6 +2212,14 @@ class VideoEdit(BaseModel):
             # crop exceeding source) must not leak earlier ops' temp files.
             abandon()
             raise
+
+        # A decode-stage filter-effect that reads RGB (geq r/g/b, rgbashift)
+        # must see rgb24, not the native yuv decode stream; prepend one
+        # conversion ahead of the whole decode chain (encode-stage effects
+        # already receive rgb24 from the frame pipe). Idempotent: only when an
+        # rgb-reading effect landed at decode and no conversion leads already.
+        if decode_needs_rgb and not (vf_filters and vf_filters[0] == "format=rgb24"):
+            vf_filters.insert(0, "format=rgb24")
 
         pipe = pipe_meta or running
         # Final output duration after every transform (decode + encode stage),

--- a/uv.lock
+++ b/uv.lock
@@ -4491,7 +4491,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Converge the editing engine on native ffmpeg filters while keeping per-frame Python effects first-class, so the common case is fast and nothing is dropped.

Engine:
- Filter-only segments render in ONE ffmpeg invocation (stream_segment_filtergraph) instead of decode -> rawvideo pipe -> Python loop -> rawvideo pipe -> encode.
- post_operations run as a pass over the assembled program (a synthetic single segment), so transforms, filter-class effects, transitions+post-ops, and audio-coupled post-ops over a multi-segment program all work; only a time-based-context post-op on a multi-segment plan is rejected.
- Segment-compat policy unified behind one _MatchTarget resolver shared by the prediction and execution passes; normalize_dimensions gains a "match" target.
- Only streamable ops in the registry: cut/cut_frames are internal_only (constructed by the engine to trim segments, not chain ops). Every registered op compiles to a filter or is a per-frame effect.

Effects (each verified in-pipeline against its numpy process_frame twin):
- Nine migrated to native ffmpeg filters: vignette, mirror_flip, chromatic_aberration, kaleidoscope, color_adjust, sharpen, text_overlay, zoom, and monochrome film_grain. process_frame is retained on each; windowed/ large-kernel/per-channel/no-font variants stay frame-only via a mode-dependent compiles_to_filter.
- New Effect.filter_needs_rgb24 contract: an effect whose filter reads RGB (geq/rgbashift) gets format=rgb24 prepended to the decode chain.
- Fixed a latent Crop center-mode odd-dimension mismatch the fast path exposed.

Breaking: the streamability classification of several plan shapes changed (more shapes stream; the nine effects move frame_effect -> filter) and cut/cut_frames are no longer chain ops. No public method signature changed.

Docs and RELEASE_NOTES updated; version bumped 0.45.0 -> 0.46.0.