### PR TITLE
feat(mcp): ergonomics at scale -- downscale keyframes, scene_keyframe…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 0.50.1
+
+MCP ergonomics at scale. MCP keyframes are downscaled (longest side <= 768px)
+before base64-encoding, shrinking the build_catalog / scene_keyframes payload by
+roughly 10x (SceneVLM captioning and the local planner keep full-resolution
+frames). `build_catalog` now always returns the full catalog text
+but caps inlined keyframes; the rest are fetched on demand with a new
+`scene_keyframes(scene_ids)` tool, and an explicit note lists any omitted scene
+ids so the agent never assumes it saw every frame. `analyze_video` gains a
+`profile="editing"` option that skips audio classification for a faster,
+catalog-only analysis on long sources.
+
 ## 0.50.0
 
 MCP server. A new `videopython/mcp/` exposes the auto-edit pipeline as Model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.50.0"
+version = "0.50.1"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_mcp.py
+++ b/src/tests/ai/test_mcp.py
@@ -31,11 +31,11 @@ from videopython.mcp import server  # noqa: E402
 def _reset_state() -> Any:
     server._analyses = {}
     server._bundle = None
-    server._analyzer = None
+    server._analyzers = {}
     yield
     server._analyses = {}
     server._bundle = None
-    server._analyzer = None
+    server._analyzers = {}
 
 
 def _real_analysis() -> VideoAnalysis:
@@ -67,6 +67,34 @@ def _real_analysis() -> VideoAnalysis:
         config=VideoAnalysisConfig(),
         run_info=AnalysisRunInfo(created_at="2026-01-01T00:00:00Z", mode="path"),
         scenes=SceneAnalysisSection(samples=scenes),
+    )
+
+
+def _analysis_with_scenes(n: int) -> VideoAnalysis:
+    meta = VideoMetadata.from_path(SMALL_VIDEO_PATH)
+    dur = meta.total_seconds
+    step = dur / n
+    samples = [
+        SceneAnalysisSample(
+            scene_index=i,
+            start_second=i * step,
+            end_second=(i + 1) * step,
+            scene_description=SceneDescription(caption=f"scene {i}", subjects=[], shot_type="wide"),
+        )
+        for i in range(n)
+    ]
+    return VideoAnalysis(
+        source=VideoAnalysisSource(
+            path=str(SMALL_VIDEO_PATH),
+            fps=meta.fps,
+            width=meta.width,
+            height=meta.height,
+            frame_count=meta.frame_count,
+            duration=dur,
+        ),
+        config=VideoAnalysisConfig(),
+        run_info=AnalysisRunInfo(created_at="2026-01-01T00:00:00Z", mode="path"),
+        scenes=SceneAnalysisSection(samples=samples),
     )
 
 
@@ -120,7 +148,7 @@ def test_analyze_video_caches_and_summarizes() -> None:
         def analyze_path(self, path: str) -> VideoAnalysis:
             return analysis
 
-    server._analyzer = _FakeAnalyzer()  # type: ignore[assignment]
+    server._analyzers["full"] = _FakeAnalyzer()  # type: ignore[assignment]
     out = server.analyze_video(str(SMALL_VIDEO_PATH))
     assert out["scenes"] == 2
     assert out["source"] == str(SMALL_VIDEO_PATH)
@@ -135,7 +163,7 @@ def test_analyze_video_keeps_stdout_clean(capsys: pytest.CaptureFixture[str]) ->
             print("transnetv2-style stdout noise that would corrupt JSON-RPC")
             return analysis
 
-    server._analyzer = _NoisyAnalyzer()  # type: ignore[assignment]
+    server._analyzers["full"] = _NoisyAnalyzer()  # type: ignore[assignment]
     server.analyze_video(str(SMALL_VIDEO_PATH))
     captured = capsys.readouterr()
     assert captured.out == ""  # stdout (the transport channel) stays clean
@@ -215,3 +243,45 @@ def test_repair_dict_shape() -> None:
         "new": 2.0,
         "code": "effect_window_exceeds_duration",
     }
+
+
+def test_build_catalog_caps_inlined_keyframes_and_notes_omitted() -> None:
+    n = server._MAX_INLINE_KEYFRAMES + 3
+    server._analyses = {str(SMALL_VIDEO_PATH): _analysis_with_scenes(n)}
+    blocks = server.build_catalog()
+
+    images = [b for b in blocks if isinstance(b, ImageContent)]
+    assert len(images) == server._MAX_INLINE_KEYFRAMES
+    note = blocks[-1]
+    assert isinstance(note, TextContent)
+    assert "scene_keyframes" in note.text
+    assert server._bundle is not None
+    omitted = [s.id for s in server._bundle.catalog.scenes][server._MAX_INLINE_KEYFRAMES :]
+    assert all(oid in note.text for oid in omitted)
+
+
+def test_scene_keyframes_returns_requested_images() -> None:
+    server._analyses = {str(SMALL_VIDEO_PATH): _real_analysis()}
+    server.build_catalog()
+    blocks = server.scene_keyframes([f"{_stem()}#0"])
+    assert sum(isinstance(b, ImageContent) for b in blocks) == 1
+
+
+def test_scene_keyframes_dedups_repeated_ids() -> None:
+    server._analyses = {str(SMALL_VIDEO_PATH): _real_analysis()}
+    server.build_catalog()
+    blocks = server.scene_keyframes([f"{_stem()}#0", f"{_stem()}#0"])
+    assert sum(isinstance(b, ImageContent) for b in blocks) == 1
+
+
+def test_scene_keyframes_unknown_id_structured_error() -> None:
+    server._analyses = {str(SMALL_VIDEO_PATH): _real_analysis()}
+    server.build_catalog()
+    [block] = server.scene_keyframes(["nope#0"])
+    assert isinstance(block, TextContent)
+    assert json.loads(block.text)["code"] == "unknown_scene_ids"
+
+
+def test_scene_keyframes_without_catalog_errors() -> None:
+    with pytest.raises(ValueError, match="catalog"):
+        server.scene_keyframes(["x#0"])

--- a/src/tests/ai/test_ollama_backend.py
+++ b/src/tests/ai/test_ollama_backend.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from videopython.ai._ollama import _encode_png_b64
+from videopython.ai._ollama import KEYFRAME_MAX_DIM, _downscale, _encode_png_b64
 from videopython.ai.auto_edit import ImagePart, OllamaVisionLLM, Part, PlannerError, TextPart
 
 
@@ -72,3 +72,19 @@ def test_encode_png_b64_roundtrips() -> None:
     frame[0, 0] = [255, 0, 0]
     decoded = Image.open(io.BytesIO(base64.b64decode(_encode_png_b64(frame))))
     assert decoded.size == (6, 4)  # PIL size is (width, height)
+
+
+def test_encode_png_b64_preserves_full_resolution() -> None:
+    # Downscaling is scoped to the MCP keyframe path, not the shared encoder: SceneVLM
+    # captioning and the local planner must keep full-resolution frames.
+    frame = np.zeros((500, 1200, 3), dtype=np.uint8)
+    decoded = Image.open(io.BytesIO(base64.b64decode(_encode_png_b64(frame))))
+    assert decoded.size == (1200, 500)
+
+
+def test_downscale_bounds_longest_side() -> None:
+    shrunk = _downscale(np.zeros((500, 1200, 3), dtype=np.uint8))
+    assert max(shrunk.shape[:2]) == KEYFRAME_MAX_DIM
+    assert shrunk.shape == (320, 768, 3)  # aspect preserved: 500 * 768 / 1200 == 320
+    small = np.zeros((4, 6, 3), dtype=np.uint8)
+    assert _downscale(small) is small  # never upscales

--- a/src/tests/ai/test_video_analysis_scene_first.py
+++ b/src/tests/ai/test_video_analysis_scene_first.py
@@ -155,6 +155,19 @@ def test_config_defaults_and_rejects_unknown_ids() -> None:
         va.VideoAnalysisConfig(enabled_analyzers={"unknown"})
 
 
+def test_for_profile_editing_drops_audio_classifier() -> None:
+    assert va.VideoAnalysisConfig.for_profile("full").enabled_analyzers == set(va.ALL_ANALYZER_IDS)
+
+    editing = va.VideoAnalysisConfig.for_profile("editing").enabled_analyzers
+    assert editing == {va.SEMANTIC_SCENE_DETECTOR, va.SCENE_VLM, va.AUDIO_TO_TEXT, va.FACE_TRACKER}
+    assert va.AUDIO_CLASSIFIER not in editing
+
+    assert va.FACE_TRACKER not in va.VideoAnalysisConfig.for_profile("editing", faces=False).enabled_analyzers
+
+    with pytest.raises(ValueError, match="Unknown profile"):
+        va.VideoAnalysisConfig.for_profile("bogus")
+
+
 def test_scene_first_full_run_outputs_scene_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_scene_first_analyzers(monkeypatch)
     analysis = va.VideoAnalyzer(config=va.VideoAnalysisConfig()).analyze(_video_4s())

--- a/src/videopython/ai/_ollama.py
+++ b/src/videopython/ai/_ollama.py
@@ -7,6 +7,7 @@ import io
 import json
 from typing import Any
 
+import cv2
 import numpy as np
 from PIL import Image
 
@@ -63,6 +64,20 @@ class OllamaStructuredClient:
 
     def unload(self) -> None:
         self._client = None
+
+
+# Used only on the MCP keyframe path (videopython.mcp). SceneVLM captioning and the local
+# planner deliberately encode full-resolution frames via _encode_png_b64.
+KEYFRAME_MAX_DIM = 768  # bound a keyframe's longest side before PNG-encoding for the MCP payload
+
+
+def _downscale(frame: np.ndarray, max_dim: int = KEYFRAME_MAX_DIM) -> np.ndarray:
+    """Shrink an RGB frame so its longest side is at most ``max_dim`` (aspect preserved; never upscales)."""
+    h, w = frame.shape[:2]
+    scale = max_dim / max(h, w)
+    if scale >= 1.0:
+        return frame
+    return cv2.resize(frame, (max(1, round(w * scale)), max(1, round(h * scale))), interpolation=cv2.INTER_AREA)
 
 
 def _encode_png_b64(frame: np.ndarray) -> str:

--- a/src/videopython/ai/video_analysis/models.py
+++ b/src/videopython/ai/video_analysis/models.py
@@ -173,6 +173,18 @@ class VideoAnalysisConfig(BaseModel):
         """Backward-compatible alias for the default config."""
         return cls()
 
+    @classmethod
+    def for_profile(cls, profile: str, *, faces: bool = True) -> VideoAnalysisConfig:
+        """Config for an analysis profile: 'full' (all analyzers) or 'editing' (catalog-only, no audio classifier)."""
+        if profile == "full":
+            return cls()
+        if profile == "editing":
+            enabled = {SEMANTIC_SCENE_DETECTOR, SCENE_VLM, AUDIO_TO_TEXT}
+            if faces:
+                enabled.add(FACE_TRACKER)
+            return cls(enabled_analyzers=enabled)
+        raise ValueError(f"Unknown profile: {profile!r} (expected 'full' or 'editing')")
+
 
 class AudioAnalysisSection(BaseModel):
     """Audio understanding outputs."""

--- a/src/videopython/mcp/server.py
+++ b/src/videopython/mcp/server.py
@@ -13,13 +13,13 @@ import json
 import sys
 from contextlib import redirect_stdout
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
 from pydantic import ValidationError
 
-from videopython.ai._ollama import _encode_png_b64
+from videopython.ai._ollama import _downscale, _encode_png_b64
 from videopython.ai.auto_edit import EditPlan, UnknownSceneIdsError, resolve_plan
 from videopython.ai.auto_edit import build_catalog as _build_scene_catalog
 from videopython.editing import VideoEdit
@@ -33,20 +33,24 @@ mcp = FastMCP("videopython")
 
 # Session state for one stdio client (one process per client).
 _analyses: dict[str, VideoAnalysis] = {}
-_analyzer: VideoAnalyzer | None = None
+_analyzers: dict[str, VideoAnalyzer] = {}
 _bundle: CatalogBundle | None = None
+
+_MAX_INLINE_KEYFRAMES = 12  # cap inlined keyframes in build_catalog; pull the rest with scene_keyframes
 
 
 @mcp.tool()
-def analyze_video(path: str) -> dict[str, Any]:
+def analyze_video(path: str, profile: Literal["full", "editing"] = "full") -> dict[str, Any]:
     """Analyze a source video (scenes, transcript, captions) and cache it for build_catalog.
 
-    Returns a short summary; call this once per source, then build_catalog.
+    ``profile="editing"`` skips audio classification (faster on long sources); the
+    catalog (captions + transcript + face flag) is unaffected. Returns a short
+    summary; call this once per source, then build_catalog.
     """
     # Heavy analyzer deps (e.g. transnetv2-pytorch) bare-print to stdout, which here is
     # the stdio JSON-RPC channel; send that to stderr so the transport stays clean.
     with redirect_stdout(sys.stderr):
-        analysis = _get_analyzer().analyze_path(path)
+        analysis = _get_analyzer(profile).analyze_path(path)
     _analyses[str(Path(path))] = analysis
     src = analysis.source
     return {
@@ -63,10 +67,11 @@ def analyze_video(path: str) -> dict[str, Any]:
 def build_catalog(sources: list[str] | None = None) -> list[TextContent | ImageContent]:
     """Build the candidate-scene catalog from analyzed videos and cache it.
 
-    Returns the catalog as JSON text plus one keyframe image per scene (each
-    preceded by its scene id), so the model can see the footage. Pass ``sources``
-    to restrict to specific analyzed paths, or omit for all. Author the edit by
-    referencing the returned ``id`` values via the edit-plan schema resource.
+    The first text block is the full catalog JSON (id/duration/shot_type/caption/
+    transcript per scene -- enough to shortlist from text alone). Up to
+    ``_MAX_INLINE_KEYFRAMES`` downscaled keyframes follow; a final note names any
+    scene ids whose images were omitted (fetch them with scene_keyframes). Pass
+    ``sources`` to restrict to specific analyzed paths, or omit for all.
     """
     global _bundle
     analyses = _selected_analyses(sources)
@@ -74,13 +79,34 @@ def build_catalog(sources: list[str] | None = None) -> list[TextContent | ImageC
         raise ValueError("No analyzed videos cached; call analyze_video first.")
     _bundle = _build_scene_catalog(analyses)
 
-    blocks: list[TextContent | ImageContent] = [TextContent(type="text", text=_bundle.catalog.model_dump_json())]
-    for scene in _bundle.catalog.scenes:
-        frame = _bundle.keyframes.get(scene.id)
-        if frame is not None:
-            blocks.append(TextContent(type="text", text=f"scene {scene.id}:"))
-            blocks.append(ImageContent(type="image", data=_encode_png_b64(frame), mimeType="image/png"))
+    ids = [scene.id for scene in _bundle.catalog.scenes]
+    inlined, omitted = ids[:_MAX_INLINE_KEYFRAMES], ids[_MAX_INLINE_KEYFRAMES:]
+    blocks: list[TextContent | ImageContent] = [
+        TextContent(type="text", text=_bundle.catalog.model_dump_json()),
+        *_keyframe_blocks(inlined),
+    ]
+    if omitted:
+        blocks.append(
+            TextContent(
+                type="text",
+                text=f"Keyframes omitted for {len(omitted)} scenes "
+                f"(call scene_keyframes for these ids): {', '.join(omitted)}",
+            )
+        )
     return blocks
+
+
+@mcp.tool(structured_output=False)
+def scene_keyframes(scene_ids: list[str]) -> list[TextContent | ImageContent]:
+    """Return downscaled keyframe images for specific catalog scene ids (use after build_catalog)."""
+    if _bundle is None:
+        raise ValueError("No catalog cached; call build_catalog first.")
+    known = _bundle.catalog.by_id()
+    unknown = sorted({sid for sid in scene_ids if sid not in known})
+    if unknown:
+        error = {"code": "unknown_scene_ids", "value": unknown, "message": f"Unknown scene ids: {unknown}"}
+        return [TextContent(type="text", text=json.dumps(error))]
+    return _keyframe_blocks(list(dict.fromkeys(scene_ids)))
 
 
 @mcp.tool()
@@ -146,19 +172,29 @@ def edit_plan_schema() -> str:
     return json.dumps(EditPlan.json_schema(strict=True))
 
 
-def _get_analyzer() -> VideoAnalyzer:
-    global _analyzer
-    if _analyzer is None:
-        from videopython.ai.video_analysis import VideoAnalyzer
+def _get_analyzer(profile: str = "full") -> VideoAnalyzer:
+    if profile not in _analyzers:
+        from videopython.ai.video_analysis import VideoAnalysisConfig, VideoAnalyzer
 
-        _analyzer = VideoAnalyzer()
-    return _analyzer
+        _analyzers[profile] = VideoAnalyzer(config=VideoAnalysisConfig.for_profile(profile))
+    return _analyzers[profile]
 
 
 def _selected_analyses(sources: list[str] | None) -> list[VideoAnalysis]:
     if sources is None:
         return list(_analyses.values())
     return [_analyses[str(Path(s))] for s in sources if str(Path(s)) in _analyses]
+
+
+def _keyframe_blocks(scene_ids: list[str]) -> list[TextContent | ImageContent]:
+    assert _bundle is not None  # callers guard; narrows the module global for mypy
+    blocks: list[TextContent | ImageContent] = []
+    for sid in scene_ids:
+        frame = _bundle.keyframes.get(sid)
+        if frame is not None:
+            blocks.append(TextContent(type="text", text=f"scene {sid}:"))
+            blocks.append(ImageContent(type="image", data=_encode_png_b64(_downscale(frame)), mimeType="image/png"))
+    return blocks
 
 
 def _resolve(plan: dict[str, Any]) -> tuple[VideoEdit | None, list[dict[str, Any]]]:

--- a/uv.lock
+++ b/uv.lock
@@ -4675,7 +4675,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.50.0"
+version = "0.50.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
…s, editing profile (0.50.1)

From a live agent-driven MCP run that flagged two scale issues (keyframe payload context-bomb; long silent analyze).

- Downscale MCP keyframes to longest-side 768 before base64 (~10x smaller payload), scoped to the MCP keyframe path so SceneVLM captioning and the local planner keep full-resolution frames.
- build_catalog always returns the full catalog text but caps inlined keyframes (12) with a note listing omitted ids; new scene_keyframes(scene_ids) tool pulls the rest on demand (order-preserving dedup).
- analyze_video gains profile="editing" (VideoAnalysisConfig.for_profile), which drops the audio classifier for a faster catalog-only analysis on long sources, via a per-profile analyzer cache.

Progress streaming (per-stage ctx.report_progress) is deferred: it needs an async analyze_video + anyio thread bridge and has no consumer until then.