### PR TITLE
refactor(ai): debt cleanup — op registration, dead API, shar…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,56 @@
 # Release Notes
 
+## 0.51.0
+
+`videopython.ai` technical-debt cleanup (PR-1 of 2): a correctness fix plus the
+removal of abstraction residue left behind when the granular extras (0.43.0) were
+collapsed into one `[ai]` (0.48.0) and the alternative translator/TTS backends
+were deleted (0.49.0). Net ~430 fewer lines; no capability removed. See `TODO.md`
+for the full audit and the PR-2 (taxonomy) follow-up.
+
+### Fixed
+
+- **AI plan-ops are now always in the planner / MCP op schema.** `FaceTrackingCrop`
+  (`face_crop`) and `ObjectDetectionOverlay` (`object_detection_overlay`) register
+  only as an import side-effect, and `ai/__init__` re-exports them lazily — so in a
+  fresh process that built `EditPlan.json_schema()` / `Operation.llm_registry()`
+  (the auto-edit planner, the MCP `edit_plan_schema` resource) before touching them,
+  both ops were silently absent and `Operation.get("face_crop")` raised. A new
+  `videopython.ai.ops` self-registration module, imported by `ai.auto_edit`, fixes
+  this; regression-tested from a clean interpreter.
+
+### Breaking
+
+- **Planner seam mirrors the Ollama client.** `StructuredVisionLLM.generate_json`
+  now takes `(system, text, images, schema)` instead of a `parts` list; the
+  `TextPart` / `ImagePart` / `Part` types are removed (the planner flattened them
+  straight back to text+images, so they added only indirection). `OllamaVisionLLM`
+  and the `StructuredVisionLLM` protocol stay. Removed from `videopython.ai` and
+  `videopython.ai.auto_edit` exports: `TextPart`, `ImagePart`, `Part`.
+- **Dead API removed**: `UnsupportedLanguageError` (never raised),
+  `TranslationBackend` (single implementor; translation is hardwired to
+  `OllamaTranslator`), `OllamaTranslator.supports()`, `DubbingConfig.translator`
+  (the `"auto"`/`"ollama"` values were behaviorally identical — use
+  `translator_model` / `translator_host`), `TimingSynchronizer.check_overlaps` +
+  its `gap_threshold` arg, `VideoAnalysisConfig.rich_understanding_preset()` (use
+  `for_profile("full")`), and the path-based `remux.replace_audio_stream` (the
+  in-memory `replace_audio_stream_from_audio` is the only caller path).
+- **`ai._optional.require()` signature**: dropped the always-`"ai"` `extra`
+  positional — now `require(module, *, feature=...)` with a hardcoded `[ai]` install
+  hint. Internal helper; call sites updated.
+
+### Internal
+
+- New `ai.understanding._yolo.YoloDetector` base unifies the duplicated YOLO wrapper
+  behind `ObjectDetector` and the face detector (lazy load, device resolution,
+  `detect`/`detect_batch`).
+- `ManagedPredictor` now provides a default `unload()` driven by a `_model_attrs`
+  class attribute, replacing ~10 near-identical hand-written `unload()` bodies.
+  `ObjectDetector` and `FaceTracker` are now context-managed and expose `unload()`,
+  closing a VRAM-release gap.
+- Docstrings/comments that still described the removed granular extras
+  (`[asr]`/`[vision]`/`[tts]`/`[dub]`/...) were rewritten for the single `[ai]` extra.
+
 ## 0.50.1
 
 MCP ergonomics at scale. MCP keyframes are downscaled (longest side <= 768px)

--- a/docs/api/ai/dubbing.md
+++ b/docs/api/ai/dubbing.md
@@ -202,8 +202,8 @@ Segments the model never returns (after the retry) are surfaced on
 `DubbingResult.translation_failures` as a list of indices; those land on the
 result with empty translated text.
 
-If neither backend covers the requested pair the auto resolver raises
-`UnsupportedLanguageError` (importable from `videopython.ai.dubbing`).
+The Ollama translator attempts any language pair, so the pipeline does not
+reject a requested target language up front.
 
 ### Pluggable TTS Backend
 
@@ -491,14 +491,6 @@ heuristic returns `recommendation="reject"`. Carries the triggering
 `TranscriptQuality` as `error.quality` for caller introspection.
 
 ::: videopython.ai.dubbing.GarbageTranscriptError
-
-## UnsupportedLanguageError
-
-Available for callers to catch. The Ollama translator attempts any language
-pair, so the pipeline no longer raises this itself; it carries both language
-fields for introspection without parsing the message.
-
-::: videopython.ai.dubbing.UnsupportedLanguageError
 
 ## Supported Languages
 

--- a/docs/api/ai/video_analysis.md
+++ b/docs/api/ai/video_analysis.md
@@ -90,16 +90,16 @@ preview.
 
 ## Rich Understanding Preset
 
-Use the built-in preset when you want broad understanding coverage across many video types:
+Use the `"full"` profile (the default config) when you want broad understanding coverage across many video types:
 
 ```python
 from videopython.ai import VideoAnalysisConfig, VideoAnalyzer
 
-config = VideoAnalysisConfig.rich_understanding_preset()
+config = VideoAnalysisConfig.for_profile("full")
 analysis = VideoAnalyzer(config=config).analyze_path("video.mp4")
 ```
 
-The preset enables every analyzer (`audio_to_text`, `audio_classifier`,
+The `"full"` profile enables every analyzer (`audio_to_text`, `audio_classifier`,
 `semantic_scene_detector`, `scene_vlm`, `face_tracker`) and is
 equivalent to bare `VideoAnalysisConfig()`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.50.1"
+version = "0.51.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_auto_edit.py
+++ b/src/tests/ai/test_auto_edit.py
@@ -110,8 +110,10 @@ class _StubPlanner:
         self.plan_dict = plan_dict
         self.calls: list[dict[str, Any]] = []
 
-    def generate_json(self, *, system: str, parts: list[Any], schema: dict[str, Any]) -> dict[str, Any]:
-        self.calls.append({"system": system, "parts": parts, "schema": schema})
+    def generate_json(
+        self, *, system: str, text: str, images: list[Any] | None, schema: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.calls.append({"system": system, "text": text, "images": images, "schema": schema})
         return json.loads(json.dumps(self.plan_dict))  # deep copy
 
 
@@ -247,8 +249,8 @@ def test_autoeditor_full_loop_returns_valid_edit() -> None:
     assert edit.segments[0].start == 0.0
     edit.validate()  # raises if the produced plan is not actually runnable
     assert planner.calls, "planner should have been invoked"
-    parts = planner.calls[0]["parts"]
-    assert any(getattr(p, "image", None) is not None for p in parts), "planner should receive keyframes"
+    images = planner.calls[0]["images"]
+    assert images and all(img is not None for img in images), "planner should receive keyframes"
 
 
 def test_autoeditor_unknown_id_exhausts_rounds() -> None:
@@ -268,8 +270,10 @@ class _SequencePlanner:
         self.plans = list(plans)
         self.calls: list[dict[str, Any]] = []
 
-    def generate_json(self, *, system: str, parts: list[Any], schema: dict[str, Any]) -> dict[str, Any]:
-        self.calls.append({"system": system, "parts": parts, "schema": schema})
+    def generate_json(
+        self, *, system: str, text: str, images: list[Any] | None, schema: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.calls.append({"system": system, "text": text, "images": images, "schema": schema})
         idx = min(len(self.calls) - 1, len(self.plans) - 1)
         return json.loads(json.dumps(self.plans[idx]))
 
@@ -375,7 +379,9 @@ def test_autoeditor_planner_error_is_retried() -> None:
         def __init__(self) -> None:
             self.calls = 0
 
-        def generate_json(self, *, system: str, parts: list[Any], schema: dict[str, Any]) -> dict[str, Any]:
+        def generate_json(
+            self, *, system: str, text: str, images: list[Any] | None, schema: dict[str, Any]
+        ) -> dict[str, Any]:
             self.calls += 1
             if self.calls == 1:
                 raise PlannerError("unparseable output")
@@ -391,7 +397,9 @@ def test_autoeditor_infra_error_propagates() -> None:
     analysis, _ = _real_video_analysis()
 
     class _BrokenPlanner:
-        def generate_json(self, *, system: str, parts: list[Any], schema: dict[str, Any]) -> dict[str, Any]:
+        def generate_json(
+            self, *, system: str, text: str, images: list[Any] | None, schema: dict[str, Any]
+        ) -> dict[str, Any]:
             raise RuntimeError("connection refused")
 
     with pytest.raises(RuntimeError, match="connection refused"):

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -132,15 +132,13 @@ class TestTimingSynchronizer:
 
         assert sync.min_speed == 0.8
         assert sync.max_speed == 1.3
-        assert sync.gap_threshold == 0.1
 
     def test_initialization_custom(self):
         """Test custom initialization values."""
-        sync = TimingSynchronizer(min_speed=0.5, max_speed=2.0, gap_threshold=0.2)
+        sync = TimingSynchronizer(min_speed=0.5, max_speed=2.0)
 
         assert sync.min_speed == 0.5
         assert sync.max_speed == 2.0
-        assert sync.gap_threshold == 0.2
 
     def test_initialization_invalid(self):
         """Test that invalid parameters raise errors."""
@@ -282,31 +280,6 @@ class TestTimingSynchronizer:
         peak = float(np.max(np.abs(result.data)))
         # sample_audio peaks at 0.5; with no overlap, output peak should match
         assert abs(peak - 0.5) < 0.01
-
-    def test_check_overlaps_no_overlaps(self):
-        """Test check_overlaps with non-overlapping segments."""
-        sync = TimingSynchronizer()
-        start_times = [0.0, 2.0, 4.0]
-        durations = [1.0, 1.0, 1.0]
-
-        overlaps = sync.check_overlaps(start_times, durations)
-
-        assert len(overlaps) == 0
-
-    def test_check_overlaps_with_overlaps(self):
-        """Test check_overlaps with overlapping segments."""
-        sync = TimingSynchronizer()
-        start_times = [0.0, 1.5, 3.0]
-        durations = [2.0, 2.0, 1.0]  # First overlaps with second
-
-        overlaps = sync.check_overlaps(start_times, durations)
-
-        assert len(overlaps) >= 1
-        # First pair should overlap
-        first_overlap = overlaps[0]
-        assert first_overlap[0] == 0  # First segment index
-        assert first_overlap[1] == 1  # Second segment index
-        assert first_overlap[2] > 0  # Overlap duration
 
 
 class TestDubbingResult:
@@ -1815,107 +1788,8 @@ class TestVoiceSampleCache:
             assert call["voice_sample_path"] is None
 
 
-class TestReplaceAudioStream:
-    """Tests for the ffmpeg audio-stream replacement helper."""
-
-    def test_missing_video_raises(self, tmp_path):
-        from videopython.ai.dubbing.remux import replace_audio_stream
-
-        audio = tmp_path / "a.wav"
-        audio.write_bytes(b"")
-
-        with pytest.raises(FileNotFoundError, match="Video file not found"):
-            replace_audio_stream(tmp_path / "missing.mp4", audio, tmp_path / "out.mp4")
-
-    def test_missing_audio_raises(self, tmp_path):
-        from videopython.ai.dubbing.remux import replace_audio_stream
-
-        video = tmp_path / "v.mp4"
-        video.write_bytes(b"")
-
-        with pytest.raises(FileNotFoundError, match="Audio file not found"):
-            replace_audio_stream(video, tmp_path / "missing.wav", tmp_path / "out.mp4")
-
-    def test_ffmpeg_failure_raises_remux_error(self, tmp_path, monkeypatch):
-        """Non-zero ffmpeg exit code is wrapped in RemuxError with stderr."""
-        import videopython.ai.dubbing.remux as remux_mod
-        from videopython.base.exceptions import FFmpegRunError
-
-        video = tmp_path / "v.mp4"
-        video.write_bytes(b"not a real video")
-        audio = tmp_path / "a.wav"
-        audio.write_bytes(b"not a real wav")
-
-        def fake_run(cmd, *, stdin=None):
-            raise FFmpegRunError("simulated ffmpeg error")
-
-        monkeypatch.setattr(remux_mod._ffmpeg, "run", fake_run)
-
-        with pytest.raises(remux_mod.RemuxError, match="simulated ffmpeg error"):
-            remux_mod.replace_audio_stream(video, audio, tmp_path / "out.mp4")
-
-    def test_ffmpeg_command_structure(self, tmp_path, monkeypatch):
-        """ffmpeg is invoked with stream-copy video and mapped audio."""
-        import videopython.ai.dubbing.remux as remux_mod
-
-        video = tmp_path / "v.mp4"
-        video.write_bytes(b"fake")
-        audio = tmp_path / "a.wav"
-        audio.write_bytes(b"fake")
-        out = tmp_path / "out.mp4"
-
-        captured: dict = {}
-
-        def fake_run(cmd, *, stdin=None):
-            captured["cmd"] = cmd
-            return b""
-
-        monkeypatch.setattr(remux_mod._ffmpeg, "run", fake_run)
-
-        remux_mod.replace_audio_stream(video, audio, out)
-
-        cmd = captured["cmd"]
-        assert cmd[0] == "ffmpeg"
-        assert "-c:v" in cmd and cmd[cmd.index("-c:v") + 1] == "copy"
-        assert "-map" in cmd
-        # Three -map args: video, dubbed audio, subtitles (?-tolerant)
-        map_indices = [i for i, v in enumerate(cmd) if v == "-map"]
-        assert len(map_indices) == 3
-        assert cmd[map_indices[0] + 1] == "0:v:0"
-        assert cmd[map_indices[1] + 1] == "1:a:0"
-        assert cmd[map_indices[2] + 1] == "0:s?"
-        assert "-c:s" in cmd and cmd[cmd.index("-c:s") + 1] == "copy"
-        assert "-shortest" in cmd
-        assert cmd[-1] == str(out)
-
-    def test_keep_original_audio_adds_extra_map(self, tmp_path, monkeypatch):
-        """``keep_original_audio=True`` adds ``-map 0:a?`` between dub and subs."""
-        import videopython.ai.dubbing.remux as remux_mod
-
-        video = tmp_path / "v.mp4"
-        video.write_bytes(b"fake")
-        audio = tmp_path / "a.wav"
-        audio.write_bytes(b"fake")
-        out = tmp_path / "out.mp4"
-
-        captured: dict = {}
-
-        def fake_run(cmd, *, stdin=None):
-            captured["cmd"] = cmd
-            return b""
-
-        monkeypatch.setattr(remux_mod._ffmpeg, "run", fake_run)
-
-        remux_mod.replace_audio_stream(video, audio, out, keep_original_audio=True)
-
-        cmd = captured["cmd"]
-        map_args = [cmd[i + 1] for i, v in enumerate(cmd) if v == "-map"]
-        # Dubbed audio first (default track), then original, then subs.
-        assert map_args == ["0:v:0", "1:a:0", "0:a?", "0:s?"]
-
-
 class TestReplaceAudioStreamFromAudio:
-    """Tests for the streaming-audio variant of replace_audio_stream."""
+    """Tests for replace_audio_stream_from_audio (the in-memory audio remux)."""
 
     def test_missing_video_raises(self, tmp_path, sample_audio):
         from videopython.ai.dubbing.remux import replace_audio_stream_from_audio
@@ -2802,20 +2676,20 @@ class TestStrictQualityIntegration:
 
 
 class TestDubberTranslatorKwarg:
-    """VideoDubber forwards the translator choice into the pipeline config."""
+    """VideoDubber forwards the translator model kwarg into the pipeline config."""
 
-    def test_dubber_propagates_translator_kwarg(self):
+    def test_dubber_propagates_translator_model_kwarg(self):
         from videopython.ai.dubbing import VideoDubber
 
-        dubber = VideoDubber(translator="ollama")
+        dubber = VideoDubber(translator_model="gemma3:27b")
         dubber._init_local_pipeline()
 
-        assert dubber._local_pipeline.config.translator == "ollama"
+        assert dubber._local_pipeline.config.translator_model == "gemma3:27b"
 
-    def test_dubber_default_translator_is_auto(self):
+    def test_dubber_default_translator_model_is_none(self):
         from videopython.ai.dubbing import VideoDubber
 
-        assert VideoDubber().config.translator == "auto"
+        assert VideoDubber().config.translator_model is None
 
 
 class TestTranslationFailuresOnResult:

--- a/src/tests/ai/test_ollama_backend.py
+++ b/src/tests/ai/test_ollama_backend.py
@@ -12,7 +12,7 @@ import pytest
 from PIL import Image
 
 from videopython.ai._ollama import KEYFRAME_MAX_DIM, _downscale, _encode_png_b64
-from videopython.ai.auto_edit import ImagePart, OllamaVisionLLM, Part, PlannerError, TextPart
+from videopython.ai.auto_edit import OllamaVisionLLM, PlannerError
 
 
 class _FakeClient:
@@ -37,9 +37,9 @@ def test_generate_json_builds_messages_and_parses() -> None:
     fake = _FakeClient('{"segments": [{"scene_id": "x"}]}')
     _inject(backend, fake)
     schema = {"type": "object", "properties": {}}
-    parts: list[Part] = [TextPart("brief"), ImagePart(image=np.zeros((4, 4, 3), dtype=np.uint8), label="x")]
+    images = [np.zeros((4, 4, 3), dtype=np.uint8)]
 
-    out = backend.generate_json(system="sys", parts=parts, schema=schema)
+    out = backend.generate_json(system="sys", text="brief", images=images, schema=schema)
 
     assert out == {"segments": [{"scene_id": "x"}]}
     call = fake.calls[0]
@@ -56,7 +56,7 @@ def test_no_images_omits_images_key() -> None:
     backend = OllamaVisionLLM()
     fake = _FakeClient("{}")
     _inject(backend, fake)
-    backend.generate_json(system="s", parts=[TextPart("only text")], schema={})
+    backend.generate_json(system="s", text="only text", images=None, schema={})
     assert "images" not in fake.calls[0]["messages"][1]
 
 
@@ -64,7 +64,7 @@ def test_non_json_raises_planner_error() -> None:
     backend = OllamaVisionLLM()
     _inject(backend, _FakeClient("I cannot help with that."))
     with pytest.raises(PlannerError):
-        backend.generate_json(system="s", parts=[TextPart("t")], schema={})
+        backend.generate_json(system="s", text="t", images=None, schema={})
 
 
 def test_encode_png_b64_roundtrips() -> None:

--- a/src/tests/ai/test_ops_registration.py
+++ b/src/tests/ai/test_ops_registration.py
@@ -1,0 +1,48 @@
+"""Regression test: AI ops must be in the op registry / plan schema.
+
+``FaceTrackingCrop`` and ``ObjectDetectionOverlay`` register only as an import
+side-effect of their class definition, and ``ai/__init__`` re-exports them
+lazily. Before the ``ai.ops`` self-registration shim (imported by
+``ai.auto_edit``), a fresh process that built ``EditPlan.json_schema()`` /
+``Operation.llm_registry()`` -- e.g. the auto-edit planner or the MCP
+``edit_plan_schema`` resource -- silently omitted both ops, so the LLM could
+never select them and ``Operation.get("face_crop")`` raised "Unknown op_id".
+
+These run in a clean subprocess so no prior import in the session's interpreter
+can mask the bug.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_AI_OP_IDS = ("face_crop", "object_detection_overlay")
+
+
+def _run(code: str) -> str:
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def test_auto_edit_import_registers_ai_ops() -> None:
+    """Importing the auto_edit package alone registers the AI ops."""
+    out = _run(
+        "import videopython.ai.auto_edit  # noqa: F401\n"
+        "from videopython.editing.operation import Operation\n"
+        "print(' '.join(sorted(Operation.llm_registry())))\n"
+    )
+    registered = set(out.split())
+    for op_id in _AI_OP_IDS:
+        assert op_id in registered, f"{op_id!r} missing from llm_registry; registered={sorted(registered)}"
+
+
+def test_edit_plan_schema_includes_ai_ops() -> None:
+    """The strict EditPlan schema (used by the planner and MCP) lists the AI ops."""
+    out = _run(
+        "import json\n"
+        "from videopython.ai.auto_edit import EditPlan\n"
+        "print(json.dumps(EditPlan.json_schema(strict=True)))\n"
+    )
+    for op_id in _AI_OP_IDS:
+        assert f'"{op_id}"' in out, f"{op_id!r} missing from EditPlan.json_schema()"

--- a/src/tests/ai/test_translator.py
+++ b/src/tests/ai/test_translator.py
@@ -9,7 +9,6 @@ from typing import Any
 from videopython.ai.generation.translation import (
     LANGUAGE_NAMES,
     OllamaTranslator,
-    TranslationBackend,
     _build_system_prompt,
     _build_user_prompt,
     _chunk_segment_indices,
@@ -117,11 +116,9 @@ def test_non_translatable_segments_skipped() -> None:
     assert translator.translation_failures == []
 
 
-def test_unload_and_protocol() -> None:
+def test_unload_and_languages() -> None:
     translator, _ = _translator_with(["{}"])
-    assert isinstance(translator, TranslationBackend)
     translator.unload()  # idempotent
-    assert OllamaTranslator.supports("en", "es")
     assert OllamaTranslator.get_supported_languages() == LANGUAGE_NAMES
 
 

--- a/src/tests/test_packaging_extras.py
+++ b/src/tests/test_packaging_extras.py
@@ -220,7 +220,7 @@ def test_import_ai_package_does_not_load_leaf_modules() -> None:
 
 
 def test_import_one_symbol_does_not_load_siblings() -> None:
-    """Importing ObjectDetector ([vision]) must not pull audio/generation siblings."""
+    """Importing ObjectDetector must not pull audio/generation sibling leaf modules."""
     pulled = _import_in_clean_ai("from videopython.ai.understanding import ObjectDetector")
     siblings = {
         m
@@ -245,7 +245,7 @@ def test_require_raises_with_extra_and_pip_hint() -> None:
     from videopython.ai._optional import require
 
     with pytest.raises(ImportError) as exc_info:
-        require("definitely_not_a_real_module_xyz", "ai", feature="TextToSpeech")
+        require("definitely_not_a_real_module_xyz", feature="TextToSpeech")
 
     msg = str(exc_info.value)
     assert "pip install" in msg
@@ -255,7 +255,7 @@ def test_require_raises_with_extra_and_pip_hint() -> None:
 def test_require_returns_module_when_present() -> None:
     from videopython.ai._optional import require
 
-    mod = require("json", "asr")
+    mod = require("json")
     import json
 
     assert mod is json

--- a/src/videopython/ai/__init__.py
+++ b/src/videopython/ai/__init__.py
@@ -2,12 +2,13 @@
 
 Every public symbol is re-exported lazily via PEP 562 ``__getattr__`` so that
 ``import videopython.ai`` (or ``from videopython.ai import X``) loads ONLY the
-leaf module backing the requested symbol — not every sibling. This is what
-makes the granular extras (``asr``, ``vision``, ``tts``, ``generation``,
-``dub``, ...) usable: with only ``[asr]`` installed, ``from videopython.ai
-import AudioToText`` works, while touching ``TextToSpeech`` raises a clear
-``[tts]``-pointing ``ImportError`` at attribute access instead of failing the
-whole package import.
+leaf module backing the requested symbol — not every sibling. All AI capabilities
+ship in the single ``[ai]`` extra; the laziness keeps ``import videopython`` (and
+importing one leaf class) light by deferring the heavy ML imports (torch /
+transformers / diffusers / ultralytics) until a symbol is actually used. When
+``[ai]`` is not installed, touching a symbol raises a clear
+``pip install 'videopython[ai]'``-pointing ``ImportError`` at attribute access
+instead of failing the whole package import.
 
 The ``TYPE_CHECKING`` block below keeps the eager imports visible to mypy and
 IDEs (static autocompletion / re-export checking) without executing them at
@@ -28,11 +29,9 @@ if TYPE_CHECKING:
     from .auto_edit import AutoEditor as AutoEditor
     from .auto_edit import EditCatalog as EditCatalog
     from .auto_edit import EditPlan as EditPlan
-    from .auto_edit import ImagePart as ImagePart
     from .auto_edit import OllamaVisionLLM as OllamaVisionLLM
     from .auto_edit import PlannerError as PlannerError
     from .auto_edit import StructuredVisionLLM as StructuredVisionLLM
-    from .auto_edit import TextPart as TextPart
     from .auto_edit import build_catalog as build_catalog
     from .effects import ObjectDetectionOverlay as ObjectDetectionOverlay
     from .generation import ImageToVideo as ImageToVideo
@@ -82,8 +81,6 @@ _exports: dict[str, str] = {
     "OllamaVisionLLM": ".auto_edit",
     "StructuredVisionLLM": ".auto_edit",
     "PlannerError": ".auto_edit",
-    "TextPart": ".auto_edit",
-    "ImagePart": ".auto_edit",
     "EditCatalog": ".auto_edit",
     "EditPlan": ".auto_edit",
     "build_catalog": ".auto_edit",

--- a/src/videopython/ai/_ollama.py
+++ b/src/videopython/ai/_ollama.py
@@ -35,7 +35,7 @@ class OllamaStructuredClient:
 
     def _get_client(self) -> Any:
         if self._client is None:
-            ollama = require("ollama", "ai", feature="Ollama")
+            ollama = require("ollama", feature="Ollama")
             self._client = ollama.Client(host=self.host)
         return self._client
 

--- a/src/videopython/ai/_optional.py
+++ b/src/videopython/ai/_optional.py
@@ -6,12 +6,11 @@ method that needs it (there are no top-level ``import torch``/``transformers``/
 importable on a slim install: importing ``ai.understanding.objects`` only needs
 core deps until a detector is actually constructed.
 
-The granular extras (``asr``, ``vision``, ``tts``, ...) partition those heavy
-deps. When a user installs only one extra and reaches a code path needing a dep
-from another, the bare ``import`` would raise a stock ``ModuleNotFoundError``
-with no hint about which extra restores it. :func:`require` wraps the import and
-turns that into an actionable ``ImportError`` pointing at the right
-``pip install 'videopython[<extra>]'``.
+All those heavy deps ship in the single ``[ai]`` extra. When it isn't installed
+and a code path reaches one of them, the bare ``import`` would raise a stock
+``ModuleNotFoundError`` with no hint about how to fix it. :func:`require` wraps
+the import and turns that into an actionable ``ImportError`` pointing at
+``pip install 'videopython[ai]'``.
 """
 
 from __future__ import annotations
@@ -21,15 +20,13 @@ from types import ModuleType
 from typing import Callable
 
 
-def require(module: str, extra: str, *, feature: str | None = None) -> ModuleType:
-    """Import ``module`` or raise a clear, extra-pointing ``ImportError``.
+def require(module: str, *, feature: str | None = None) -> ModuleType:
+    """Import ``module`` or raise a clear, ``[ai]``-pointing ``ImportError``.
 
     Args:
         module: Dotted module name to import (e.g. ``"chatterbox.mtl_tts"``,
             ``"torch"``). The fully-imported module object is returned so the
             call site can bind the symbols it needs.
-        extra: The videopython extra that ships ``module`` (e.g. ``"tts"``,
-            ``"asr"``). Surfaced verbatim in the install hint.
         feature: Optional human-readable feature name for the message head. When
             omitted the top-level package of ``module`` is used.
 
@@ -38,14 +35,14 @@ def require(module: str, extra: str, *, feature: str | None = None) -> ModuleTyp
 
     Raises:
         ImportError: If ``module`` cannot be imported. The message always
-            contains the extra name and a ``pip install 'videopython[<extra>]'``
-            hint so the caller knows exactly how to fix it.
+            contains a ``pip install 'videopython[ai]'`` hint so the caller
+            knows exactly how to fix it.
     """
     try:
         return importlib.import_module(module)
     except ImportError as exc:
         label = feature or module.split(".")[0]
-        raise ImportError(f"{label} requires the '{extra}' extra: pip install 'videopython[{extra}]'") from exc
+        raise ImportError(f"{label} requires the 'ai' extra: pip install 'videopython[ai]'") from exc
 
 
 def lazy_exports(package: str, exports: dict[str, str]) -> tuple[Callable[[str], object], Callable[[], list[str]]]:
@@ -53,8 +50,9 @@ def lazy_exports(package: str, exports: dict[str, str]) -> tuple[Callable[[str],
 
     Re-exports a set of public symbols lazily: the submodule backing a symbol is
     imported only on first attribute access, so importing the package does not
-    pull in any sibling leaf module (this is what keeps the granular ``ai``
-    extras independently installable).
+    pull in any sibling leaf module. This keeps ``import videopython`` (and
+    importing a single leaf class) light by deferring the heavy ML imports
+    (torch / transformers / diffusers / ultralytics) until a symbol is used.
 
     Args:
         package: The ``__name__`` of the package defining the re-exports. Used

--- a/src/videopython/ai/_predictor.py
+++ b/src/videopython/ai/_predictor.py
@@ -1,21 +1,27 @@
-"""Context-manager mixin for VRAM-releasing predictors.
+"""Context-manager base with a default VRAM-releasing ``unload()``.
 
-Every predictor under ``videopython.ai`` already exposes an ``unload()`` method
-that drops its model reference (``self._model = None``, plus any processor /
-pipeline fields) and calls :func:`videopython.ai._device.release_device_memory`
-to free the allocator cache. Today that has to be called by hand -- the dubbing
-pipeline, for example, unloads each stage manually once it is done.
+Every predictor under ``videopython.ai`` holds a lazily-loaded model (and
+sometimes a processor / pipeline / VAD field) on the selected device, and needs
+to drop those references and free the allocator cache when done. That teardown
+is mechanical and identical across predictors: set the model field(s) to
+``None`` and call :func:`videopython.ai._device.release_device_memory`.
 
-:class:`ManagedPredictor` makes that bookkeeping automatic by turning any such
-predictor into a context manager::
+:class:`ManagedPredictor` provides that as a default ``unload()`` driven by two
+class attributes -- ``_model_attrs`` (the fields holding model state) and
+``_device_attr`` (the field holding the device) -- and turns any predictor into
+a context manager::
 
     with SceneVLM(...) as vlm:
         ...  # use vlm
     # vlm.unload() has fired here, releasing VRAM
 
-The mixin is deliberately tiny and dependency-free: it imports no torch /
-transformers / ultralytics and holds no state, so it is safe to mix into any
-predictor class regardless of how it is constructed.
+Subclasses with non-default model fields just declare ``_model_attrs``; those
+whose teardown isn't "null the fields + release" (e.g. delegating to a client's
+own ``unload()``) override ``unload()`` instead.
+
+The base imports no torch / transformers / ultralytics (``release_device_memory``
+defers its torch import), so it stays safe to mix into any predictor regardless
+of how it is constructed.
 """
 
 from __future__ import annotations
@@ -23,23 +29,33 @@ from __future__ import annotations
 from types import TracebackType
 from typing import TYPE_CHECKING, Literal
 
+from videopython.ai._device import release_device_memory
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
 
 class ManagedPredictor:
-    """Adds ``with``-statement support that calls ``unload()`` on exit.
+    """Adds a default ``unload()`` plus ``with``-statement support.
 
-    Subclasses MUST define their own ``unload()`` method; this mixin does not
-    provide one. The expected contract is the one shared by every predictor in
-    ``videopython.ai``: ``unload()`` clears the model reference(s) and releases
-    device memory, and is safe to call more than once (including before the
-    model was ever loaded).
-
-    ``__exit__`` always returns ``False`` so exceptions raised inside the ``with``
-    block are never suppressed -- ``unload()`` runs on both the success and
-    failure paths.
+    ``unload()`` clears each attribute named in ``_model_attrs`` to ``None`` and
+    releases the cache for the device named by ``_device_attr``. It is idempotent
+    (safe before the model is loaded and on repeated calls). ``__exit__`` always
+    returns ``False`` so exceptions inside the ``with`` block propagate --
+    ``unload()`` runs on both the success and failure paths.
     """
+
+    # Attributes holding model state, cleared to None on unload. Override per
+    # predictor (e.g. ("_model", "_processor")).
+    _model_attrs: tuple[str, ...] = ("_model",)
+    # Attribute holding the resolved device passed to release_device_memory.
+    _device_attr: str = "device"
+
+    def unload(self) -> None:
+        """Drop the model reference(s) and release device memory. Idempotent."""
+        for attr in self._model_attrs:
+            setattr(self, attr, None)
+        release_device_memory(getattr(self, self._device_attr, None))
 
     def __enter__(self) -> Self:
         return self
@@ -50,5 +66,5 @@ class ManagedPredictor:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> Literal[False]:
-        self.unload()  # type: ignore[attr-defined]
+        self.unload()
         return False

--- a/src/videopython/ai/auto_edit/__init__.py
+++ b/src/videopython/ai/auto_edit/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from .backend import ImagePart, Part, PlannerError, StructuredVisionLLM, TextPart
+import videopython.ai.ops  # noqa: F401  -- registers the AI ops (face_crop, object_detection_overlay)
+
+from .backend import PlannerError, StructuredVisionLLM
 from .catalog import build_catalog
 from .editor import AutoEditError, AutoEditor
 from .local import OllamaVisionLLM
@@ -16,13 +18,10 @@ __all__ = [
     "CatalogScene",
     "EditCatalog",
     "EditPlan",
-    "ImagePart",
     "OllamaVisionLLM",
-    "Part",
     "PlanSegment",
     "PlannerError",
     "StructuredVisionLLM",
-    "TextPart",
     "UnknownSceneIdsError",
     "build_catalog",
     "resolve_plan",

--- a/src/videopython/ai/auto_edit/backend.py
+++ b/src/videopython/ai/auto_edit/backend.py
@@ -2,28 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-import numpy as np
-
-
-@dataclass
-class TextPart:
-    """A text chunk in a planner prompt."""
-
-    text: str
-
-
-@dataclass
-class ImagePart:
-    """A keyframe in a planner prompt: an RGB (H, W, 3) uint8 array."""
-
-    image: np.ndarray
-    label: str | None = None
-
-
-Part = TextPart | ImagePart
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class PlannerError(RuntimeError):
@@ -32,6 +14,15 @@ class PlannerError(RuntimeError):
 
 @runtime_checkable
 class StructuredVisionLLM(Protocol):
-    """Returns schema-shaped JSON from interleaved text + images; raises PlannerError on bad output."""
+    """Returns schema-shaped JSON from a system prompt + text + optional keyframes.
 
-    def generate_json(self, *, system: str, parts: list[Part], schema: dict[str, Any]) -> dict[str, Any]: ...
+    The signature mirrors
+    :meth:`videopython.ai._ollama.OllamaStructuredClient.generate_json`, so any
+    structured-generation client satisfies it structurally. Implementations
+    raise :class:`PlannerError` on unusable output (the editor retries those);
+    infra errors should propagate so they are not silently retried.
+    """
+
+    def generate_json(
+        self, *, system: str, text: str, images: list[np.ndarray] | None, schema: dict[str, Any]
+    ) -> dict[str, Any]: ...

--- a/src/videopython/ai/auto_edit/editor.py
+++ b/src/videopython/ai/auto_edit/editor.py
@@ -8,12 +8,14 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import ValidationError
 
-from .backend import ImagePart, Part, PlannerError, StructuredVisionLLM, TextPart
+from .backend import PlannerError, StructuredVisionLLM
 from .catalog import build_catalog
 from .models import CatalogBundle, CatalogScene, EditPlan
 from .resolve import UnknownSceneIdsError, resolve_plan
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from videopython.ai.video_analysis import VideoAnalysis, VideoAnalyzer
     from videopython.base.video import VideoMetadata
     from videopython.editing import VideoEdit
@@ -61,13 +63,13 @@ class AutoEditor:
         metadata = _metadata_by_source(analyses)
         run_context = _merge_context(analyses, context)
         schema = EditPlan.json_schema(strict=True)
-        base_parts = _build_parts(brief, bundle)
+        base_text, images = _build_prompt(brief, bundle)
 
         feedback: str | None = None
         for _ in range(self.max_rounds):
-            parts = base_parts if feedback is None else [*base_parts, TextPart(feedback)]
+            text = base_text if feedback is None else f"{base_text}\n\n{feedback}"
             try:
-                raw = self.planner.generate_json(system=_SYSTEM_PROMPT, parts=parts, schema=schema)
+                raw = self.planner.generate_json(system=_SYSTEM_PROMPT, text=text, images=images or None, schema=schema)
                 edit = resolve_plan(EditPlan.model_validate(raw), bundle.catalog)
             except (PlannerError, ValidationError, UnknownSceneIdsError) as exc:
                 feedback = _shape_feedback(exc)
@@ -89,14 +91,16 @@ class AutoEditor:
         return self._analyzer
 
 
-def _build_parts(brief: str, bundle: CatalogBundle) -> list[Part]:
-    parts: list[Part] = [TextPart(f"Brief: {brief}\n\nCandidate scenes:")]
+def _build_prompt(brief: str, bundle: CatalogBundle) -> tuple[str, list[np.ndarray]]:
+    """The planner prompt: scene-line text plus the keyframes, in catalog order."""
+    lines = [f"Brief: {brief}\n\nCandidate scenes:"]
+    images: list[np.ndarray] = []
     for scene in bundle.catalog.scenes:
-        parts.append(TextPart(_scene_line(scene)))
+        lines.append(_scene_line(scene))
         frame = bundle.keyframes.get(scene.id)
         if frame is not None:
-            parts.append(ImagePart(image=frame, label=scene.id))
-    return parts
+            images.append(frame)
+    return "\n\n".join(lines), images
 
 
 def _scene_line(scene: CatalogScene) -> str:

--- a/src/videopython/ai/auto_edit/local.py
+++ b/src/videopython/ai/auto_edit/local.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from videopython.ai._ollama import OllamaError, OllamaStructuredClient
 
-from .backend import ImagePart, Part, PlannerError, TextPart
+from .backend import PlannerError
+
+if TYPE_CHECKING:
+    import numpy as np
 
 DEFAULT_OLLAMA_MODEL = "gemma3:27b"
 
@@ -19,6 +22,10 @@ class OllamaVisionLLM:
     every model supports schema conditioning -- ``gemma3:27b`` is verified working;
     some builds (e.g. certain MLX ones) fail it. ``ollama pull <model>`` first;
     ``options`` are extra generation options merged over ``temperature=0``.
+
+    Thin wrapper over the shared :class:`OllamaStructuredClient`: its only job is
+    to translate :class:`OllamaError` into the :class:`PlannerError` the editor
+    retries on.
     """
 
     def __init__(
@@ -30,9 +37,9 @@ class OllamaVisionLLM:
     ) -> None:
         self._client = OllamaStructuredClient(model=model, host=host, options=options)
 
-    def generate_json(self, *, system: str, parts: list[Part], schema: dict[str, Any]) -> dict[str, Any]:
-        text = "\n\n".join(part.text for part in parts if isinstance(part, TextPart))
-        images = [part.image for part in parts if isinstance(part, ImagePart)]
+    def generate_json(
+        self, *, system: str, text: str, images: list[np.ndarray] | None, schema: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
             return self._client.generate_json(system=system, text=text, schema=schema, images=images or None)
         except OllamaError as exc:

--- a/src/videopython/ai/dubbing/__init__.py
+++ b/src/videopython/ai/dubbing/__init__.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from videopython.ai.dubbing.quality import TranscriptQuality as TranscriptQuality
     from videopython.ai.dubbing.quality import assess_transcript as assess_transcript
     from videopython.ai.dubbing.timing import TimingSynchronizer as TimingSynchronizer
-    from videopython.ai.generation.translation import UnsupportedLanguageError as UnsupportedLanguageError
 
 # Public symbol -> fully-qualified module that defines it.
 _exports: dict[str, str] = {
@@ -45,7 +44,6 @@ _exports: dict[str, str] = {
     "GarbageTranscriptError": "videopython.ai.dubbing.quality",
     "TranscriptQuality": "videopython.ai.dubbing.quality",
     "assess_transcript": "videopython.ai.dubbing.quality",
-    "UnsupportedLanguageError": "videopython.ai.generation.translation",
 }
 
 __all__ = list(_exports)

--- a/src/videopython/ai/dubbing/config.py
+++ b/src/videopython/ai/dubbing/config.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-TranslatorChoice = Literal["auto", "ollama"]
 WhisperModel = Literal["tiny", "base", "small", "medium", "large", "turbo"]
 
 
@@ -47,9 +46,8 @@ class DubbingConfig(BaseModel):
             WARNING but processing continues. Either way the
             :class:`TranscriptQuality` is exposed on ``DubbingResult`` for
             inspection.
-        translator: Translation backend; ``"auto"`` and ``"ollama"`` both use the
-            local Ollama text model. ``translator_model`` sets the Ollama tag and
-            ``translator_host`` the server URL.
+        translator_model: Ollama tag for the translation model (``None`` uses the
+            translator's default). ``translator_host`` sets the server URL.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -62,7 +60,6 @@ class DubbingConfig(BaseModel):
     logprob_threshold: float | None = -1.0
     vocabulary: list[str] | None = None
     strict_quality: bool = False
-    translator: TranslatorChoice = "auto"
     translator_model: str | None = None
     translator_host: str | None = None
 
@@ -75,5 +72,5 @@ class DubbingConfig(BaseModel):
             "device": self.device.lower() if isinstance(self.device, str) else "auto",
             "low_memory": self.low_memory,
             "whisper_model": self.whisper_model,
-            "translator": self.translator,
+            "translator_model": self.translator_model,
         }

--- a/src/videopython/ai/dubbing/dubber.py
+++ b/src/videopython/ai/dubbing/dubber.py
@@ -36,8 +36,9 @@ class VideoDubber:
             raise TypeError("Pass either `config=` or knob kwargs, not both")
         self.config = config or DubbingConfig(**kwargs)
         # Optional injected speech backend. None -> the pipeline lazily builds
-        # the local chatterbox-backed TextToSpeech (requires the [tts] extra).
-        # Inject a SpeechBackend to dub with only [dub] installed.
+        # the local chatterbox-backed TextToSpeech (from the [ai] extra). Inject
+        # a SpeechBackend to run synthesis out-of-process (e.g. a remote/Modal
+        # function) without loading chatterbox here.
         self._tts_backend = tts_backend
         self._local_pipeline: Any = None
         logger.info(

--- a/src/videopython/ai/dubbing/loudness.py
+++ b/src/videopython/ai/dubbing/loudness.py
@@ -64,7 +64,7 @@ def loudness_match(target: Audio, reference: Audio) -> Audio:
 
     from videopython.ai._optional import require
 
-    pyloudnorm = require("pyloudnorm", "ai", feature="loudness matching")
+    pyloudnorm = require("pyloudnorm", feature="loudness matching")
 
     target_lufs = pyloudnorm.Meter(target.metadata.sample_rate).integrated_loudness(target.data)
     reference_lufs = pyloudnorm.Meter(reference.metadata.sample_rate).integrated_loudness(reference.data)

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -48,9 +48,9 @@ class LocalDubbingPipeline:
         self.config = config or DubbingConfig(**kwargs)
         # Injected speech backend (a SpeechBackend, e.g. a remote/out-of-process
         # synthesizer). When None, _init_tts lazily constructs the local
-        # chatterbox-backed TextToSpeech — which requires the [tts] extra.
-        # Supplying a backend lets dubbing run with only [dub] installed (no
-        # chatterbox in the process).
+        # chatterbox-backed TextToSpeech (from the [ai] extra). Supplying a
+        # backend lets dubbing run synthesis out-of-process without loading
+        # chatterbox here.
         self._tts_backend = tts_backend
         logger.info(
             "LocalDubbingPipeline initialized with %s%s",
@@ -211,8 +211,8 @@ class LocalDubbingPipeline:
         When a ``tts_backend`` was injected at construction it is used as-is
         (it owns its own language handling). Otherwise the local
         chatterbox-backed :class:`TextToSpeech` is constructed for ``language``
-        — importing it requires the ``[tts]`` extra; a bare ``[dub]`` install
-        raises a clear ``[tts]``-pointing ``ImportError`` at this point.
+        — importing it requires the ``[ai]`` extra and raises a clear
+        ``pip install 'videopython[ai]'``-pointing ``ImportError`` at this point.
         """
         if self._tts_backend is not None:
             self._tts = self._tts_backend

--- a/src/videopython/ai/dubbing/remux.py
+++ b/src/videopython/ai/dubbing/remux.py
@@ -38,71 +38,6 @@ def _build_stream_maps(keep_original_audio: bool) -> list[str]:
     return maps
 
 
-def replace_audio_stream(
-    video_path: str | Path,
-    audio_path: str | Path,
-    output_path: str | Path,
-    audio_codec: str = "aac",
-    audio_bitrate: str = "192k",
-    keep_original_audio: bool = False,
-) -> None:
-    """Copy ``video_path``'s video stream and mux in ``audio_path`` as the audio track.
-
-    Uses ffmpeg stream-copy for video (no re-encode) and encodes audio to AAC.
-    Subtitle streams from ``video_path`` are carried through unchanged
-    (stream-copy). ``-shortest`` trims to the shorter of the two streams so
-    the output duration matches the source video when the dubbed audio is
-    slightly longer.
-
-    Args:
-        video_path: Source video file (video + subtitle streams are copied unchanged).
-        audio_path: Audio file to use as the new (default) audio track.
-        output_path: Destination file. Overwritten if it exists.
-        audio_codec: ffmpeg audio codec name. Defaults to ``aac`` (MP4-compatible).
-        audio_bitrate: Audio bitrate passed to ffmpeg (``-b:a``).
-        keep_original_audio: If True, retain the source audio as a secondary
-            track behind the dubbed one. Useful for editorial A/B.
-
-    Raises:
-        FileNotFoundError: If ``video_path`` or ``audio_path`` does not exist.
-        RemuxError: If ffmpeg returns a non-zero exit code.
-    """
-    video_path = Path(video_path)
-    audio_path = Path(audio_path)
-    output_path = Path(output_path)
-
-    if not video_path.exists():
-        raise FileNotFoundError(f"Video file not found: {video_path}")
-    if not audio_path.exists():
-        raise FileNotFoundError(f"Audio file not found: {audio_path}")
-
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-i",
-        str(video_path),
-        "-i",
-        str(audio_path),
-        *_build_stream_maps(keep_original_audio),
-        "-c:v",
-        "copy",
-        "-c:a",
-        audio_codec,
-        "-b:a",
-        audio_bitrate,
-        "-c:s",
-        "copy",
-        "-shortest",
-        str(output_path),
-    ]
-
-    logger.info("replace_audio_stream: %s + %s -> %s", video_path, audio_path, output_path)
-    try:
-        _ffmpeg.run(cmd)
-    except FFmpegRunError as e:
-        raise RemuxError(str(e)) from e
-
-
 def replace_audio_stream_from_audio(
     video_path: str | Path,
     audio: Audio,
@@ -111,13 +46,13 @@ def replace_audio_stream_from_audio(
     audio_bitrate: str = "192k",
     keep_original_audio: bool = False,
 ) -> None:
-    """Like ``replace_audio_stream`` but takes an in-memory ``Audio`` and pipes WAV to ffmpeg.
+    """Copy ``video_path``'s video stream and mux in an in-memory ``Audio`` as the audio track.
 
-    Avoids the ``Audio.save -> read-from-disk -> ffmpeg`` round-trip used by
-    the path-based variant: we serialize the WAV in memory and feed it to
-    ffmpeg via stdin. For long dubs this saves a full WAV write+read of the
-    output audio (~10 GB for a 2h source). Subtitle streams from
-    ``video_path`` are carried through unchanged (stream-copy).
+    Serializes the WAV in memory and feeds it to ffmpeg via stdin, avoiding an
+    ``Audio.save -> read-from-disk -> ffmpeg`` round-trip. For long dubs this
+    saves a full WAV write+read of the output audio (~10 GB for a 2h source).
+    Video is stream-copied (no re-encode); subtitle streams from ``video_path``
+    are carried through unchanged. ``-shortest`` trims to the shorter stream.
 
     Args:
         video_path: Source video file (video + subtitle streams are copied unchanged).

--- a/src/videopython/ai/dubbing/timing.py
+++ b/src/videopython/ai/dubbing/timing.py
@@ -45,18 +45,15 @@ class TimingSynchronizer:
         self,
         min_speed: float | None = None,
         max_speed: float | None = None,
-        gap_threshold: float = 0.1,
     ):
         """Initialize the timing synchronizer.
 
         Args:
             min_speed: Minimum speed factor (default: 0.8).
             max_speed: Maximum speed factor (default: 1.3).
-            gap_threshold: Minimum gap between segments in seconds (default: 0.1).
         """
         self.min_speed = min_speed if min_speed is not None else self.MIN_SPEED
         self.max_speed = max_speed if max_speed is not None else self.MAX_SPEED
-        self.gap_threshold = gap_threshold
 
         if self.min_speed <= 0:
             raise ValueError("min_speed must be positive")
@@ -235,39 +232,3 @@ class TimingSynchronizer:
             frame_count=end_sample,
         )
         return Audio(output, metadata)
-
-    def check_overlaps(
-        self,
-        start_times: list[float],
-        durations: list[float],
-    ) -> list[tuple[int, int, float]]:
-        """Check for overlapping segments.
-
-        Args:
-            start_times: Start time for each segment.
-            durations: Duration of each segment.
-
-        Returns:
-            List of overlapping pairs as (index1, index2, overlap_duration).
-        """
-        if len(start_times) != len(durations):
-            raise ValueError("Length mismatch between start_times and durations")
-
-        overlaps = []
-        n = len(start_times)
-
-        for i in range(n):
-            end_i = start_times[i] + durations[i]
-            for j in range(i + 1, n):
-                # Check if segment j starts before segment i ends
-                if start_times[j] < end_i and start_times[j] >= start_times[i]:
-                    overlap = end_i - start_times[j]
-                    if overlap > self.gap_threshold:
-                        overlaps.append((i, j, overlap))
-                # Check if segment i starts before segment j ends
-                elif start_times[i] < start_times[j] + durations[j] and start_times[i] >= start_times[j]:
-                    overlap = start_times[j] + durations[j] - start_times[i]
-                    if overlap > self.gap_threshold:
-                        overlaps.append((j, i, overlap))
-
-        return overlaps

--- a/src/videopython/ai/generation/_tts_backend.py
+++ b/src/videopython/ai/generation/_tts_backend.py
@@ -1,18 +1,17 @@
 """Pluggable speech-synthesis backend protocol for the dubbing pipeline.
 
-Mirrors :class:`videopython.ai.generation.translation.TranslationBackend`: a
-dependency-free, ``runtime_checkable`` Protocol that the dubbing pipeline
+A dependency-free, ``runtime_checkable`` Protocol that the dubbing pipeline
 depends on instead of binding directly to the local
 :class:`videopython.ai.generation.audio.TextToSpeech` implementation.
 
-This is the seam that lets dubbing run WITHOUT chatterbox in the process. The
-local ``TextToSpeech`` (which pulls ``chatterbox-tts`` via the ``[tts]`` extra)
+This is the seam that lets a consumer run speech synthesis out-of-process. The
+local ``TextToSpeech`` (which pulls ``chatterbox-tts`` from the ``[ai]`` extra)
 satisfies this protocol structurally — no changes needed there. A consumer that
-can't or won't install chatterbox (e.g. a service running synthesis in a
+can't or won't load chatterbox in-process (e.g. a service running synthesis in a
 separate process or on a remote/Modal function) supplies its own object
-implementing :meth:`SpeechBackend.generate_audio` and injects it; the pipeline never
-imports chatterbox in that case. videopython ships ONLY this protocol plus the
-local backend — no reference remote/HTTP backend.
+implementing :meth:`SpeechBackend.generate_audio` and injects it; the pipeline
+never imports chatterbox in that case. videopython ships ONLY this protocol plus
+the local backend — no reference remote/HTTP backend.
 """
 
 from __future__ import annotations

--- a/src/videopython/ai/generation/audio.py
+++ b/src/videopython/ai/generation/audio.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from videopython.ai._device import log_device_initialization, release_device_memory, select_device
+from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
 from videopython.audio import Audio, AudioMetadata
@@ -37,9 +37,7 @@ class TextToSpeech(ManagedPredictor):
     def _init_local(self) -> None:
         from videopython.ai._optional import require
 
-        ChatterboxMultilingualTTS = require(
-            "chatterbox.mtl_tts", "ai", feature="TextToSpeech"
-        ).ChatterboxMultilingualTTS
+        ChatterboxMultilingualTTS = require("chatterbox.mtl_tts", feature="TextToSpeech").ChatterboxMultilingualTTS
 
         requested_device = self.device
         device = select_device(self.device, mps_allowed=False)
@@ -141,17 +139,11 @@ class TextToSpeech(ManagedPredictor):
             if cleanup_path and speaker_wav_path is not None:
                 speaker_wav_path.unlink(missing_ok=True)
 
-    def unload(self) -> None:
-        """Release the TTS model so the next generate_audio() re-initializes.
-
-        Used by low-memory dubbing to free VRAM between pipeline stages.
-        """
-        self._model = None
-        release_device_memory(self.device)
-
 
 class TextToMusic(ManagedPredictor):
     """Generates music from text descriptions using MusicGen."""
+
+    _model_attrs = ("_model", "_processor")
 
     def __init__(self, device: str | None = None):
         self.device = device
@@ -164,7 +156,7 @@ class TextToMusic(ManagedPredictor):
 
         from videopython.ai._optional import require
 
-        _transformers = require("transformers", "ai", feature="TextToMusic")
+        _transformers = require("transformers", feature="TextToMusic")
         AutoProcessor = _transformers.AutoProcessor
         MusicgenForConditionalGeneration = _transformers.MusicgenForConditionalGeneration
 
@@ -204,9 +196,3 @@ class TextToMusic(ManagedPredictor):
             frame_count=len(audio_data),
         )
         return Audio(audio_data, metadata)
-
-    def unload(self) -> None:
-        """Release the MusicGen model so the next generate_audio() re-initializes."""
-        self._model = None
-        self._processor = None
-        release_device_memory(self.device)

--- a/src/videopython/ai/generation/image.py
+++ b/src/videopython/ai/generation/image.py
@@ -6,13 +6,15 @@ from typing import Any
 
 from PIL import Image
 
-from videopython.ai._device import log_device_initialization, release_device_memory, select_device
+from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
 
 
 class TextToImage(ManagedPredictor):
     """Generates images from text descriptions using local models."""
+
+    _model_attrs = ("_pipeline",)
 
     def __init__(self, device: str | None = None):
         self.device = device
@@ -24,7 +26,7 @@ class TextToImage(ManagedPredictor):
 
         from videopython.ai._optional import require
 
-        DiffusionPipeline = require("diffusers", "ai", feature="TextToImage").DiffusionPipeline
+        DiffusionPipeline = require("diffusers", feature="TextToImage").DiffusionPipeline
 
         requested_device = self.device
         device = select_device(self.device, mps_allowed=True)
@@ -55,8 +57,3 @@ class TextToImage(ManagedPredictor):
         if self._pipeline is None:
             self._init_local()
         return self._pipeline(prompt=prompt).images[0]
-
-    def unload(self) -> None:
-        """Release the diffusion pipeline so the next generate_image() re-initializes."""
-        self._pipeline = None
-        release_device_memory(self.device)

--- a/src/videopython/ai/generation/translation.py
+++ b/src/videopython/ai/generation/translation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable
 
 from videopython.ai._ollama import OllamaError, OllamaStructuredClient
 from videopython.ai._predictor import ManagedPredictor
@@ -27,23 +27,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_TRANSLATION_MODEL = "gemma3:27b"
 
 
-class UnsupportedLanguageError(ValueError):
-    """Raised when no translation backend supports a ``(source, target)`` pair.
-
-    Carries the requested pair so callers can introspect::
-
-        try:
-            dubber.dub(video, target_lang="xh")
-        except UnsupportedLanguageError as e:
-            print(f"No backend covers {e.source_lang}->{e.target_lang}")
-    """
-
-    def __init__(self, source_lang: str, target_lang: str, message: str | None = None):
-        self.source_lang = source_lang
-        self.target_lang = target_lang
-        super().__init__(message or f"No translation backend supports {source_lang}->{target_lang}")
-
-
 def _is_translatable_text(text: str) -> bool:
     """Return True if text has enough content to be worth translating.
 
@@ -51,29 +34,6 @@ def _is_translatable_text(text: str) -> bool:
     (" .", "...", "?", "♪"). Require at least 2 alphanumeric characters.
     """
     return sum(1 for c in text if c.isalnum()) >= 2
-
-
-@runtime_checkable
-class TranslationBackend(Protocol):
-    """Pipeline-facing translation interface."""
-
-    def translate_segments(
-        self,
-        segments: list[TranscriptionSegment],
-        target_lang: str,
-        source_lang: str | None = None,
-        progress_callback: Callable[[float], None] | None = None,
-    ) -> list[TranslatedSegment]: ...
-
-    def unload(self) -> None: ...
-
-    @property
-    def translation_failures(self) -> list[int]:
-        """Indices into the most recent ``segments`` input where translation failed."""
-        ...
-
-    @staticmethod
-    def get_supported_languages() -> dict[str, str]: ...
 
 
 LANGUAGE_NAMES = {
@@ -366,10 +326,3 @@ class OllamaTranslator(ManagedPredictor):
     @staticmethod
     def get_supported_languages() -> dict[str, str]:
         return LANGUAGE_NAMES.copy()
-
-    @classmethod
-    def supports(cls, source_lang: str, target_lang: str) -> bool:
-        """Coverage hint for the dubbing pipeline."""
-        if source_lang == target_lang:
-            return True
-        return source_lang in LANGUAGE_NAMES and target_lang in LANGUAGE_NAMES

--- a/src/videopython/ai/generation/video.py
+++ b/src/videopython/ai/generation/video.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from videopython.ai._device import log_device_initialization, release_device_memory, select_device
+from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
 from videopython.base.video import Video
@@ -28,6 +28,8 @@ def _get_torch_device_and_dtype(device: str | None) -> tuple[str, Any]:
 class TextToVideo(ManagedPredictor):
     """Generates videos from text descriptions using local diffusion models."""
 
+    _model_attrs = ("_pipeline",)
+
     def __init__(self, device: str | None = None):
         self.device = device
         self._pipeline: Any = None
@@ -35,7 +37,7 @@ class TextToVideo(ManagedPredictor):
     def _init_local(self) -> None:
         from videopython.ai._optional import require
 
-        CogVideoXPipeline = require("diffusers", "ai", feature="TextToVideo").CogVideoXPipeline
+        CogVideoXPipeline = require("diffusers", feature="TextToVideo").CogVideoXPipeline
 
         requested_device = self.device
         device, dtype = _get_torch_device_and_dtype(self.device)
@@ -73,14 +75,11 @@ class TextToVideo(ManagedPredictor):
         video_frames = np.asarray(video_frames, dtype=np.uint8)
         return Video.from_frames(video_frames, fps=16.0)
 
-    def unload(self) -> None:
-        """Release the diffusion pipeline so the next generate_video() re-initializes."""
-        self._pipeline = None
-        release_device_memory(self.device)
-
 
 class ImageToVideo(ManagedPredictor):
     """Generates videos from static images using local video diffusion."""
+
+    _model_attrs = ("_pipeline",)
 
     def __init__(self, device: str | None = None):
         self.device = device
@@ -89,7 +88,7 @@ class ImageToVideo(ManagedPredictor):
     def _init_local(self) -> None:
         from videopython.ai._optional import require
 
-        CogVideoXImageToVideoPipeline = require("diffusers", "ai", feature="ImageToVideo").CogVideoXImageToVideoPipeline
+        CogVideoXImageToVideoPipeline = require("diffusers", feature="ImageToVideo").CogVideoXImageToVideoPipeline
 
         requested_device = self.device
         device, dtype = _get_torch_device_and_dtype(self.device)
@@ -130,8 +129,3 @@ class ImageToVideo(ManagedPredictor):
         ).frames[0]
         video_frames = np.asarray(video_frames, dtype=np.uint8)
         return Video.from_frames(video_frames, fps=16.0)
-
-    def unload(self) -> None:
-        """Release the diffusion pipeline so the next generate_video() re-initializes."""
-        self._pipeline = None
-        release_device_memory(self.device)

--- a/src/videopython/ai/ops.py
+++ b/src/videopython/ai/ops.py
@@ -1,0 +1,23 @@
+"""Force-registration of the AI-defined editing operations.
+
+``FaceTrackingCrop`` (``ai/transforms.py``) and ``ObjectDetectionOverlay``
+(``ai/effects.py``) are :class:`~videopython.editing.operation.Operation`
+subclasses, so they enter ``Operation._registry`` as a side-effect of their
+class definition (via ``__pydantic_init_subclass__``). But ``ai/__init__``
+re-exports them *lazily* (PEP 562), so in a fresh process that builds the op
+schema before anything touches those symbols, they are silently absent from
+``Operation.llm_registry()`` / ``EditPlan.json_schema()`` / the MCP
+``edit_plan_schema`` resource -- the planner can never select them and
+``Operation.get("face_crop")`` raises "Unknown op_id".
+
+Importing this module eagerly imports both leaf modules, guaranteeing the AI
+ops are registered. Import it wherever the AI op universe is assembled (it is
+imported from ``ai.auto_edit``, which the MCP server depends on transitively).
+The imports are light: ``transforms``/``effects`` pull only ``understanding``
+leaves whose heavy ML deps load lazily, so this drags in no torch at import.
+"""
+
+from __future__ import annotations
+
+import videopython.ai.effects  # noqa: F401  -- registers ObjectDetectionOverlay
+import videopython.ai.transforms  # noqa: F401  -- registers FaceTrackingCrop

--- a/src/videopython/ai/understanding/__init__.py
+++ b/src/videopython/ai/understanding/__init__.py
@@ -1,9 +1,9 @@
 """Local understanding models, lazily re-exported (PEP 562).
 
 Each symbol's backing leaf module is imported only on first access, so
-``from videopython.ai.understanding import ObjectDetector`` (``[vision]``)
-does not pull in ``audio`` (whisper/pyannote — ``[asr]``). The
-``TYPE_CHECKING`` block keeps the symbols visible to mypy and IDEs.
+``from videopython.ai.understanding import ObjectDetector`` does not pull in
+``audio`` (whisper/pyannote) or its heavy deps. The ``TYPE_CHECKING`` block
+keeps the symbols visible to mypy and IDEs.
 """
 
 from __future__ import annotations

--- a/src/videopython/ai/understanding/_yolo.py
+++ b/src/videopython/ai/understanding/_yolo.py
@@ -1,0 +1,111 @@
+"""Shared lazy YOLOv8 detector wrapper for the understanding layer.
+
+``ObjectDetector`` (COCO objects) and ``_FaceDetector`` (faces) were nearly
+identical YOLO wrappers: same ``cpu``/``gpu``/``auto`` device resolution, same
+lazy load + ``.to("cuda")``, same ``detect`` / ``detect_batch`` shape, differing
+only in how the model is loaded and how a result is parsed into detections.
+:class:`YoloDetector` holds all the shared machinery; subclasses supply just
+``_load_model`` (build ``self._yolo_model``), ``_parse`` (one result -> list of
+detections), and ``_conf`` (the confidence passed to YOLO).
+
+The heavy ``ultralytics`` import is deferred to :meth:`_build_yolo` (guarded by
+``require``), so constructing a detector pulls in no torch until it actually runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Generic, Literal, TypeVar
+
+import numpy as np
+
+from videopython.ai._device import select_device
+from videopython.ai._predictor import ManagedPredictor
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+Backend = Literal["cpu", "gpu", "auto"]
+
+
+class YoloDetector(ManagedPredictor, Generic[T]):
+    """Lazy YOLOv8 wrapper: device resolution, lazy load, detect/detect_batch, unload.
+
+    Context-managed via :class:`ManagedPredictor`; ``unload()`` drops the model
+    and frees the resolved device. Subclass contract:
+      * ``_FEATURE`` -- name surfaced in the ``[ai]``-extra ``ImportError``.
+      * ``_load_model()`` -- set ``self._yolo_model`` (call :meth:`_build_yolo`)
+        plus any label state.
+      * ``_parse(result)`` -- map one ultralytics result to a list of detections.
+      * ``_conf()`` -- the ``conf`` threshold passed to the model.
+    """
+
+    _FEATURE = "YoloDetector"
+    _model_attrs = ("_yolo_model",)
+    _device_attr = "_resolved_device"
+
+    def __init__(self, *, backend: Backend = "auto") -> None:
+        self.backend: Backend = backend
+        self._resolved_device: Literal["cpu", "cuda"] | None = None
+        self._yolo_model: Any = None
+
+    def _resolve_device(self) -> Literal["cpu", "cuda"]:
+        if self._resolved_device is not None:
+            return self._resolved_device
+
+        if self.backend == "cpu":
+            self._resolved_device = "cpu"
+        elif self.backend == "gpu":
+            if select_device(None, mps_allowed=False) != "cuda":
+                raise ValueError("GPU backend requested but CUDA is not available.")
+            self._resolved_device = "cuda"
+        else:
+            self._resolved_device = "cuda" if select_device(None, mps_allowed=False) == "cuda" else "cpu"
+        return self._resolved_device
+
+    def execution_device(self) -> Literal["cpu", "cuda"]:
+        """Resolved execution device for this detector."""
+        return self._resolve_device()
+
+    def _build_yolo(self, model_path: str) -> None:
+        """Construct ``self._yolo_model`` from a model id/path and move it to the device."""
+        from videopython.ai._optional import require
+
+        YOLO = require("ultralytics", feature=self._FEATURE).YOLO
+        self._yolo_model = YOLO(model_path)
+        if self._resolve_device() == "cuda":
+            self._yolo_model.to("cuda")
+
+    # --- subclass hooks -----------------------------------------------------
+    def _load_model(self) -> None:
+        raise NotImplementedError
+
+    def _conf(self) -> float:
+        raise NotImplementedError
+
+    def _parse(self, result: Any) -> list[T]:
+        raise NotImplementedError
+
+    # --- public API ---------------------------------------------------------
+    def _ensure_loaded(self) -> None:
+        if self._yolo_model is None:
+            self._load_model()
+
+    def detect(self, image: np.ndarray) -> list[T]:
+        """Detect in a single ``(H, W, 3)`` frame."""
+        self._ensure_loaded()
+        results = self._yolo_model(image, conf=self._conf(), verbose=False)
+        if not results:
+            return []
+        return self._parse(results[0])
+
+    def detect_batch(self, images: list[np.ndarray] | np.ndarray) -> list[list[T]]:
+        """Detect in a batch of frames (list or stacked ``(N, H, W, 3)``)."""
+        if isinstance(images, np.ndarray):
+            images = [images[i] for i in range(images.shape[0])] if images.ndim == 4 else [images]
+        if not images:
+            return []
+
+        self._ensure_loaded()
+        results = self._yolo_model(images, conf=self._conf(), verbose=False)
+        return [self._parse(result) for result in results]

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
-from videopython.ai._device import log_device_initialization, release_device_memory, select_device
+from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
 from videopython.audio import Audio
@@ -59,7 +59,7 @@ def _build_initial_prompt(vocabulary: list[str]) -> str | None:
 
     from videopython.ai._optional import require
 
-    whisper_tokenizer = require("whisper.tokenizer", "ai", feature="AudioToText")
+    whisper_tokenizer = require("whisper.tokenizer", feature="AudioToText")
 
     tokenizer = whisper_tokenizer.get_tokenizer(multilingual=True, task="transcribe")
     kept = list(vocabulary)
@@ -139,6 +139,7 @@ class AudioToText(ManagedPredictor):
     """
 
     PYANNOTE_DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"
+    _model_attrs = ("_model", "_diarization_pipeline", "_vad_model")
 
     def __init__(
         self,
@@ -187,7 +188,7 @@ class AudioToText(ManagedPredictor):
         """Initialize local Whisper model."""
         from videopython.ai._optional import require
 
-        whisper = require("whisper", "ai", feature="AudioToText")
+        whisper = require("whisper", feature="AudioToText")
 
         # No revision pin: openai-whisper downloads weights by name from OpenAI's
         # own CDN, not via a HF from_pretrained repo, so there is no HF commit
@@ -200,7 +201,7 @@ class AudioToText(ManagedPredictor):
 
         from videopython.ai._optional import require
 
-        Pipeline = require("pyannote.audio", "ai", feature="AudioToText diarization").Pipeline
+        Pipeline = require("pyannote.audio", feature="AudioToText diarization").Pipeline
 
         self._diarization_pipeline = Pipeline.from_pretrained(
             self.PYANNOTE_DIARIZATION_MODEL, revision=pinned(self.PYANNOTE_DIARIZATION_MODEL)
@@ -216,19 +217,9 @@ class AudioToText(ManagedPredictor):
         """
         from videopython.ai._optional import require
 
-        load_silero_vad = require("silero_vad", "ai", feature="AudioToText VAD").load_silero_vad
+        load_silero_vad = require("silero_vad", feature="AudioToText VAD").load_silero_vad
 
         self._vad_model = load_silero_vad()
-
-    def unload(self) -> None:
-        """Release the Whisper, diarization, and VAD models so the next call re-initializes.
-
-        Used by low-memory dubbing to free VRAM between pipeline stages.
-        """
-        self._model = None
-        self._diarization_pipeline = None
-        self._vad_model = None
-        release_device_memory(self.device)
 
     def _process_transcription_result(self, transcription_result: dict[str, Any]) -> Transcription:
         """Process raw transcription result into a Transcription object."""
@@ -496,6 +487,7 @@ class AudioToText(ManagedPredictor):
 class AudioClassifier(ManagedPredictor):
     """Audio event and sound classification using AST."""
 
+    _model_attrs = ("_model", "_processor")
     SUPPORTED_MODELS: list[str] = ["MIT/ast-finetuned-audioset-10-10-0.4593"]
     AST_SAMPLE_RATE: int = 16000
     AST_CHUNK_SECONDS: float = 10.0
@@ -529,7 +521,7 @@ class AudioClassifier(ManagedPredictor):
         """Initialize local AST model from HuggingFace."""
         from videopython.ai._optional import require
 
-        _transformers = require("transformers", "ai", feature="AudioClassifier")
+        _transformers = require("transformers", feature="AudioClassifier")
         ASTFeatureExtractor = _transformers.ASTFeatureExtractor
         ASTForAudioClassification = _transformers.ASTForAudioClassification
 
@@ -539,15 +531,6 @@ class AudioClassifier(ManagedPredictor):
         self._model.eval()
 
         self._labels = [self._model.config.id2label[i] for i in range(len(self._model.config.id2label))]
-
-    def unload(self) -> None:
-        """Release the AST model so the next classify() re-initializes.
-
-        Used by low-memory dubbing to free VRAM between pipeline stages.
-        """
-        self._model = None
-        self._processor = None
-        release_device_memory(self.device)
 
     def _merge_events(self, events: list[AudioEvent], gap_threshold: float = 0.5) -> list[AudioEvent]:
         """Merge consecutive events of the same class."""

--- a/src/videopython/ai/understanding/faces.py
+++ b/src/videopython/ai/understanding/faces.py
@@ -16,8 +16,9 @@ from typing import Any, Literal
 
 import numpy as np
 
-from videopython.ai._device import select_device
+from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
+from videopython.ai.understanding._yolo import Backend, YoloDetector
 from videopython.base.description import BoundingBox, DetectedFace, FaceTrack
 
 logger = logging.getLogger(__name__)
@@ -30,68 +31,39 @@ DEFAULT_IOU_MATCH_THRESHOLD = 0.3
 DEFAULT_MAX_MISSED_FRAMES = 3
 
 
-class _FaceDetector:
-    """Internal YOLOv8-face detector. Renamed from ``_FaceDetectionBackend``.
+class _FaceDetector(YoloDetector[DetectedFace]):
+    """Internal YOLOv8-face detector over the shared :class:`YoloDetector` base.
 
-    Identical behaviour to the previous transforms-layer implementation —
-    only the import path changed. Producers in ``transforms.py`` reach for
-    this class via the lifted module path.
+    Pulls the pinned ``arnabdhar/YOLOv8-Face-Detection`` checkpoint and filters
+    detections below ``min_face_size`` pixels. Producers in ``transforms.py``
+    reach for this class via the lifted module path.
     """
 
     CONFIDENCE_THRESHOLD = 0.5
+    _FEATURE = "FaceTracker"
 
     def __init__(
         self,
         min_face_size: int = 30,
-        backend: Literal["cpu", "gpu", "auto"] = "auto",
+        backend: Backend = "auto",
     ):
+        super().__init__(backend=backend)
         self.min_face_size = min_face_size
-        self.backend: Literal["cpu", "gpu", "auto"] = backend
-        self._resolved_device: Literal["cpu", "cuda"] | None = None
-        self._yolo_model: Any = None
 
-    def _resolve_device(self) -> Literal["cpu", "cuda"]:
-        if self._resolved_device is not None:
-            return self._resolved_device
+    def _conf(self) -> float:
+        return self.CONFIDENCE_THRESHOLD
 
-        if self.backend == "cpu":
-            self._resolved_device = "cpu"
-            return self._resolved_device
-
-        if self.backend == "gpu":
-            resolved = select_device(None, mps_allowed=False)
-            if resolved != "cuda":
-                raise ValueError("GPU backend requested but CUDA is not available.")
-            self._resolved_device = "cuda"
-            return self._resolved_device
-
-        resolved_auto = select_device(None, mps_allowed=False)
-        self._resolved_device = "cuda" if resolved_auto == "cuda" else "cpu"
-        return self._resolved_device
-
-    def execution_device(self) -> Literal["cpu", "cuda"]:
-        """Resolved execution device for this detector."""
-        return self._resolve_device()
-
-    def _init_yolo_face(self) -> None:
+    def _load_model(self) -> None:
         from huggingface_hub import hf_hub_download
-
-        from videopython.ai._optional import require
-
-        YOLO = require("ultralytics", "ai", feature="FaceTracker").YOLO
 
         model_path = hf_hub_download(
             repo_id="arnabdhar/YOLOv8-Face-Detection",
             filename="model.pt",
             revision=pinned("arnabdhar/YOLOv8-Face-Detection"),
         )
-        self._yolo_model = YOLO(model_path)
+        self._build_yolo(model_path)
 
-        device = self._resolve_device()
-        if device == "cuda":
-            self._yolo_model.to("cuda")
-
-    def _faces_from_yolo_result(self, result: Any) -> list[DetectedFace]:
+    def _parse(self, result: Any) -> list[DetectedFace]:
         detected_faces: list[DetectedFace] = []
         boxes = result.boxes
         if boxes is None:
@@ -121,29 +93,6 @@ class _FaceDetector:
         detected_faces.sort(key=lambda f: f.area or 0, reverse=True)
         return detected_faces
 
-    def detect(self, image: np.ndarray) -> list[DetectedFace]:
-        if self._yolo_model is None:
-            self._init_yolo_face()
-        assert self._yolo_model is not None
-
-        results = self._yolo_model(image, conf=self.CONFIDENCE_THRESHOLD, verbose=False)
-        if not results:
-            return []
-        return self._faces_from_yolo_result(results[0])
-
-    def detect_batch(self, images: list[np.ndarray] | np.ndarray) -> list[list[DetectedFace]]:
-        if isinstance(images, np.ndarray):
-            images = [images[i] for i in range(images.shape[0])] if images.ndim == 4 else [images]
-        if not images:
-            return []
-
-        if self._yolo_model is None:
-            self._init_yolo_face()
-        assert self._yolo_model is not None
-
-        results = self._yolo_model(images, conf=self.CONFIDENCE_THRESHOLD, verbose=False)
-        return [self._faces_from_yolo_result(result) for result in results]
-
 
 def _bbox_iou(a: BoundingBox, b: BoundingBox) -> float:
     """Standard IoU on normalized bounding boxes."""
@@ -166,7 +115,7 @@ def _bbox_iou(a: BoundingBox, b: BoundingBox) -> float:
     return intersection / union
 
 
-class FaceTracker:
+class FaceTracker(ManagedPredictor):
     """Face tracking utility with per-frame smoothing and per-shot tracks.
 
     Two surfaces:
@@ -232,6 +181,11 @@ class FaceTracker:
         self._smoothed_position: tuple[float, float] | None = None
         self._smoothed_size: tuple[float, float] | None = None
         logger.info("FaceTracker initialized with backend=%s", self.backend)
+
+    def unload(self) -> None:
+        """Release the underlying face-detection model (idempotent)."""
+        if self._detector is not None:
+            self._detector.unload()
 
     def _init_detector(self) -> None:
         """Initialize face detector lazily."""

--- a/src/videopython/ai/understanding/objects.py
+++ b/src/videopython/ai/understanding/objects.py
@@ -3,8 +3,9 @@
 ``ObjectDetector`` is the object-detection counterpart to the face detector in
 ``faces.py``: a lazy YOLOv8-COCO wrapper returning
 :class:`~videopython.base.description.DetectedObject` with normalized bounding
-boxes. It mirrors ``_FaceDetector`` (lazy init, device selection, ``detect`` /
-``detect_batch``) so the two share one mental model. Consumed by
+boxes. Both share :class:`~videopython.ai.understanding._yolo.YoloDetector`
+(lazy init, device selection, ``detect`` / ``detect_batch`` / ``unload``), so the
+two stay one mental model. Consumed by
 ``videopython.ai.effects.ObjectDetectionOverlay``; usable directly for any
 per-frame object analysis.
 """
@@ -12,11 +13,9 @@ per-frame object analysis.
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
+from typing import Any
 
-import numpy as np
-
-from videopython.ai._device import select_device
+from videopython.ai.understanding._yolo import Backend, YoloDetector
 from videopython.base.description import BoundingBox, DetectedObject
 
 logger = logging.getLogger(__name__)
@@ -24,7 +23,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["ObjectDetector"]
 
 
-class ObjectDetector:
+class ObjectDetector(YoloDetector[DetectedObject]):
     """Lazy YOLOv8-COCO object detector returning normalized detections.
 
     The Ultralytics weights (default ``yolov8n.pt``) auto-download on first
@@ -33,13 +32,14 @@ class ObjectDetector:
     """
 
     DEFAULT_CONFIDENCE_THRESHOLD = 0.5
+    _FEATURE = "ObjectDetector"
 
     def __init__(
         self,
         model_name: str = "yolov8n.pt",
         confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
         class_filter: tuple[str, ...] = (),
-        backend: Literal["cpu", "gpu", "auto"] = "auto",
+        backend: Backend = "auto",
     ):
         """Initialize the detector.
 
@@ -50,53 +50,24 @@ class ObjectDetector:
             class_filter: If non-empty, only these COCO class names are kept.
             backend: Detection device - ``"cpu"``, ``"gpu"``, or ``"auto"``.
         """
+        super().__init__(backend=backend)
         self.model_name = model_name
         self.confidence_threshold = confidence_threshold
         self.class_filter = class_filter
-        self.backend: Literal["cpu", "gpu", "auto"] = backend
-        self._resolved_device: Literal["cpu", "cuda"] | None = None
-        self._yolo_model: Any = None
         self._class_names: dict[int, str] = {}
         logger.info("ObjectDetector initialized with model=%s backend=%s", model_name, backend)
 
-    def _resolve_device(self) -> Literal["cpu", "cuda"]:
-        if self._resolved_device is not None:
-            return self._resolved_device
+    def _conf(self) -> float:
+        return self.confidence_threshold
 
-        if self.backend == "cpu":
-            self._resolved_device = "cpu"
-            return self._resolved_device
-
-        if self.backend == "gpu":
-            resolved = select_device(None, mps_allowed=False)
-            if resolved != "cuda":
-                raise ValueError("GPU backend requested but CUDA is not available.")
-            self._resolved_device = "cuda"
-            return self._resolved_device
-
-        resolved_auto = select_device(None, mps_allowed=False)
-        self._resolved_device = "cuda" if resolved_auto == "cuda" else "cpu"
-        return self._resolved_device
-
-    def execution_device(self) -> Literal["cpu", "cuda"]:
-        """Resolved execution device for this detector."""
-        return self._resolve_device()
-
-    def _init_yolo(self) -> None:
-        from videopython.ai._optional import require
-
-        YOLO = require("ultralytics", "ai", feature="ObjectDetector").YOLO
-
+    def _load_model(self) -> None:
         # No revision pin: ultralytics resolves/downloads this asset from its own
         # GitHub release assets, not a HF repo, and YOLO() takes no revision arg
         # (see videopython.ai._revisions module docstring).
-        self._yolo_model = YOLO(self.model_name)
+        self._build_yolo(self.model_name)
         self._class_names = dict(self._yolo_model.names)
 
-        if self._resolve_device() == "cuda":
-            self._yolo_model.to("cuda")
-
-    def _objects_from_yolo_result(self, result: Any) -> list[DetectedObject]:
+    def _parse(self, result: Any) -> list[DetectedObject]:
         detected: list[DetectedObject] = []
         boxes = result.boxes
         if boxes is None:
@@ -123,28 +94,3 @@ class ObjectDetector:
             )
         detected.sort(key=lambda d: d.confidence, reverse=True)
         return detected
-
-    def detect(self, image: np.ndarray) -> list[DetectedObject]:
-        """Detect objects in a single ``(H, W, 3)`` frame."""
-        if self._yolo_model is None:
-            self._init_yolo()
-        assert self._yolo_model is not None
-
-        results = self._yolo_model(image, conf=self.confidence_threshold, verbose=False)
-        if not results:
-            return []
-        return self._objects_from_yolo_result(results[0])
-
-    def detect_batch(self, images: list[np.ndarray] | np.ndarray) -> list[list[DetectedObject]]:
-        """Detect objects in a batch of frames (list or stacked ``(N, H, W, 3)``)."""
-        if isinstance(images, np.ndarray):
-            images = [images[i] for i in range(images.shape[0])] if images.ndim == 4 else [images]
-        if not images:
-            return []
-
-        if self._yolo_model is None:
-            self._init_yolo()
-        assert self._yolo_model is not None
-
-        results = self._yolo_model(images, conf=self.confidence_threshold, verbose=False)
-        return [self._objects_from_yolo_result(result) for result in results]

--- a/src/videopython/ai/understanding/separation.py
+++ b/src/videopython/ai/understanding/separation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from videopython.ai._device import log_device_initialization, release_device_memory, select_device
+from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai.dubbing.models import SeparatedAudio
 from videopython.audio import Audio, AudioMetadata
@@ -75,7 +75,7 @@ class AudioSeparator(ManagedPredictor):
         """Initialize local Demucs model."""
         from videopython.ai._optional import require
 
-        get_model = require("demucs.pretrained", "ai", feature="AudioSeparator").get_model
+        get_model = require("demucs.pretrained", feature="AudioSeparator").get_model
 
         requested_device = self.device
         device = select_device(self.device, mps_allowed=False)
@@ -297,11 +297,3 @@ class AudioSeparator(ManagedPredictor):
     def extract_background(self, audio: Audio) -> Audio:
         """Convenience method to extract only background from audio."""
         return self.separate(audio).background
-
-    def unload(self) -> None:
-        """Release the Demucs model so the next separate() re-initializes.
-
-        Used by low-memory dubbing to free VRAM between pipeline stages.
-        """
-        self._model = None
-        release_device_memory(self.device)

--- a/src/videopython/ai/understanding/temporal.py
+++ b/src/videopython/ai/understanding/temporal.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from videopython.ai._device import log_device_initialization, release_device_memory, select_device
+from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.base.description import SceneBoundary
 
@@ -67,7 +67,7 @@ class SemanticSceneDetector(ManagedPredictor):
 
         from videopython.ai._optional import require
 
-        TransNetV2 = require("transnetv2_pytorch", "ai", feature="SemanticSceneDetector").TransNetV2
+        TransNetV2 = require("transnetv2_pytorch", feature="SemanticSceneDetector").TransNetV2
 
         requested_device = self.device
         device = select_device(self.device, mps_allowed=True)
@@ -79,11 +79,6 @@ class SemanticSceneDetector(ManagedPredictor):
         self.device = device
         self._model = TransNetV2(device=device)
         self._model.eval()
-
-    def unload(self) -> None:
-        """Release the TransNetV2 model so the next call re-initializes."""
-        self._model = None
-        release_device_memory(self.device)
 
     def detect(self, video: Video) -> list[SceneBoundary]:
         """Detect scenes in a video using ML-based boundary detection.

--- a/src/videopython/ai/video_analysis/models.py
+++ b/src/videopython/ai/video_analysis/models.py
@@ -169,11 +169,6 @@ class VideoAnalysisConfig(BaseModel):
         return dict(self.analyzer_params.get(analyzer_id, {}))
 
     @classmethod
-    def rich_understanding_preset(cls) -> VideoAnalysisConfig:
-        """Backward-compatible alias for the default config."""
-        return cls()
-
-    @classmethod
     def for_profile(cls, profile: str, *, faces: bool = True) -> VideoAnalysisConfig:
         """Config for an analysis profile: 'full' (all analyzers) or 'editing' (catalog-only, no audio classifier)."""
         if profile == "full":

--- a/src/videopython/ai/video_analysis/sampling.py
+++ b/src/videopython/ai/video_analysis/sampling.py
@@ -96,7 +96,7 @@ def phash_dedup_frames(
 
     from videopython.ai._optional import require
 
-    imagehash = require("imagehash", "ai", feature="scene-frame dedup")
+    imagehash = require("imagehash", feature="scene-frame dedup")
 
     kept: list[np.ndarray | Image.Image] = []
     kept_hashes: list[Any] = []

--- a/uv.lock
+++ b/uv.lock
@@ -4675,7 +4675,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.50.1"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
…ed bases (0.51.0)

Tier 0: fix AI plan-ops (face_crop, object_detection_overlay) missing from the planner/MCP op schema in a fresh process — new ai/ops.py self-registration shim imported by auto_edit, plus a clean-interpreter regression test.

Tier 1: remove abstraction residue from the granular-extras (0.43) and multi-backend (0.49) eras: collapse the Part/TextPart/ImagePart planner layer onto OllamaStructuredClient (StructuredVisionLLM.generate_json now (system,text,images,schema)); delete dead API (UnsupportedLanguageError, TranslationBackend, OllamaTranslator.supports(), DubbingConfig.translator, TimingSynchronizer.check_overlaps/gap_threshold, rich_understanding_preset(), path-based replace_audio_stream); drop require()'s always-'ai' extra param; rewrite stale granular-extras docstrings for the single [ai] extra.

Tier 2: YoloDetector base unifies the ObjectDetector/_FaceDetector wrapper; ManagedPredictor gains a _model_attrs-driven default unload(); ObjectDetector and FaceTracker are now context-managed, closing a VRAM-release gap.

Net ~430 fewer lines; no capability removed. Full AI + editing + base suites pass; ruff + mypy clean.