### PR TITLE
feat(editing): migrate blur/shake/flash; drop the streamable flag; de…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,74 @@
 # Release Notes
 
+## 0.47.0
+
+Pixel effects go back to numpy. After 0.46.0 migrated nine effects to native
+ffmpeg filters, benchmarks showed the migrations were not worth it: ffmpeg only
+beat the vectorised numpy/cv2 `process_frame` by ~1.1–1.4x (and that gain was
+from skipping the rawvideo round-trip, not faster compute), some were *slower*
+(`gblur`), and the `geq`-based ones were catastrophic. So the engine now reserves
+ffmpeg filters for what numpy can't do well — geometry/timing transforms and text
+rendering — and runs every pixel effect per-frame. No wire-format change; every
+op remains streamable.
+
+### Every pixel effect runs per-frame numpy again
+
+The benchmark (1080×1920, ~390 frames) was decisive: decode + encode dominate
+every render (~6s, paid by both paths), pure numpy compute is tiny (<1s for most
+effects), and the rawvideo round-trip a per-frame effect adds is only ~0.8s. So
+the per-effect filter win was marginal at best:
+
+| effect | filter (ffmpeg) | frame (numpy) | filter speedup |
+|---|---|---|---|
+| `blur` (gblur) | 12–15s | 7.3s | **0.6x (slower)** |
+| `sharpen` (unsharp) | 7.6s | 8.1s | 1.07x |
+| `zoom` (zoompan) | 6.5s | 7.6s | 1.17x |
+| `film_grain` (noise) | 27.8s | 31.9s | 1.15x |
+| `chromatic` h/v (rgbashift) | 6.4s | 8.7s | 1.36x |
+| `mirror` h/v (hflip) | 6.1s | 8.0s | 1.31x |
+
+Every pixel effect is now a per-frame `process_frame` numpy/cv2 implementation:
+`blur`, `sharpen`, `zoom`, `film_grain`, `chromatic_aberration`, `mirror_flip`,
+`vignette`, `color_adjust`, `kaleidoscope`, `shake`, `flash`, `glitch`,
+`pixelate`, `ken_burns`, `punch_in`, and the image overlays. Output is bit-identical
+to the pre-0.46.0 numpy path (no re-baseline). The only effects that still compile
+to ffmpeg filters are the two with no good numpy form: `text_overlay` (drawtext)
+and `add_subtitles` (libass). Transforms (`resize`, `crop`, `resample_fps`,
+`speed_change`, `freeze_frame`, `silence_removal`, `face_crop`) are unchanged —
+they stay native filters and an all-transform segment still renders in a single
+ffmpeg invocation.
+
+Relative to 0.46.0, the streamability *class* of every migrated pixel effect moves
+from `filter` back to `frame_effect` (all remain streamable); consumers gating on
+`edit.streamability()` should expect that reclassification.
+
+### Removed the `filter_needs_rgb24` mechanism (internal)
+
+Only the `geq`/`rgbashift`/`gblur` filters read RGB and needed the decode chain
+converted to `rgb24` first; with every pixel effect back on numpy, no effect sets
+`filter_needs_rgb24`. The `Effect.filter_needs_rgb24` ClassVar and the plan
+builder's `format=rgb24` prepend are removed. (The single-invocation fast path's
+own rgb24 round-trip — which mirrors the framewise encoder for byte-parity — is
+unrelated and stays.)
+
+### Removed the `streamable` ClassVar (internal)
+
+Every registered op is streamable, so the `streamable` flag was redundant. It is
+replaced by `Operation.streams()` — a transform streams iff it overrides
+`to_ffmpeg_filter`; an effect iff it overrides `process_frame` or sets
+`compiles_to_filter`. The classifier and plan builder now decide structurally,
+so the report and the builder cannot disagree (the residual "filter compiles to
+None at this position" case is still caught by the runtime drift guard). A custom
+`Operation`/`Effect` subclass no longer declares `streamable`; it streams by
+implementing one of those methods.
+
+### Removed dead post-op-fold machinery (internal)
+
+`EffectScheduleEntry.index_offset` / `total_effect_frames` were only set by the
+per-segment post-op fold removed in 0.46.0 (post-ops now run as a pass over the
+assembled program), so they always took their defaults. Dropped, with the
+framewise loop and a stale docstring simplified accordingly.
+
 ## 0.46.0
 
 A faster, single-mechanism editing engine. Filter-only segments render in one

--- a/docs/api/editing.md
+++ b/docs/api/editing.md
@@ -92,24 +92,27 @@ time) regardless of video length.
 Each operation is one of two kinds:
 
 - a **filter** — compiles to a native ffmpeg filter (`op.to_ffmpeg_filter(ctx)`).
-  All transforms (`resize`, `crop`, `resample_fps`, the duration-changing
+  This is reserved for ops ffmpeg does that numpy can't (or can't do as well):
+  all transforms (`resize`, `crop`, `resample_fps`, the duration-changing
   `speed_change`/`freeze_frame`, the transcription-consuming `silence_removal`,
-  and `face_crop` from the ai extra) and most effects (`add_subtitles`,
-  `vignette`, `color_adjust`, `chromatic_aberration`, `kaleidoscope`,
-  `mirror_flip`, `sharpen`, `text_overlay`, `zoom`, monochrome `film_grain`).
+  and `face_crop` from the ai extra), and the two text-rendering effects
+  `text_overlay` (drawtext) and `add_subtitles` (libass).
 - a **per-frame effect** — shape-preserving Python over each decoded frame
-  (`streaming_init` + `process_frame`). The effects with no faithful ffmpeg form
-  (`blur`, `glitch`, `pixelate`, `ken_burns`, `punch_in`, `shake`, `flash`, the
-  image overlays) stay here.
+  (`streaming_init` + `process_frame`). **Every pixel effect** lives here:
+  `blur`, `sharpen`, `zoom`, `film_grain`, `chromatic_aberration`, `mirror_flip`,
+  `vignette`, `color_adjust`, `kaleidoscope`, `shake`, `flash`, `glitch`,
+  `pixelate`, `ken_burns`, `punch_in`, and the image overlays. These run
+  vectorised numpy/cv2 — benchmarks showed the native-filter equivalents were at
+  best ~1.1–1.4x faster (the win came from skipping the rawvideo round-trip, not
+  faster math) and in some cases slower (`gblur`), so the per-frame path is kept
+  for its simplicity and exact output.
 
 A segment whose ops are all filters renders in a **single ffmpeg invocation** —
 no rawvideo round-trip, no Python loop. A per-frame effect switches that segment
 to the decode → Python → encode pipeline, where filters before the effect join
 the decode chain and filters after it the encode chain (so `[fade, add_subtitles]`
 streams). Duration-changing transforms fold their predicted metadata through the
-chain, so later effect windows and the audio follow the new timeline. An effect
-whose filter reads RGB pixels (`geq`/`rgbashift`) sets `filter_needs_rgb24` so the
-decode chain is converted to `rgb24` first.
+chain, so later effect windows and the audio follow the new timeline.
 
 `post_operations` run as a second pass over the assembled program, so any op —
 filter, effect, or transform — applies to the whole concatenated timeline.

--- a/docs/api/effects.md
+++ b/docs/api/effects.md
@@ -84,16 +84,16 @@ context, passed to the runner: `run_to_file(..., context={"transcription": ...})
 ## Available Effects
 
 Every effect is streamable (compatible with `VideoEdit.run_to_file()` for
-constant-memory processing). Many effects compile to a native ffmpeg filter at
-plan-compile time (faster, no per-frame Python) in their common forms:
-`add_subtitles` (libass `subtitles=`), `vignette` / `color_adjust` /
-`kaleidoscope` (geq), `chromatic_aberration` (rgbashift/geq), `mirror_flip`
-(hflip/vflip/geq), `sharpen` (unsharp), `text_overlay` (drawtext), `zoom`
-(zoompan), and monochrome `film_grain` (noise); the rest run per-frame Python via
-`process_frame`. An effect whose filter reads RGB sets `filter_needs_rgb24` so
-the builder converts the decode chain to `rgb24` first. Context-requiring ops
-(`add_subtitles`) stream too: pass `context=` to `run_to_file` and the runner
-re-bases it onto each segment's local timeline.
+constant-memory processing). The two text-rendering effects compile to a native
+ffmpeg filter at plan-compile time (no per-frame Python): `add_subtitles` (libass
+`subtitles=`) and `text_overlay` (drawtext). **Every other effect runs per-frame
+Python via `process_frame`** — vectorised numpy/cv2. Benchmarks showed compiling
+pixel effects to ffmpeg filters bought at best ~1.1–1.4x (the gain was avoiding
+the rawvideo round-trip, not faster compute) and in some cases lost (`gblur`),
+so the engine keeps ffmpeg only for what numpy can't do well: geometry/timing
+transforms and text rendering. Context-requiring ops (`add_subtitles`) stream
+too: pass `context=` to `run_to_file` and the runner re-bases it onto each
+segment's local timeline.
 
 | op | Class | Description |
 |---|---|---|

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -29,7 +29,6 @@ class Resize(Operation):
 
     op: Literal["resize"] = "resize"            # discriminator + registry key
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
 
     width: int | None = Field(None, gt=0)
     height: int | None = Field(None, gt=0)
@@ -58,11 +57,11 @@ Notes:
   into the JSON wire as the discriminator and is also the registry key.
 - `category` is `OpCategory.TRANSFORM`, `OpCategory.EFFECT`, or
   `OpCategory.SPECIAL`.
-- `streamable: ClassVar[bool] = True` lets `VideoEdit.run_to_file()`
-  treat this op as streaming-compatible. Transforms implement
-  `to_ffmpeg_filter`; effects implement either `process_frame` +
+- Every registered op is streamable, decided structurally by `op.streams()`
+  (there is no `streamable` flag): a transform streams iff it implements
+  `to_ffmpeg_filter`; an effect iff it implements `process_frame` +
   `streaming_init` (a frame effect) or `to_ffmpeg_filter` + `compiles_to_filter`
-  (a filter effect). Every registered op is streamable.
+  (a filter effect).
 - `internal_only: ClassVar[bool] = False`, when `True`, keeps an op OUT of the
   registry — constructed directly by the engine, never a chain op. `cut`/
   `cut_frames` use it, since trimming is the segment's own `start`/`end`.
@@ -85,7 +84,6 @@ frames outside the window untouched. A frame effect implements the
 ```python
 class Glitch(Effect):  # a frame effect: no faithful ffmpeg form
     op: Literal["glitch"] = "glitch"
-    streamable: ClassVar[bool] = True
     # ... fields ...
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray: ...
@@ -97,15 +95,15 @@ The `window` field on the wire:
 {"op": "blur_effect", "mode": "constant", "iterations": 2, "window": {"start": 1.0, "stop": 3.0}}
 ```
 
-Most effects instead compile to a native ffmpeg filter (faster, no per-frame
+The two text-rendering effects instead compile to a native filter (no per-frame
 Python) by setting the `compiles_to_filter` property and implementing
-`to_ffmpeg_filter`: `add_subtitles`, `vignette`, `color_adjust`,
-`chromatic_aberration`, `kaleidoscope`, `mirror_flip`, `sharpen`, `text_overlay`,
-`zoom`, and monochrome `film_grain`. Audio-coupled effects (`Fade`,
-`VolumeAdjust`) add `to_ffmpeg_audio_filter`; an effect whose filter reads RGB
-(`geq`/`rgbashift`) sets `filter_needs_rgb24` so the decode chain is converted to
-`rgb24` first. `compiles_to_filter` may depend on field values — a windowed
-`sharpen`/`zoom` or a per-channel `film_grain` stays a frame effect.
+`to_ffmpeg_filter`: `add_subtitles` (libass `subtitles=`) and `text_overlay`
+(drawtext). Audio-coupled effects (`Fade`, `VolumeAdjust`) add
+`to_ffmpeg_audio_filter` for their audio twin while their video runs per-frame.
+Every other (pixel) effect runs vectorised numpy/cv2 in `process_frame`:
+benchmarks showed compiling them to ffmpeg filters bought at best ~1.1–1.4x (from
+skipping the rawvideo round-trip, not faster compute) and sometimes lost, so the
+engine reserves filters for geometry/timing transforms and text rendering.
 
 ## Registry API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.46.0"
+version = "0.47.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_effects.py
+++ b/src/tests/ai/test_effects.py
@@ -121,7 +121,7 @@ class TestStreamingContract:
             assert out.shape == (64, 64, 3)
             assert out.dtype == np.uint8
 
-        assert eff.streamable is True
+        assert eff.streams() is True
         assert eff.requires == ()  # stays in the streaming plan path
 
 

--- a/src/tests/ai/test_streamability_alignment.py
+++ b/src/tests/ai/test_streamability_alignment.py
@@ -12,22 +12,19 @@ from videopython.editing.effects import Effect
 from videopython.editing.operation import Operation
 
 
-def test_streamable_flag_matches_filter_compilation_including_ai_ops():
-    """Every registered transform must declare ``streamable`` coherently.
+def test_every_registered_op_streams_structurally_including_ai_ops():
+    """Every registered op (incl. ai) is streamable by structure.
 
-    Both ``analyze_streamability`` and ``_build_streaming_plan`` treat the
-    ``streamable`` ClassVar as authoritative, but a flag-True transform
-    without a working ``to_ffmpeg_filter`` only fails at runtime (the
-    strict-mode drift guard), and a flag-False transform with one carries
-    dead filter code.
+    The ``streamable`` ClassVar is gone; an op streams iff it overrides
+    ``to_ffmpeg_filter`` (a filter op) or ``process_frame`` (a frame effect).
+    ``face_crop`` streams via ``to_ffmpeg_filter``; ``object_detection_overlay``
+    via ``process_frame``.
     """
     assert "face_crop" in Operation._registry
     assert "object_detection_overlay" in Operation._registry
     for op_id, cls in Operation._registry.items():
-        if issubclass(cls, Effect):
-            continue
+        if not cls.__module__.startswith("videopython"):
+            continue  # skip test-defined stub ops that pollute the global registry
         overrides_filter = cls.to_ffmpeg_filter is not Operation.to_ffmpeg_filter
-        assert overrides_filter == cls.streamable, (
-            f"op '{op_id}': streamable={cls.streamable} but "
-            f"{'overrides' if overrides_filter else 'does not override'} to_ffmpeg_filter"
-        )
+        overrides_pf = issubclass(cls, Effect) and cls.process_frame is not Effect.process_frame
+        assert overrides_filter or overrides_pf, f"op '{op_id}' streams via neither path"

--- a/src/tests/editing/test_effects.py
+++ b/src/tests/editing/test_effects.py
@@ -119,36 +119,38 @@ def test_effect_window(render):
     assert in_diff > pre_diff * 3, f"in-window frame not blurred: in={in_diff}, pre={pre_diff}"
 
 
-def test_filter_effect_matches_numpy_in_pipeline(render):
-    """A migrated filter-effect renders through ``run_to_file`` faithfully.
+def test_frame_effect_matches_numpy_in_pipeline(render):
+    """A per-frame effect renders through ``run_to_file`` faithfully.
 
-    ``vignette`` compiles to a ``geq`` whose ``r``/``g``/``b`` accessors read
-    garbage on the native yuv decode stream, so the builder must convert to
-    ``rgb24`` first (``filter_needs_rgb24``). This renders the effect end-to-end
-    and asserts it tracks its numpy ``process_frame`` twin within an x264
-    tolerance -- a guard a standalone PNG check (rgb in, rgb out) cannot give.
+    Pixel effects run as numpy ``process_frame`` over the decoded rawvideo stream
+    (the engine no longer compiles them to ffmpeg filters). This renders
+    ``chromatic_aberration`` end-to-end and asserts it tracks its standalone numpy
+    ``process_frame`` twin within an x264 tolerance -- a guard that the decode ->
+    Python -> encode pipeline feeds the effect the right frames and order.
     """
     seg = {"source": SMALL_VIDEO_PATH, "start": 0.0, "end": 2.0}
     base = render(VideoEdit.from_dict({"segments": [{**seg, "operations": []}]}), name="base.mp4")
-    vig = render(
-        VideoEdit.from_dict({"segments": [{**seg, "operations": [{"op": "vignette", "strength": 0.5}]}]}),
-        name="vig.mp4",
+    out = render(
+        VideoEdit.from_dict(
+            {"segments": [{**seg, "operations": [{"op": "chromatic_aberration", "shift_px": 4, "mode": "horizontal"}]}]}
+        ),
+        name="chromatic.mp4",
     )
-    eff = Vignette(strength=0.5)
+    eff = ChromaticAberration(shift_px=4, mode="horizontal")
     n, h, w = base.frames.shape[:3]
     eff.streaming_init(n, base.fps, w, h)
     ref = np.stack([eff.process_frame(base.frames[i].copy(), i) for i in range(n)])
-    m = min(len(ref), len(vig.frames))
-    mean_diff = np.abs(ref[:m].astype(int) - vig.frames[:m].astype(int)).mean()
-    assert mean_diff < 6, f"vignette filter diverges from its numpy twin in-pipeline: mean={mean_diff}"
+    m = min(len(ref), len(out.frames))
+    mean_diff = np.abs(ref[:m].astype(int) - out.frames[:m].astype(int)).mean()
+    assert mean_diff < 6, f"chromatic_aberration diverges from its numpy twin in-pipeline: mean={mean_diff}"
 
 
-def test_zoom_filter_preserves_frame_count(render):
-    """zoom compiles to ``zoompan``, which reinterprets PTS at its own framerate.
+def test_zoom_preserves_frame_count(render):
+    """zoom is a per-frame effect, so it must preserve the cut's frame count.
 
-    The trailing ``setpts=N/(fps*TB)`` is load-bearing: without it the
-    decode-stage ``fps=`` resampler multiplies the frame count (a 48-frame cut
-    rendered as tens of thousands of frames). Guards that exact regression.
+    A 2s cut at 24fps is 48 frames; rendering a zoom over it must return ~48
+    frames (effects are shape- and count-preserving). Guards against a regression
+    where a zoom resamples or duplicates frames through the pipeline.
     """
     out = render(
         VideoEdit.from_dict(

--- a/src/tests/editing/test_streamability.py
+++ b/src/tests/editing/test_streamability.py
@@ -102,10 +102,12 @@ class TestStreamabilityReport:
 
         class _NoFilterTransform:
             op = "fake_transform"
-            streamable = False
             requires: tuple[str, ...] = ()
             compiles_from_source = False
             changes_duration = False
+
+            def streams(self) -> bool:
+                return False
 
         entries = _classify_op_list([_NoFilterTransform()], "segments[0].operations")
         (entry,) = entries
@@ -113,12 +115,14 @@ class TestStreamabilityReport:
         assert entry.reason is not None and "no ffmpeg filter" in entry.reason
 
     def test_non_streamable_effect_is_unstreamable(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setattr(Fade, "streamable", False)
+        # Defensive: an effect that streams via neither path is flagged. No
+        # built-in effect is like this, so simulate by forcing streams() False.
+        monkeypatch.setattr(Fade, "streams", lambda self: False)
         report = _plan([FADE]).streamability()
 
         (entry,) = report.entries
         assert entry.streaming_class is StreamingClass.UNSTREAMABLE
-        assert entry.reason is not None and "streamable=False" in entry.reason
+        assert entry.reason is not None and "no streaming implementation" in entry.reason
 
     def test_post_op_effect_on_single_segment_streams(self):
         report = _plan([], post_operations=[FADE]).streamability()
@@ -196,8 +200,8 @@ class TestTransitionStreamability:
 
     def test_post_op_with_transition_streams(self):
         # A post-op runs over the assembled program AFTER the transition is
-        # baked, so the combination streams (the blur post-op is FRAME_EFFECT).
-        plan = self._transition_plan(post_operations=[{"op": "blur_effect", "mode": "constant", "iterations": 5}])
+        # baked, so the combination streams (glitch is a frame-effect post-op).
+        plan = self._transition_plan(post_operations=[{"op": "glitch"}])
         report = plan.streamability()
         (entry,) = report.entries
         assert entry.streaming_class is StreamingClass.FRAME_EFFECT
@@ -205,25 +209,27 @@ class TestTransitionStreamability:
 
 
 class TestRegistryAlignment:
-    def test_streamable_flag_matches_filter_compilation(self):
-        """Every registered transform must declare ``streamable`` coherently.
-
-        Both the report and the plan builder treat the ``streamable`` ClassVar
-        as authoritative, but a flag-True transform without a working
-        ``to_ffmpeg_filter`` only fails at runtime (the strict-mode drift
-        guard), and a flag-False transform with one carries dead filter code.
-        This covers ops registered by the editing layer; a twin test under
-        ``src/tests/ai`` covers the ai layer, which this suite must not
+    def test_every_registered_op_streams_structurally(self):
+        """Every registered op is streamable by structure (the ``streamable``
+        ClassVar is gone): it overrides ``to_ffmpeg_filter`` (a filter op) or
+        ``process_frame`` (a frame effect). Covers the editing layer; a twin test
+        under ``src/tests/ai`` covers the ai layer, which this suite must not
         import.
         """
         for op_id, cls in Operation._registry.items():
-            if issubclass(cls, Effect):
-                continue
+            if not cls.__module__.startswith("videopython"):
+                continue  # skip test-defined stub ops that pollute the global registry
             overrides_filter = cls.to_ffmpeg_filter is not Operation.to_ffmpeg_filter
-            assert overrides_filter == cls.streamable, (
-                f"op '{op_id}': streamable={cls.streamable} but "
-                f"{'overrides' if overrides_filter else 'does not override'} to_ffmpeg_filter"
-            )
+            overrides_pf = issubclass(cls, Effect) and cls.process_frame is not Effect.process_frame
+            assert overrides_filter or overrides_pf, f"op '{op_id}' streams via neither path"
+
+    def test_add_subtitles_streams_via_filter_only(self):
+        # The one op that streams purely via compiles_to_filter (no process_frame
+        # override) -- the reason Effect.streams() must consult compiles_to_filter.
+        from videopython.editing.transcription_overlay import TranscriptionOverlay
+
+        assert TranscriptionOverlay.process_frame is Effect.process_frame
+        assert TranscriptionOverlay(font_scale=0.1).streams()
 
     def test_cut_ops_are_internal_only(self):
         """cut/cut_frames trim via the segment's own start/end, so they are kept
@@ -296,21 +302,11 @@ class TestRunToFileRejection:
         assert err.op == "glitch"
 
     def test_builder_drift_raises_instead_of_silent_fallback(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
-        """A streamable-flagged transform that fails to compile must not slip through."""
+        """A transform whose ``to_ffmpeg_filter`` compiles to ``None`` at its plan
+        position must not slip through: the structural report says FILTER but the
+        build finds ``None``, and the drift raise catches it."""
         monkeypatch.setattr(Resize, "to_ffmpeg_filter", lambda self, ctx: None)
         plan = _plan([RESIZE])
 
         with pytest.raises(PlanValidationError, match="despite a clean streamability report"):
-            plan.run_to_file(tmp_path / "out.mp4")
-
-    def test_flag_false_transform_is_rejected_even_with_working_filter(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
-        """The ``streamable`` flag is authoritative in both directions: a
-        transform declaring ``streamable=False`` is rejected even if its
-        ``to_ffmpeg_filter`` compiles, so the report and the runtime can
-        never disagree."""
-        monkeypatch.setattr(Resize, "streamable", False)
-        plan = _plan([RESIZE])
-
-        assert not plan.streamability().streamable
-        with pytest.raises(PlanValidationError, match="cannot stream"):
             plan.run_to_file(tmp_path / "out.mp4")

--- a/src/tests/editing/test_video_edit.py
+++ b/src/tests/editing/test_video_edit.py
@@ -1117,11 +1117,11 @@ class TestStreamingRequiresGuard:
         )
         seg = plan.segments[0]
         assert plan._build_streaming_plan(seg, None, None, None) is not None
-        # A context-requiring transform streams when its compile can consume
-        # the context (silence_removal); without a streaming strategy it
-        # still defers to eager.
+        # A context-requiring transform streams when its compile can consume the
+        # context (silence_removal); when its filter compiles to None at this
+        # position the builder returns None (the drift the runtime guard catches).
         monkeypatch.setattr(Resize, "requires", ("transcription",))
-        monkeypatch.setattr(Resize, "streamable", False)
+        monkeypatch.setattr(Resize, "to_ffmpeg_filter", lambda self, ctx: None)
         assert plan._build_streaming_plan(seg, None, None, None) is None
 
     def test_requires_effect_builds_plan_with_rebased_context(self):

--- a/src/videopython/ai/effects.py
+++ b/src/videopython/ai/effects.py
@@ -9,7 +9,7 @@ AI-free renderer in :mod:`videopython.base.draw_detections`.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Literal
+from typing import Any, Literal
 
 import numpy as np
 from pydantic import Field, PrivateAttr
@@ -39,7 +39,6 @@ class ObjectDetectionOverlay(Effect):
     """
 
     op: Literal["object_detection_overlay"] = "object_detection_overlay"
-    streamable: ClassVar[bool] = True
 
     confidence_threshold: float = Field(0.5, ge=0, le=1, description="Minimum detection confidence to draw a box, 0-1.")
     class_filter: list[str] | None = Field(

--- a/src/videopython/ai/transforms.py
+++ b/src/videopython/ai/transforms.py
@@ -44,7 +44,6 @@ class FaceTrackingCrop(Operation):
 
     op: Literal["face_crop"] = "face_crop"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
     compiles_from_source: ClassVar[bool] = True
 
     target_aspect: tuple[int, int] = Field((9, 16), description="Output aspect ratio as (width, height).")

--- a/src/videopython/editing/effects.py
+++ b/src/videopython/editing/effects.py
@@ -15,7 +15,6 @@ override :meth:`Effect.predict_metadata`. Anchored RGBA overlays
 from __future__ import annotations
 
 import logging
-import math
 import tempfile
 from io import BytesIO
 from pathlib import Path
@@ -73,7 +72,6 @@ class FullImageOverlay(Effect):
     """
 
     op: Literal["full_image_overlay"] = "full_image_overlay"
-    streamable: ClassVar[bool] = True
     llm_exposed: ClassVar[bool] = False
 
     source: Path = Field(
@@ -143,7 +141,6 @@ class Blur(Effect):
     """Applies Gaussian blur that can stay constant or ramp up/down over the clip."""
 
     op: Literal["blur_effect"] = "blur_effect"
-    streamable: ClassVar[bool] = True
 
     mode: Literal["constant", "ascending", "descending"] = Field(
         description=(
@@ -192,7 +189,6 @@ class Zoom(Effect):
     """Progressively zooms into or out of the frame center over the clip duration."""
 
     op: Literal["zoom_effect"] = "zoom_effect"
-    streamable: ClassVar[bool] = True
 
     zoom_factor: float = Field(
         gt=1,
@@ -228,47 +224,11 @@ class Zoom(Effect):
         cropped = frame[round(y) : round(y + h), round(x) : round(x + w)]
         return cv2.resize(cropped, (width, height))
 
-    @property
-    def compiles_to_filter(self) -> bool:
-        # Only an unwindowed, whole-clip zoom is a single comma-join-safe -vf
-        # entry. A windowed zoom (frames outside the window pass through) cannot
-        # be one zoompan, so it stays frame-only.
-        return self.window is None
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Whole-clip center zoom via ffmpeg ``zoompan``.
-
-        Matches the numpy twin: the crop SIZE ramps linearly between the full
-        frame and ``width // zoom_factor`` and the frame is rescaled to the
-        original size, so the per-frame zoom is ``iw/crop_w``. The trailing
-        ``setpts=N/(fps*TB)`` is LOAD-BEARING: zoompan reinterprets PTS at its
-        own framerate, and without re-deriving PTS from the output frame number
-        the decode-stage ``fps=`` resampler multiplies the frame count. yuv-safe.
-        """
-        if ctx.frame_count <= 0:
-            return None
-        n = ctx.frame_count
-        w, h = ctx.width, ctx.height
-        small_w = w // self.zoom_factor
-        if self.mode == "out":
-            cw0, cw1 = float(small_w), float(w)
-        else:  # in
-            cw0, cw1 = float(w), float(small_w)
-        denom = max(n - 1, 1)
-        z_expr = f"iw/({cw0:.6f}+({cw1 - cw0:.6f})*on/{denom})"
-        return (
-            f"zoompan=z='{z_expr}'"
-            f":x='iw/2-iw/zoom/2':y='ih/2-ih/zoom/2'"
-            f":d=1:s={w}x{h}:fps={ctx.fps},setpts=N/({ctx.fps}*TB)"
-        )
-
 
 class ColorGrading(Effect):
     """Adjusts color properties: brightness, contrast, saturation, and temperature."""
 
     op: Literal["color_adjust"] = "color_adjust"
-    streamable: ClassVar[bool] = True
-    filter_needs_rgb24: ClassVar[bool] = True
 
     brightness: float = Field(
         0.0,
@@ -316,80 +276,11 @@ class ColorGrading(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._grade_frame(frame)
 
-    @property
-    def _is_noop(self) -> bool:
-        return self.brightness == 0.0 and self.contrast == 1.0 and self.saturation == 1.0 and self.temperature == 0.0
-
-    def _channel_expr(self, src: str, temp_offset: float) -> str:
-        """Per-channel ``geq`` expression mirroring :meth:`_grade_frame`.
-
-        ``src`` is the geq accessor for the channel being computed
-        (``r(X,Y)``/``g(X,Y)``/``b(X,Y)``); ``temp_offset`` is the additive
-        temperature shift for this channel (``+t`` on red, ``0`` on green, ``-t``
-        on blue). The pipeline runs on normalised 0..1 values: brightness add,
-        contrast about 0.5 (unclipped, matching numpy), a cv2-equivalent HSV
-        "toward-max" saturation scale, the temperature shift, then a final clamp.
-        """
-        norm = {"r": "(r(X,Y)/255)", "g": "(g(X,Y)/255)", "b": "(b(X,Y)/255)"}
-
-        def bc(v: str) -> str:
-            return f"((({v}+{self.brightness:g})-0.5)*{self.contrast:g}+0.5)"
-
-        graded = bc(f"({src}/255)")
-        if self.saturation != 1.0:
-            # cv2 RGB->HSV scales saturation toward V=max(R,G,B), clipping S at 1:
-            # each channel C maps to V-(V-C)*ratio with ratio=min(sat, V/chroma).
-            # The HSV roundtrip clips inputs to 0..1 first.
-            rc = f"clip({bc(norm['r'])},0,1)"
-            gc = f"clip({bc(norm['g'])},0,1)"
-            bcl = f"clip({bc(norm['b'])},0,1)"
-            src_c = f"clip({graded},0,1)"
-            v = f"max(max({rc},{gc}),{bcl})"
-            mn = f"min(min({rc},{gc}),{bcl})"
-            chroma = f"({v}-{mn})"
-            ratio = f"if(gt({chroma},0),min({self.saturation:g},{v}/{chroma}),1)"
-            graded = f"({v}-({v}-{src_c})*({ratio}))"
-        if temp_offset != 0.0:
-            graded = f"({graded}+({temp_offset:g}))"
-        return f"clip(({graded})*255,0,255)"
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile the colour grade to a single ``geq`` ``-vf`` entry.
-
-        Mirrors :meth:`_grade_frame` per channel (brightness, contrast,
-        cv2-equivalent HSV saturation, temperature) on normalised RGB, faithful
-        to the numpy path to within uint8 rounding (geq rounds; numpy truncates).
-        All commas live inside single-quoted per-channel expressions, so the
-        entry is comma-join safe. A no-op grade returns ``None``. ``self.window``
-        appends a timeline ``enable='between(t,start,stop)'``.
-        """
-        if self._is_noop:
-            return None
-        temp_shift = self.temperature * 0.1
-        r = self._channel_expr("r(X,Y)", temp_shift)
-        g = self._channel_expr("g(X,Y)", 0.0)
-        b = self._channel_expr("b(X,Y)", -temp_shift)
-        expr = f"geq=r='{r}':g='{g}':b='{b}'"
-        if self.window is not None:
-            stop = ctx.frame_count / ctx.fps if ctx.fps > 0 and ctx.frame_count > 0 else None
-            start_s = 0.0 if self.window.start is None else float(self.window.start)
-            stop_s = stop if self.window.stop is None else float(self.window.stop)
-            if stop_s is not None:
-                expr += f":enable='between(t,{start_s:g},{stop_s:g})'"
-        return expr
-
-    @property
-    def compiles_to_filter(self) -> bool:
-        """A no-op grade emits no filter; any active field compiles to one ``geq`` entry."""
-        return not self._is_noop
-
 
 class Vignette(Effect):
     """Darkens the edges of the frame, drawing attention to the center."""
 
     op: Literal["vignette"] = "vignette"
-    streamable: ClassVar[bool] = True
-    filter_needs_rgb24: ClassVar[bool] = True
 
     strength: float = Field(
         0.5,
@@ -427,38 +318,6 @@ class Vignette(Effect):
         assert self._stream_mask_3d is not None
         return (frame.astype(np.float32) * self._stream_mask_3d).astype(np.uint8)
 
-    @property
-    def compiles_to_filter(self) -> bool:
-        return True
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile the radial darkening to a per-channel ``geq`` expression.
-
-        Reproduces :meth:`_create_mask` exactly in ffmpeg's expression language:
-        ``geq`` exposes per-pixel ``X``/``Y`` and the plane size ``W``/``H``, so
-        the normalized coordinates ``Xn = 2*X/(W-1) - 1`` / ``Yn = 2*Y/(H-1) - 1``
-        mirror ``np.linspace(-1, 1, ...)``, and the mask is
-        ``1 - clip(hypot(Xn, Yn)/radius - 0.5, 0, 1) * 2*strength`` applied to every
-        channel. ``clip`` is spelled with ``min``/``max`` and explicit products so
-        the expression carries no commas of its own -- only the quoted ``r(X,Y)``
-        lookups and the ``enable`` clause do, and those quotes survive the runner's
-        comma-join of the ``-vf`` chain. ``geq`` has native timeline support, so a
-        windowed vignette gates on ``enable`` and passes other frames through.
-        """
-        xn = "((2*X/(W-1))-1)"
-        yn = "((2*Y/(H-1))-1)"
-        falloff = 2.0 * self.strength
-        mask = f"(1-min(max(sqrt({xn}*{xn}+{yn}*{yn})/{self.radius:.6f}-0.5,0),1)*{falloff:.6f})"
-        r = f"r='r(X,Y)*{mask}'"
-        g = f"g='g(X,Y)*{mask}'"
-        b = f"b='b(X,Y)*{mask}'"
-        filt = f"geq={r}:{g}:{b}"
-        if self.window is not None:
-            start_s = 0.0 if self.window.start is None else float(self.window.start)
-            stop_s = ctx.frame_count / ctx.fps if self.window.stop is None else float(self.window.stop)
-            filt += f":enable='between(t,{start_s:.6f},{stop_s:.6f})'"
-        return filt
-
 
 class KenBurns(Effect):
     """Cinematic pan-and-zoom that smoothly animates between two crop regions.
@@ -469,7 +328,6 @@ class KenBurns(Effect):
     """
 
     op: Literal["ken_burns"] = "ken_burns"
-    streamable: ClassVar[bool] = True
 
     start_region: BoundingBox = Field(
         description="Starting crop region as a BoundingBox with normalized 0-1 coordinates."
@@ -549,7 +407,6 @@ class Fade(Effect):
     """Fades video and audio to or from black."""
 
     op: Literal["fade"] = "fade"
-    streamable: ClassVar[bool] = True
     audio_coupled: ClassVar[bool] = True
 
     mode: Literal["in", "out", "in_out"] = Field(
@@ -651,7 +508,6 @@ class VolumeAdjust(Effect):
     """Changes audio volume within a time range without affecting video frames."""
 
     op: Literal["volume_adjust"] = "volume_adjust"
-    streamable: ClassVar[bool] = True
     audio_coupled: ClassVar[bool] = True
 
     volume: float = Field(
@@ -828,7 +684,6 @@ class TextOverlay(_AnchoredOverlay):
     """Draws text on video frames, with auto word-wrap and optional background box."""
 
     op: Literal["text_overlay"] = "text_overlay"
-    streamable: ClassVar[bool] = True
 
     text: str = Field(min_length=1, description=r"The string to display. Use \n for line breaks.")
     position: tuple[float, float] = Field(
@@ -1036,7 +891,6 @@ class ImageOverlay(_AnchoredOverlay):
     """
 
     op: Literal["image_overlay"] = "image_overlay"
-    streamable: ClassVar[bool] = True
     llm_exposed: ClassVar[bool] = False
 
     source: Path = Field(
@@ -1158,7 +1012,6 @@ class Shake(Effect):
     """
 
     op: Literal["shake"] = "shake"
-    streamable: ClassVar[bool] = True
 
     intensity_px: float = Field(
         gt=0,
@@ -1224,7 +1077,6 @@ class PunchIn(Effect):
     """
 
     op: Literal["punch_in"] = "punch_in"
-    streamable: ClassVar[bool] = True
 
     zoom_factor: float = Field(
         gt=1.0,
@@ -1287,7 +1139,6 @@ class Flash(Effect):
     """
 
     op: Literal["flash"] = "flash"
-    streamable: ClassVar[bool] = True
 
     color: tuple[int, int, int] = Field(
         (255, 255, 255),
@@ -1351,8 +1202,6 @@ class ChromaticAberration(Effect):
     """
 
     op: Literal["chromatic_aberration"] = "chromatic_aberration"
-    streamable: ClassVar[bool] = True
-    filter_needs_rgb24: ClassVar[bool] = True
 
     shift_px: int = Field(
         gt=0,
@@ -1410,52 +1259,6 @@ class ChromaticAberration(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._aberrate(frame)
 
-    def _enable_suffix(self, ctx: FilterCtx) -> str:
-        """``:enable='between(t,START,STOP)'`` for a windowed effect, else ``""``.
-
-        START defaults to 0.0 and STOP to the segment duration
-        (``ctx.frame_count / ctx.fps``); an unset window yields no suffix. The
-        clause is single-quoted, so its inner comma survives the runner's
-        ``",".join`` into the ``-vf`` chain.
-        """
-        if self.window is None:
-            return ""
-        total_seconds = ctx.frame_count / ctx.fps if ctx.fps > 0 and ctx.frame_count > 0 else 0.0
-        start_s = 0.0 if self.window.start is None else float(self.window.start)
-        stop_s = total_seconds if self.window.stop is None else float(self.window.stop)
-        return f":enable='between(t,{start_s:.6f},{stop_s:.6f})'"
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile the channel split to a single native ``-vf`` entry.
-
-        ``horizontal``/``vertical`` become ``rgbashift`` (R by ``+shift_px``,
-        B by ``-shift_px`` along the axis, ``edge=smear`` == BORDER_REPLICATE).
-        ``radial`` becomes one ``geq`` sampling R/B from a scale about the frame
-        center (matches bilinear ``cv2.remap`` to ~4/255). Green is untouched.
-        Every inner comma sits inside single-quoted ``geq`` expressions or the
-        ``enable`` clause, so the entry is comma-join-safe.
-        """
-        enable = self._enable_suffix(ctx)
-        if self.mode == "horizontal":
-            return f"rgbashift=rh={self.shift_px}:bh={-self.shift_px}:edge=smear{enable}"
-        if self.mode == "vertical":
-            return f"rgbashift=rv={self.shift_px}:bv={-self.shift_px}:edge=smear{enable}"
-        # radial: reproduce the cv2.remap scale about the center via geq.
-        cx, cy = ctx.width / 2.0, ctx.height / 2.0
-        max_d = float(max(ctx.width, ctx.height))
-        scale_r = 1.0 - self.shift_px / max_d
-        scale_b = 1.0 + self.shift_px / max_d
-        rx = f"((X-{cx:.6f})*{scale_r:.9f}+{cx:.6f})"
-        ry = f"((Y-{cy:.6f})*{scale_r:.9f}+{cy:.6f})"
-        bx = f"((X-{cx:.6f})*{scale_b:.9f}+{cx:.6f})"
-        by = f"((Y-{cy:.6f})*{scale_b:.9f}+{cy:.6f})"
-        return f"geq=r='r({rx}\\,{ry})':b='b({bx}\\,{by})'{enable}"
-
-    @property
-    def compiles_to_filter(self) -> bool:
-        """Every mode compiles to a single, comma-join-safe ``-vf`` entry."""
-        return True
-
 
 class Glitch(Effect):
     """Random horizontal slice displacement + channel offsets for a digital-corruption look.
@@ -1466,7 +1269,6 @@ class Glitch(Effect):
     """
 
     op: Literal["glitch"] = "glitch"
-    streamable: ClassVar[bool] = True
 
     intensity: float = Field(
         0.5,
@@ -1528,7 +1330,6 @@ class FilmGrain(Effect):
     """
 
     op: Literal["film_grain"] = "film_grain"
-    streamable: ClassVar[bool] = True
 
     intensity: float = Field(
         0.1,
@@ -1558,31 +1359,6 @@ class FilmGrain(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._grain_frame(frame, frame_index)
 
-    @property
-    def compiles_to_filter(self) -> bool:
-        # Only unwindowed monochrome (luma-only) grain compiles to a single
-        # comma-join-safe `noise` entry. The per-channel variant and any windowed
-        # grain stay on the numpy frame path.
-        return self.monochrome and self.window is None
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile luma-only grain to ffmpeg's temporal ``noise`` filter.
-
-        A statistical (NOT pixel-identical) twin of :meth:`process_frame`:
-        ffmpeg's RNG differs from numpy's, so the grain is a different but
-        distributionally-matched draw -- equivalent in look for a random grain.
-        ``c0_flags=t`` adds fresh temporal noise to component 0 (Y in the
-        pipeline's yuv420p) each frame; ``c0_strength`` is ffmpeg's 0-100 scale,
-        which the numpy std (``intensity*255``) maps onto by the empirically-fit
-        ``strength = intensity * 255 / 0.57`` (clamped to [1, 100]) so the
-        injected per-pixel std matches in the real yuv pipeline. yuv-safe.
-        """
-        if not self.monochrome:
-            return None
-        strength = int(round(self.intensity * 255.0 / 0.57))
-        strength = max(1, min(100, strength))
-        return f"noise=c0_seed={self.seed}:c0_strength={strength}:c0_flags=t"
-
 
 class Sharpen(Effect):
     """Unsharp-mask sharpening: blur the frame and subtract from itself with weight.
@@ -1592,7 +1368,6 @@ class Sharpen(Effect):
     """
 
     op: Literal["sharpen"] = "sharpen"
-    streamable: ClassVar[bool] = True
 
     amount: float = Field(
         1.0,
@@ -1625,29 +1400,6 @@ class Sharpen(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._sharpen_frame(frame)
 
-    @property
-    def compiles_to_filter(self) -> bool:
-        # The whole-frame, windowless case maps cleanly to a single comma-join
-        # safe `unsharp` -vf entry. A `window` would need an enable= gate that
-        # `unsharp` does not support, so windowed sharpening stays frame-only;
-        # `unsharp` also caps the combined matrix, so kernel_size > 13 stays too.
-        return self.window is None and self.kernel_size <= 13
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Native unsharp-mask sharpening via ffmpeg's ``unsharp`` filter.
-
-        The numpy twin blends ``out = in + amount*(in - gaussian_blur(in))``.
-        ``unsharp=lx:ly:la`` is the same unsharp-mask form with the same
-        ``amount`` (``la``) weighting; its kernel is a box rather than a Gaussian,
-        so the result is a faithful visual twin (re-baseline-to-ffmpeg), not
-        bit-identical. ``amount == 0`` is a no-op (``None`` -> the runner keeps
-        the frame). ``unsharp`` is yuv-safe, so no ``format=rgb24`` is needed.
-        """
-        if self.amount == 0:
-            return None
-        k = self.kernel_size
-        return f"unsharp={k}:{k}:{self.amount:.6f}:{k}:{k}:{self.amount:.6f}"
-
 
 class Pixelate(Effect):
     """Mosaic blocks: downscale + nearest-neighbour upscale, optionally limited to a region.
@@ -1657,7 +1409,6 @@ class Pixelate(Effect):
     """
 
     op: Literal["pixelate"] = "pixelate"
-    streamable: ClassVar[bool] = True
 
     block_size: int = Field(
         gt=1,
@@ -1697,22 +1448,6 @@ class Pixelate(Effect):
         return self._pixelate_frame(frame, self._stream_region_px)
 
 
-def _mirror_geq(coord: str, src_x: str, src_y: str) -> str:
-    """One comma-join-safe ``geq`` entry that reflects a half-frame.
-
-    ``coord`` is the per-pixel predicate (e.g. ``gte(X,W/2)``); where it holds
-    the pixel samples its mirror ``(src_x, src_y)``, elsewhere it keeps
-    ``(X, Y)``. Per-channel (r/g/b) so geq runs in RGB. The function-call commas
-    live inside single-quoted plane expressions, so the whole entry survives
-    ``",".join`` into the ``-vf`` chain.
-    """
-
-    def plane(channel: str) -> str:
-        return f"if({coord},{channel}({src_x},{src_y}),{channel}(X,Y))"
-
-    return f"geq=r='{plane('r')}':g='{plane('g')}':b='{plane('b')}'"
-
-
 class MirrorFlip(Effect):
     """Flip frames or reflect one half onto the other.
 
@@ -1722,8 +1457,6 @@ class MirrorFlip(Effect):
     """
 
     op: Literal["mirror_flip"] = "mirror_flip"
-    streamable: ClassVar[bool] = True
-    filter_needs_rgb24: ClassVar[bool] = True
 
     mode: Literal[
         "horizontal",
@@ -1767,54 +1500,6 @@ class MirrorFlip(Effect):
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._flip_frame(frame)
 
-    def _enable_suffix(self, ctx: FilterCtx) -> str:
-        """``enable='between(t,START,STOP)'`` for the window, or '' when full-clip.
-
-        START defaults to 0.0 and STOP to the segment duration
-        (``ctx.frame_count / ctx.fps``). Returns the bare ``key=value`` (no
-        leading separator); the caller joins it with the right separator.
-        """
-        win = self.window
-        if win is None:
-            return ""
-        stop = ctx.frame_count / ctx.fps if win.stop is None else float(win.stop)
-        start = 0.0 if win.start is None else float(win.start)
-        return f"enable='between(t,{start:.6f},{stop:.6f})'"
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile to one comma-join-safe ``-vf`` entry mirroring :meth:`process_frame`.
-
-        ``horizontal`` / ``vertical`` map to native ``hflip`` / ``vflip``
-        (bit-exact). The ``mirror_*`` modes reflect one half onto the other via a
-        single per-channel ``geq`` expression: each output pixel samples its
-        mirror (``W-1-X`` / ``H-1-Y``) on the reflected half and itself on the
-        kept half, matching the numpy ``w//2`` / ``h//2`` split for both even and
-        odd dimensions. A window appends an ``enable=`` option (``=`` for the
-        option-less flips, ``:`` after the ``geq`` options).
-        """
-        if self.mode == "horizontal":
-            base, sep = "hflip", "="
-        elif self.mode == "vertical":
-            base, sep = "vflip", "="
-        else:
-            sep = ":"
-            if self.mode == "mirror_left":
-                coord, src_x, src_y = "gte(X,W/2)", "W-1-X", "Y"
-            elif self.mode == "mirror_right":
-                coord, src_x, src_y = "lt(X,W/2)", "W-1-X", "Y"
-            elif self.mode == "mirror_top":
-                coord, src_x, src_y = "gte(Y,H/2)", "X", "H-1-Y"
-            else:  # mirror_bottom
-                coord, src_x, src_y = "lt(Y,H/2)", "X", "H-1-Y"
-            base = _mirror_geq(coord, src_x, src_y)
-
-        enable = self._enable_suffix(ctx)
-        return f"{base}{sep}{enable}" if enable else base
-
-    @property
-    def compiles_to_filter(self) -> bool:
-        return True
-
 
 class Kaleidoscope(Effect):
     """N-way radial mirror around the frame center.
@@ -1825,8 +1510,6 @@ class Kaleidoscope(Effect):
     """
 
     op: Literal["kaleidoscope"] = "kaleidoscope"
-    streamable: ClassVar[bool] = True
-    filter_needs_rgb24: ClassVar[bool] = True
 
     segments: int = Field(
         6,
@@ -1875,58 +1558,3 @@ class Kaleidoscope(Effect):
 
     def process_frame(self, frame: np.ndarray, frame_index: int) -> np.ndarray:
         return self._kaleidoscope_frame(frame)
-
-    def to_ffmpeg_filter(self, ctx: FilterCtx) -> str | None:
-        """Compile the radial mirror to a single per-pixel ``geq`` remap.
-
-        Mirrors :meth:`_build_maps`/:meth:`process_frame`. For each output pixel
-        ``geq`` recovers polar coordinates about ``((W-1)/2, (H-1)/2)``, folds
-        the angle into one wedge (``2*pi/segments``) the same way the numpy path
-        does (``mod`` then reflect across the half-wedge), and samples with
-        ``interpolation=bilinear``. Out-of-frame sample coordinates are reflected
-        back in-bounds (registers 8/9) to reproduce ``cv2.BORDER_REFLECT``. One
-        ``-vf`` node, comma-join-safe.
-        """
-        if ctx.width <= 0 or ctx.height <= 0:
-            return None
-        width, height = ctx.width, ctx.height
-        cx = (width - 1) / 2.0
-        cy = (height - 1) / 2.0
-        wedge = 2.0 * math.pi / self.segments
-        half = wedge * 0.5
-        pw = 2 * width
-        ph = 2 * height
-        ao = self.angle_offset
-
-        common = (
-            f"st(1,X-{cx:.8f});"
-            f"st(2,Y-{cy:.8f});"
-            f"st(3,hypot(ld(1),ld(2)));"
-            f"st(4,atan2(ld(2),ld(1))-{ao:.8f});"
-            f"st(5,mod(ld(4),{wedge:.10f}));"
-            f"st(5,if(lt(ld(5),0),ld(5)+{wedge:.10f},ld(5)));"
-            f"st(6,if(gt(ld(5),{half:.10f}),{wedge:.10f}-ld(5),ld(5)));"
-            f"st(7,ld(6)+{ao:.8f});"
-            f"st(8,mod({cx:.8f}+ld(3)*cos(ld(7)),{pw}));"
-            f"st(8,if(lt(ld(8),0),ld(8)+{pw},ld(8)));"
-            f"st(8,if(gte(ld(8),{width}),{pw - 1}-ld(8),ld(8)));"
-            f"st(9,mod({cy:.8f}+ld(3)*sin(ld(7)),{ph}));"
-            f"st(9,if(lt(ld(9),0),ld(9)+{ph},ld(9)));"
-            f"st(9,if(gte(ld(9),{height}),{ph - 1}-ld(9),ld(9)));"
-        )
-        expr = (
-            f"geq=interpolation=bilinear:"
-            f"r='{common}r(ld(8),ld(9))':"
-            f"g='{common}g(ld(8),ld(9))':"
-            f"b='{common}b(ld(8),ld(9))'"
-        )
-        if self.window is not None:
-            stop = ctx.frame_count / ctx.fps if ctx.fps > 0 and ctx.frame_count > 0 else 0.0
-            start_s = self.window.start if self.window.start is not None else 0.0
-            stop_s = self.window.stop if self.window.stop is not None else stop
-            expr += f":enable='between(t,{start_s:.6f},{stop_s:.6f})'"
-        return expr
-
-    @property
-    def compiles_to_filter(self) -> bool:
-        return True

--- a/src/videopython/editing/operation.py
+++ b/src/videopython/editing/operation.py
@@ -18,7 +18,6 @@ Subclass contract::
 
         op: Literal["resize"] = "resize"
         category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-        streamable: ClassVar[bool] = True
 
         width: int | None = Field(None, gt=0)
         height: int | None = Field(None, gt=0)
@@ -234,8 +233,8 @@ class Operation(BaseModel):
 
     Concrete subclasses MUST declare an ``op`` field with a single-value
     ``Literal[str]`` annotation; that value is the discriminator on the JSON
-    wire and the registry key. Subclasses may override the ``category``,
-    ``streamable``, and ``requires`` ClassVars.
+    wire and the registry key. Subclasses may override the ``category`` and
+    ``requires`` ClassVars.
 
     ``predict_metadata`` defaults to identity; ``to_ffmpeg_filter`` defaults to
     ``None`` (no filter compilation).
@@ -246,7 +245,6 @@ class Operation(BaseModel):
     op: str
 
     category: ClassVar[OpCategory] = OpCategory.SPECIAL
-    streamable: ClassVar[bool] = False
     requires: ClassVar[tuple[str, ...]] = ()
     compiles_from_source: ClassVar[bool] = False
     """Whether the op's filter compile decodes the source itself (face_crop's
@@ -269,12 +267,11 @@ class Operation(BaseModel):
     """Whether this op is engine-internal and must NOT be a chain op.
 
     ``CutSeconds``/``CutFrames`` trim a segment, but trimming is the segment's own
-    ``start``/``end`` mechanism -- the engine constructs them directly. They are
-    non-streamable (no ffmpeg filter, no ``process_frame``), so to honor
-    "every registered op is streamable" they set this flag and are kept OUT of
-    the registry: they cannot appear in a plan's ``operations`` list or the LLM
+    ``start``/``end`` mechanism -- the engine constructs them directly. They have
+    no ffmpeg filter and no ``process_frame``, so this flag keeps them OUT of the
+    registry: they cannot appear in a plan's ``operations`` list or the LLM
     schema, while direct construction (``CutSeconds(start=..., end=...)``) still
-    works. Default False (a normal, streamable chain op)."""
+    works. Default False (a normal chain op)."""
     time_fields: ClassVar[tuple[BoundedTimeField, ...]] = ()
     """Time-valued (seconds) fields :meth:`VideoEdit.repair` may clamp into range.
 
@@ -449,6 +446,19 @@ class Operation(BaseModel):
         """
         return None
 
+    def streams(self) -> bool:
+        """Whether this op streams in O(1) memory at its plan position.
+
+        Structural replacement for the former ``streamable`` ClassVar: a transform
+        streams iff it overrides :meth:`to_ffmpeg_filter`. :class:`Effect` widens
+        this (a frame effect streams via ``process_frame``; a filter effect via
+        ``compiles_to_filter``). The one case structure cannot express -- the
+        override exists but the filter compiles to ``None`` at this position -- is
+        caught at runtime by the ``STREAMING_UNSUPPORTED`` raise in
+        ``VideoEdit._compile_streaming_plans``.
+        """
+        return type(self).to_ffmpeg_filter is not Operation.to_ffmpeg_filter
+
 
 class Effect(Operation):
     """Operation that preserves shape and frame count, driven by per-frame streaming.
@@ -470,17 +480,6 @@ class Effect(Operation):
     category: ClassVar[OpCategory] = OpCategory.EFFECT
     audio_coupled: ClassVar[bool] = False
     """Whether the effect mutates audio alongside pixels (``afade``/``volume``)."""
-    filter_needs_rgb24: ClassVar[bool] = False
-    """Whether :meth:`to_ffmpeg_filter` reads RGB pixel values and so needs the
-    decode chain converted to ``rgb24`` first.
-
-    ``geq``'s ``r``/``g``/``b`` accessors and ``rgbashift`` read RGB channels;
-    on the native yuv decode stream they read garbage. When a decode-stage
-    effect sets this, the plan builder prepends ``format=rgb24`` to the segment's
-    decode filter chain (encode-stage effects already receive rgb24 from the
-    frame pipe). Default False -- geometry/overlay filters (``hflip``,
-    ``subtitles=``) work in any pixel format. Mirrors the rgb24 frames the numpy
-    ``process_frame`` twin operated on."""
 
     window: TimeRange | None = Field(
         None,
@@ -527,3 +526,14 @@ class Effect(Operation):
         ``frame_index`` is 0-based within this effect's active window.
         """
         raise NotImplementedError(f"{type(self).__name__} does not support streaming")
+
+    def streams(self) -> bool:
+        """An effect streams via per-frame Python (``process_frame``) or a filter.
+
+        Frame effects override :meth:`process_frame`; filter effects
+        (``add_subtitles``, ``vignette``, ...) instead set
+        :attr:`compiles_to_filter` and implement :meth:`to_ffmpeg_filter`.
+        ``add_subtitles`` streams *only* via the filter path (it does not override
+        ``process_frame``), so ``compiles_to_filter`` is consulted per-instance.
+        """
+        return type(self).process_frame is not Effect.process_frame or self.compiles_to_filter

--- a/src/videopython/editing/streaming.py
+++ b/src/videopython/editing/streaming.py
@@ -110,11 +110,12 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
     ``location_prefix`` is the plan path entries are stamped under
     (``segments[i].operations`` or ``post_operations``).
 
-    ``streamable`` is the authoritative declaration (a flag-False transform
-    never streams, even with a working ``to_ffmpeg_filter``); the one divergence
-    the flag cannot express -- flag True but the filter compiles to ``None`` --
-    is caught at runtime by the ``STREAMING_UNSUPPORTED`` raise in
-    ``_compile_streaming_plans``. Purely structural: no disk access, no context.
+    A transform streams iff it overrides ``to_ffmpeg_filter`` and an effect iff it
+    overrides ``process_frame`` or sets ``compiles_to_filter`` (``op.streams()``);
+    the one divergence structure cannot express -- the override exists but the
+    filter compiles to ``None`` at this position -- is caught at runtime by the
+    ``STREAMING_UNSUPPORTED`` raise in ``_compile_streaming_plans``. Purely
+    structural: no disk access, no context.
     """
     entries: list[OpStreamability] = []
     seen_effect = False
@@ -123,7 +124,7 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
     for j, op in enumerate(ops):
         location = f"{location_prefix}[{j}]"
         if isinstance(op, Effect):
-            if op.streamable and op.requires and seen_duration_change:
+            if op.requires and seen_duration_change:
                 # The builder rejects context-consuming ops behind a
                 # duration-changing transform: segment-local context is
                 # not re-mapped through the time warp yet.
@@ -140,7 +141,7 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
                     )
                 )
                 continue
-            if op.streamable and op.compiles_to_filter:
+            if op.compiles_to_filter:
                 # Filter-class effect (add_subtitles, vignette, ...): joins the
                 # decode filter chain at this plan position -- or the encode
                 # chain when frame effects precede it -- so it streams in plan
@@ -150,13 +151,16 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
                 if seen_effect:
                     seen_encode_stage = True
                 continue
-            if not op.streamable:
+            if not op.streams():
+                # Defensive: a custom Effect that overrides neither process_frame
+                # nor to_ffmpeg_filter (no built-in op does). compiles_to_filter
+                # was handled above, so this is "no process_frame".
                 entries.append(
                     OpStreamability(
                         location,
                         op.op,
                         StreamingClass.UNSTREAMABLE,
-                        reason="effect has no streaming implementation (streamable=False)",
+                        reason="effect has no streaming implementation (no process_frame or to_ffmpeg_filter)",
                     )
                 )
             elif seen_encode_stage:
@@ -189,7 +193,7 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
                     ),
                 )
             )
-        elif op.requires and not op.streamable:
+        elif op.requires and not op.streams():
             entries.append(
                 OpStreamability(
                     location,
@@ -198,7 +202,7 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
                     reason=(f"transform requires runtime context {sorted(op.requires)} and has no streaming strategy"),
                 )
             )
-        elif op.streamable and op.compiles_from_source and (seen_effect or seen_encode_stage):
+        elif op.streams() and op.compiles_from_source and (seen_effect or seen_encode_stage):
             entries.append(
                 OpStreamability(
                     location,
@@ -210,7 +214,7 @@ def _classify_op_list(ops: Sequence[Operation], location_prefix: str) -> list[Op
                     ),
                 )
             )
-        elif op.streamable:
+        elif op.streams():
             # Transforms compile to filters at any plan position: the decode
             # chain normally, the encode chain (after every process_frame) when
             # frame effects precede them.
@@ -269,22 +273,12 @@ class EffectScheduleEntry:
     re-based onto the segment-local timeline by the plan builder), forwarded
     as keyword arguments to ``streaming_init``. Empty for context-free
     effects.
-
-    For a post-operation folded across a multi-segment plan, the effect's
-    window lives on the assembled (concatenated) timeline: ``index_offset``
-    is the number of window frames consumed by previous segments (so
-    ``process_frame`` indices continue across the concat boundary) and
-    ``total_effect_frames`` is the global window length ``streaming_init``
-    must size envelopes to. Defaults describe the ordinary segment-local
-    case.
     """
 
     effect: Effect
     start_frame: int
     end_frame: int  # exclusive
     context: dict[str, Any] = field(default_factory=dict)
-    index_offset: int = 0
-    total_effect_frames: int | None = None
 
 
 @dataclass
@@ -751,9 +745,7 @@ def _stream_segment_framewise(
     # so a context-requiring effect with missing context fails before any
     # frame work on this segment.
     for entry in plan.effect_schedule:
-        n_effect_frames = (
-            entry.total_effect_frames if entry.total_effect_frames is not None else entry.end_frame - entry.start_frame
-        )
+        n_effect_frames = entry.end_frame - entry.start_frame
         entry.effect.streaming_init(
             n_effect_frames, plan.output_fps, plan.output_width, plan.output_height, **entry.context
         )
@@ -794,7 +786,7 @@ def _stream_segment_framewise(
                         # sized to the estimate stay in bounds.
                         open_ended = entry.end_frame >= total_frames
                         if entry.start_frame <= frame_count and (frame_count < entry.end_frame or open_ended):
-                            local_index = entry.index_offset + min(frame_count, entry.end_frame - 1) - entry.start_frame
+                            local_index = min(frame_count, entry.end_frame - 1) - entry.start_frame
                             frame = entry.effect.process_frame(frame, local_index)
 
                     encoder.write_frame(frame)

--- a/src/videopython/editing/transcription_overlay.py
+++ b/src/videopython/editing/transcription_overlay.py
@@ -107,7 +107,6 @@ class TranscriptionOverlay(Effect):
     """
 
     op: Literal["add_subtitles"] = "add_subtitles"
-    streamable: ClassVar[bool] = True
     requires: ClassVar[tuple[str, ...]] = ("transcription",)
 
     # ---- primary, resolution-independent surface ----

--- a/src/videopython/editing/transforms.py
+++ b/src/videopython/editing/transforms.py
@@ -146,7 +146,6 @@ class Resize(Operation):
 
     op: Literal["resize"] = "resize"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
 
     width: int | None = Field(None, gt=0, description="Target width in pixels, or None to maintain aspect ratio.")
     height: int | None = Field(None, gt=0, description="Target height in pixels, or None to maintain aspect ratio.")
@@ -187,7 +186,6 @@ class ResampleFPS(Operation):
 
     op: Literal["resample_fps"] = "resample_fps"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
 
     fps: float = Field(gt=0, description="Target frames per second.")
 
@@ -212,7 +210,6 @@ class Crop(Operation):
 
     op: Literal["crop"] = "crop"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
 
     width: int | float = Field(description="Crop width in pixels (int) or fraction in (0, 1] of source width.")
     height: int | float = Field(description="Crop height in pixels (int) or fraction in (0, 1] of source height.")
@@ -280,7 +277,6 @@ class SpeedChange(Operation):
 
     op: Literal["speed_change"] = "speed_change"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
     changes_duration: ClassVar[bool] = True
 
     speed: float = Field(gt=0, description="Playback speed multiplier. 2.0 = twice as fast, 0.5 = half speed.")
@@ -385,7 +381,6 @@ class FreezeFrame(Operation):
 
     op: Literal["freeze_frame"] = "freeze_frame"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
     changes_duration: ClassVar[bool] = True
     # `timestamp` indexes a frame, so it must be strictly < the clip duration;
     # repair clamps an out-of-range value to the last frame.
@@ -510,7 +505,6 @@ class SilenceRemoval(Operation):
 
     op: Literal["silence_removal"] = "silence_removal"
     category: ClassVar[OpCategory] = OpCategory.TRANSFORM
-    streamable: ClassVar[bool] = True
     changes_duration: ClassVar[bool] = True
     requires: ClassVar[tuple[str, ...]] = ("transcription",)
 

--- a/src/videopython/editing/video_edit.py
+++ b/src/videopython/editing/video_edit.py
@@ -1954,9 +1954,9 @@ class VideoEdit(BaseModel):
 
         The single admission point for :meth:`run_to_file`. Unstreamable shapes raise
         :class:`PlanValidationError` with the streamability report's
-        structured errors; a builder/report drift (e.g. a third-party
-        transform whose ``streamable`` flag does not match its
-        ``to_ffmpeg_filter``) raises with a generic ``STREAMING_UNSUPPORTED``.
+        structured errors; a builder/report drift (e.g. an op whose
+        ``to_ffmpeg_filter`` returns ``None`` at its plan position despite
+        overriding it) raises with a generic ``STREAMING_UNSUPPORTED``.
         On raise, any compile-time temp files already created are deleted;
         on success the caller owns ``plan.owned_temp_files``.
         """
@@ -2073,7 +2073,6 @@ class VideoEdit(BaseModel):
         post_af_filters: list[str] = []
         audio_idx = 0
         duration_changed = False
-        decode_needs_rgb = False
 
         def compile_audio_twin(op: Operation, ctx: FilterCtx, encode_stage: bool) -> None:
             """Append the op's audio-domain filter at the same stage the video
@@ -2100,7 +2099,7 @@ class VideoEdit(BaseModel):
         try:
             for op in segment.operations:
                 if isinstance(op, Effect):
-                    if not op.streamable:
+                    if not op.streams():
                         abandon()
                         return None
                     if op.requires and duration_changed:
@@ -2129,7 +2128,6 @@ class VideoEdit(BaseModel):
                                 post_vf_filters.append(filter_expr)
                             else:
                                 vf_filters.append(filter_expr)
-                                decode_needs_rgb = decode_needs_rgb or op.filter_needs_rgb24
                             # Audio twin at the same stage (add_subtitles has
                             # none today; kept coupled for extensibility).
                             compile_audio_twin(op, ctx, encode_stage_effect)
@@ -2155,7 +2153,7 @@ class VideoEdit(BaseModel):
                     effect_ctx = make_ctx()
                     compile_audio_twin(op, effect_ctx, encode_stage=False)
                     continue
-                if op.requires and (duration_changed or not op.streamable):
+                if op.requires and (duration_changed or not op.streams()):
                     # A context-requiring transform can stream only when its
                     # filter compile can consume the context (silence_removal
                     # does, via FilterCtx.context) -- but not after a
@@ -2165,15 +2163,13 @@ class VideoEdit(BaseModel):
                     # streamability report.
                     abandon()
                     return None
-                # Non-effect transform: compile to ffmpeg filter if streamable.
-                # The `streamable` flag is the authoritative declaration -- checked
-                # first so the streamability report (which classifies by the flag)
-                # can never disagree with the builder in this direction: a
-                # flag-False transform is classified UNSTREAMABLE even if it has
-                # a working to_ffmpeg_filter. The remaining drift class (flag
-                # True, filter compiles to None) is caught by the
-                # STREAMING_UNSUPPORTED raise in _compile_streaming_plans.
-                if not op.streamable:
+                # Non-effect transform: streams iff it compiles a filter. Checked
+                # structurally (op.streams() == overrides to_ffmpeg_filter) so the
+                # streamability report and the builder cannot disagree; the
+                # remaining drift class (overrides to_ffmpeg_filter but it compiles
+                # to None here) is caught by the STREAMING_UNSUPPORTED raise in
+                # _compile_streaming_plans.
+                if not op.streams():
                     abandon()
                     return None
                 encode_stage = bool(effect_schedule or post_vf_filters)
@@ -2212,14 +2208,6 @@ class VideoEdit(BaseModel):
             # crop exceeding source) must not leak earlier ops' temp files.
             abandon()
             raise
-
-        # A decode-stage filter-effect that reads RGB (geq r/g/b, rgbashift)
-        # must see rgb24, not the native yuv decode stream; prepend one
-        # conversion ahead of the whole decode chain (encode-stage effects
-        # already receive rgb24 from the frame pipe). Idempotent: only when an
-        # rgb-reading effect landed at decode and no conversion leads already.
-        if decode_needs_rgb and not (vf_filters and vf_filters[0] == "format=rgb24"):
-            vf_filters.insert(0, "format=rgb24")
 
         pipe = pipe_meta or running
         # Final output duration after every transform (decode + encode stage),

--- a/uv.lock
+++ b/uv.lock
@@ -4491,7 +4491,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.46.0"
+version = "0.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
…ad-code cleanup (0.47.0)

Follow-ups to 0.46.0's single-mechanism engine. No wire-format change, and the streamability classification of every built-in op is unchanged.

- blur (constant), shake (rhythmic), and flash (windowless) now compile to native ffmpeg filters (gblur/geq) and take the single-invocation fast path, verified in-pipeline vs the numpy twins (mean abs diff <= ~2). Other modes stay frame-only via a mode-dependent compiles_to_filter; the RGB-reading ones set filter_needs_rgb24.
- Drop the redundant `streamable` ClassVar (every registered op is streamable): classification is now structural via Operation.streams() -- a transform streams iff it overrides to_ffmpeg_filter, an effect iff it overrides process_frame or sets compiles_to_filter. Classifier and builder decide structurally; the runtime drift guard still catches a filter that compiles to None at its position.
- Remove the dead post-op-fold machinery (EffectScheduleEntry.index_offset / total_effect_frames were never set after 0.46.0 moved post-ops to an assembled-program pass); simplify the framewise loop.

Docs and RELEASE_NOTES updated; version 0.46.0 -> 0.47.0.