### PR TITLE
docs: highlight MCP + streaming on home page; align docs with 0.46-0.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ Putting an LLM in the loop works three ways:
 2. **`AutoEditor`** — a local Ollama vision model is the planner (see [Automatic editing](#automatic-editing-local-llm) above).
 3. **MCP server** — `videopython-mcp` exposes the pipeline as [Model Context Protocol](https://modelcontextprotocol.io) tools, so an agent like Claude drives editing with its own model. Install `[ai,mcp]`, run `videopython-mcp`, and point your MCP client at it. See the [MCP Server Guide](https://videopython.com/guides/mcp/).
 
-For mode 1: every operation is a Pydantic model whose fields ARE the JSON wire format. `VideoEdit.json_schema()` returns a JSON Schema with a discriminated union over every LLM-exposed `Operation` (server-only ops like `image_overlay` are excluded by default) — pass it straight to Anthropic tool use, OpenAI function calling, or any structured-output API. Pass `strict=True` for a provider strict-mode grammar that prevents simple bound violations at decode time.
+**Mode 1** in brief: every operation is a Pydantic model whose fields *are* the JSON wire format, so `VideoEdit.json_schema()` hands your model a ready-made tool schema — a discriminated union over every LLM-exposed op (pass `strict=True` for provider grammar modes). Plans parse permissively and own their numeric bounds at validation, so a refine loop converges fast:
 
-The plan parses permissively (shape only) and owns numeric bounds at validation, so a refine loop converges fast: `edit.check(meta)` collects **every** structured `PlanError` in one pass, `edit.repair(meta)` auto-clamps the mechanical violations (window/timestamp overruns, negatives) with a reported changelog, and `edit.normalize_dimensions(meta, target)` makes heterogeneous segments concat-compatible by construction. `edit.validate()` still raises a typed `PlanValidationError` (a `ValueError` with structured `.errors`) for the single-error path.
+- **`edit.check(meta)`** — collect *every* structured error in one pass, not just the first
+- **`edit.repair(meta)`** — auto-clamp mechanical violations (overruns, negatives) with a changelog
+- **`edit.normalize_dimensions(meta, target)`** — make heterogeneous segments concat-compatible
 
-See the [LLM Integration Guide](https://videopython.com/guides/llm-integration/) for end-to-end examples, the collect/repair/normalize refine loop, and operation discovery patterns.
+See the [LLM Integration Guide](https://videopython.com/guides/llm-integration/) for end-to-end examples (Anthropic / OpenAI tool use), the refine loop, and operation discovery.
 
 ## Features
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,7 +19,7 @@ Editing primitives and the plan runner:
 
 - [**Editing Plans (`VideoEdit`)**](editing.md) - Multi-segment editing plans with JSON parsing, validation, and schema generation
 - [**Operations**](operations.md) - The `Operation` Pydantic base, auto-registry, and discriminated-union schema
-- [**Transforms**](transforms.md) - Frame transformations (cut, resize, resample)
+- [**Transforms**](transforms.md) - Frame transformations (resize, crop, fps, speed, freeze)
 - [**Effects**](effects.md) - Visual effects (blur, zoom, overlays) — including `TranscriptionOverlay` for subtitles
 
 ## `videopython.ai`
@@ -54,8 +54,8 @@ from videopython.audio import (
     AudioMetadata,
 )
 from videopython.editing import (
-    CutSeconds,
     Resize,
+    Crop,
     Blur,
 )
 

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -10,11 +10,13 @@ Transforms are not applied to a `Video` directly. They run only through
 the streaming engine: add the operation(s) to a `VideoEdit` and render
 with `run_to_file`.
 
+The time cut is the segment's own `start`/`end`; resizing, cropping, and fps
+changes go in `operations`:
+
 ```python
-from videopython.editing import VideoEdit, SegmentConfig, Resize, Crop, CutSeconds
+from videopython.editing import VideoEdit, SegmentConfig, Resize, Crop
 
 edit = VideoEdit(segments=[SegmentConfig(source="input.mp4", start=0, end=10, operations=[
-    CutSeconds(start=0.0, end=10.0),
     Crop(width=0.5, height=0.5),        # 50% center crop
     Resize(width=1280, height=720),
 ])])
@@ -81,6 +83,12 @@ edit.run_to_file("out.mp4", context={"transcription": my_transcription})
 ```
 
 ## API Reference
+
+!!! note "`CutSeconds` / `CutFrames` are engine-internal"
+    These are documented because the engine constructs them from each segment's
+    `start`/`end`, but they are `internal_only` — not in the op registry or the LLM
+    schema, and rejected if placed in a plan's `operations` list. Cut via the
+    segment range instead.
 
 ### CutSeconds
 

--- a/docs/examples/large-videos.md
+++ b/docs/examples/large-videos.md
@@ -62,7 +62,8 @@ edit.run_to_file("output.mp4", context={"transcription": transcription})
 ```
 
 See the [Operations](../api/operations.md#registered-operations) table for the
-list of streamable ops. Inspect `Operation.get(op_id).streamable` programmatically.
+list of streamable ops. Every registered op streams; `edit.streamability()` gives
+the per-op classification at each plan position without touching the disk.
 
 ## Solution: FrameIterator
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -45,6 +45,33 @@ generation, dubbing, and the LLM auto-editing planner. The heavy ML dependencies
 still load lazily at first use (no top-level imports under `ai/`), so importing
 `videopython` stays light even with `[ai]` installed.
 
+### With the MCP Server
+
+To drive editing from an MCP-capable agent, add the `[mcp]` extra (it needs `[ai]` too):
+
+```bash
+pip install "videopython[ai,mcp]"
+```
+
+This installs the `videopython-mcp` console script (a stdio [Model Context
+Protocol](https://modelcontextprotocol.io) server). See the
+[MCP Server guide](../guides/mcp.md).
+
+!!! warning "Ollama is required for scene captioning, dubbing translation, and auto-editing"
+    Scene captioning (`SceneVLM`, used by `VideoAnalyzer`), dubbing translation,
+    and the `AutoEditor` / MCP planner run against a local
+    [Ollama](https://ollama.com) server — there is no in-process fallback. Install
+    Ollama, then pull the verified default model:
+
+    ```bash
+    ollama serve            # start the local daemon
+    ollama pull gemma3:27b  # the default vision/translation model
+    ```
+
+    The model must support Ollama's structured-output `format`; `gemma3:27b` is
+    verified. Generation (image/video/speech/music), transcription, detection, and
+    audio classification do **not** need Ollama.
+
 !!! note "Dubbing TTS"
     The dubbing pipeline synthesizes speech with a local Chatterbox
     `TextToSpeech` by default. To run synthesis out of process instead, inject

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -18,11 +18,19 @@ server.
 
 ## Tools
 
-- **`analyze_video(path)`** — analyze a source (scenes + transcript + captions);
-  cached server-side for the catalog. Returns a short summary.
-- **`build_catalog(sources=None)`** — returns the candidate scenes (JSON) plus one
-  keyframe image per scene, so the model can see the footage. Author the edit by
-  referencing the returned `id` values.
+- **`analyze_video(path, profile="full")`** — analyze a source (scenes + transcript
+  + captions); cached server-side for the catalog. Returns a short summary. Pass
+  `profile="editing"` to skip audio classification — faster on long sources, since
+  the catalog never reads it.
+- **`build_catalog(sources=None)`** — returns the candidate scenes as one JSON text
+  block (id, duration, shot_type, caption, transcript per scene — enough to
+  shortlist from text alone), followed by up to 12 **downscaled** keyframe images.
+  If there are more scenes, a trailing note names the omitted ids so the agent
+  never assumes it saw every frame. Author the edit by referencing the returned
+  `id` values.
+- **`scene_keyframes(scene_ids)`** — fetch downscaled keyframe images for a chosen
+  shortlist of scene ids. Use after `build_catalog` to pull the frames that were
+  capped out, without re-inlining the whole library.
 - **`validate_edit(plan)`** — validate an `EditPlan` (references catalog
   `scene_id`s); returns every problem at once as structured errors.
 - **`repair_edit(plan)`** — clamp mechanical issues + normalize dimensions;
@@ -39,9 +47,21 @@ server.
 
 ## Flow
 
-`analyze_video` per source → `build_catalog` (see scenes + keyframes) → author an
+`analyze_video` per source → `build_catalog` (read the scene JSON + the first
+keyframes; pull any capped-out frames with `scene_keyframes`) → author an
 `EditPlan` (scene ids + operations) against the schema resource → `validate_edit`
 → `run_edit`. The server is a thin wrapper over the same primitives as the
 programmatic `AutoEditor`; the planner is the client's model. The server caches
 analyses + the catalog so the agent passes small payloads (scene ids), not whole
 analysis blobs.
+
+## Scaling to many scenes
+
+Keyframes are the payload that grows with the footage, so the server keeps it
+bounded: every image the MCP path returns is downscaled (longest side ≤ 768px,
+~10× smaller than a full-res PNG), and `build_catalog` inlines at most 12 of them,
+naming the rest. The agent shortlists from the always-complete catalog *text*, then
+calls `scene_keyframes(scene_ids)` for just the frames it wants to look at. This
+keeps a ~100-scene library from flooding the model's context in one result.
+(Downscaling is scoped to MCP — `SceneVLM` captioning and the local planner keep
+full-resolution frames.)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,8 @@ edit = VideoEdit.from_dict({
 edit.run_to_file("output.mp4")
 ```
 
+`run_to_file()` streams ffmpeg decode → per-frame effects → encode, so memory stays bounded (~O(1)) even for hour-long sources — no frames are held in RAM.
+
 <div class="feature-grid" markdown>
 
 <div class="feature-card" markdown>
@@ -65,7 +67,15 @@ Drive videopython from your own LLM: JSON Schema generation, dry-run validation,
 
 ### Automatic Editing
 
-Hand `AutoEditor` your clips and a one-line brief — a local vision LLM selects and orders the shots, then renders the cut. Or drive the same pipeline from any MCP agent. [Learn more →](guides/auto-editing.md)
+Hand `AutoEditor` your clips and a one-line brief — a local vision LLM selects and orders the shots, then renders the cut. [Learn more →](guides/auto-editing.md)
+
+</div>
+
+<div class="feature-card" markdown>
+
+### MCP Server
+
+Expose the auto-edit pipeline as [Model Context Protocol](https://modelcontextprotocol.io) tools, so an agent like Claude drives editing with its own model — analyze, browse scenes by keyframe, author a plan, validate, render. [Learn more →](guides/mcp.md)
 
 </div>
 


### PR DESCRIPTION
…50.1

- index: add MCP Server feature card (completes the three LLM modes) and a streaming/O(1)-memory caption under the hero code
- installation: document the [mcp] extra and the Ollama hard-runtime requirement (scene captioning, dub translation, AutoEditor/MCP planner)
- guides/mcp: cover scene_keyframes, build_catalog keyframe cap+downscale, analyze_video(profile="editing"), and a "scaling to many scenes" section
- large-videos: fix removed Operation.streamable -> edit.streamability()
- transforms / api/index: stop steering users to the internal-only cut op