### PR TITLE
refactor(ai): pipeline process/revoice dedup + drop speculative confi…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## 0.52.1
+
+`videopython.ai` internal cleanup (PR-3): the two Tier-5 items deferred from 0.52.0.
+No public API or behavior change.
+
+### Internal
+
+- **Dubbing pipeline dedup** — the Demucs source-separation block that was copy-pasted
+  between `LocalDubbingPipeline.process()` and `revoice()` is now a single
+  `_separate()` helper. Behavior-preserving; the only difference between the two call
+  sites was a progress fraction (0.15 vs 0.20), now a parameter.
+- **Dropped speculative config** — removed `AudioClassifier.SUPPORTED_MODELS` and its
+  single-model validation guard, and `AudioSeparator.SUPPORTED_MODELS` /
+  `STEM_NAMES_6S` (the 6-stem branch was never selected). `model_name` is now accepted
+  as-is; an unknown model surfaces a clear error at model-load time (HuggingFace /
+  Demucs) instead of a constructor `ValueError`.
+
 ## 0.52.0
 
 `videopython.ai` technical-debt cleanup (PR-2 of 2): the taxonomy moves, file/class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.52.0"
+version = "0.52.1"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_audio_classifier.py
+++ b/src/tests/ai/test_audio_classifier.py
@@ -24,12 +24,11 @@ SMALL_VIDEO_PATH = os.path.join(TEST_DATA_DIR, "small_video.mp4")
 class TestAudioClassifierInit:
     """Lightweight tests for AudioClassifier initialization (no model download needed)."""
 
-    def test_classifier_unsupported_model(self):
-        """Test classifier raises error for unsupported model."""
+    def test_classifier_accepts_arbitrary_model_name(self):
+        """model_name is no longer validated at construction (deferred to model load)."""
         from videopython.ai.understanding.classification import AudioClassifier
 
-        with pytest.raises(ValueError, match="not supported"):
-            AudioClassifier(model_name="InvalidModel")
+        assert AudioClassifier(model_name="some/other-ast-model").model_name == "some/other-ast-model"
 
 
 @requires_model_download

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -767,12 +767,11 @@ class TestAudioSeparator:
 
         assert separator.model_name == "htdemucs_ft"
 
-    def test_initialization_invalid_model(self):
-        """Test that invalid model raises error."""
+    def test_initialization_accepts_arbitrary_model(self):
+        """model_name is no longer validated at construction (deferred to Demucs)."""
         from videopython.ai.dubbing.separation import AudioSeparator
 
-        with pytest.raises(ValueError, match="not supported"):
-            AudioSeparator(model_name="invalid_model")
+        assert AudioSeparator(model_name="some_other_model").model_name == "some_other_model"
 
 
 class TestMergeRegions:

--- a/src/videopython/ai/dubbing/pipeline.py
+++ b/src/videopython/ai/dubbing/pipeline.py
@@ -229,6 +229,43 @@ class LocalDubbingPipeline:
         """Initialize the timing synchronizer."""
         self._synchronizer = TimingSynchronizer()
 
+    def _separate(
+        self,
+        source_audio: Audio,
+        transcription: Transcription,
+        progress_fraction: float,
+        report_progress: Callable[[str, float], None],
+    ) -> tuple[SeparatedAudio | None, Audio, Audio | None]:
+        """Demucs source separation over the speech regions; shared by process()/revoice().
+
+        Limits Demucs to the speech-bearing portion of the audio: the transcription
+        has already located every speech region, and separating outside those is pure
+        overhead (no vocals to isolate). On talk-heavy sources with silence/music gaps
+        this roughly halves separation time; when speech covers most of the track,
+        separate_regions falls back to a full-track separate().
+
+        Returns ``(separated_audio, vocal_audio, background_audio)``. In low_memory
+        mode the ``SeparatedAudio`` container is dropped (returned as ``None``) so
+        vocals and background release as soon as their last local reference goes.
+        """
+        report_progress("Separating audio", progress_fraction)
+        if self._separator is None:
+            self._init_separator()
+
+        from videopython.ai.dubbing.separation import merge_regions
+
+        speech_regions = merge_regions(
+            [(s.start, s.end) for s in transcription.segments],
+            audio_duration=source_audio.metadata.duration_seconds,
+        )
+        separated_audio = self._separator.separate_regions(source_audio, speech_regions)
+        self._maybe_unload("_separator")
+        vocal_audio = separated_audio.vocals
+        background_audio = separated_audio.background
+        if self.config.low_memory:
+            separated_audio = None
+        return separated_audio, vocal_audio, background_audio
+
     def _finalise_audio(
         self,
         dubbed_speech: Audio,
@@ -355,32 +392,9 @@ class LocalDubbingPipeline:
         background_audio: Audio | None = None
 
         if preserve_background:
-            report_progress("Separating audio", 0.15)
-            if self._separator is None:
-                self._init_separator()
-
-            # Limit Demucs to the speech-bearing portion of the audio. The
-            # transcription has already located every speech region; running
-            # source separation outside those is pure overhead (no vocals to
-            # isolate). On talk-heavy sources with silence/music gaps this
-            # roughly halves separation time. When speech covers most of the
-            # track separate_regions falls back to a full-track separate().
-            from videopython.ai.dubbing.separation import merge_regions
-
-            speech_regions = merge_regions(
-                [(s.start, s.end) for s in transcription.segments],
-                audio_duration=source_audio.metadata.duration_seconds,
+            separated_audio, vocal_audio, background_audio = self._separate(
+                source_audio, transcription, 0.15, report_progress
             )
-            separated_audio = self._separator.separate_regions(source_audio, speech_regions)
-            self._maybe_unload("_separator")
-            vocal_audio = separated_audio.vocals
-            background_audio = separated_audio.background
-            # In low_memory mode, drop the SeparatedAudio container so vocals
-            # and background can be released as soon as their last local
-            # reference goes (after voice-sample extraction and final overlay
-            # respectively). The result will report separated_audio=None.
-            if self.config.low_memory:
-                separated_audio = None
 
         voice_samples: dict[str, Audio] = {}
         if voice_clone:
@@ -527,22 +541,9 @@ class LocalDubbingPipeline:
         background_audio: Audio | None = None
 
         if preserve_background:
-            report_progress("Separating audio", 0.20)
-            if self._separator is None:
-                self._init_separator()
-
-            from videopython.ai.dubbing.separation import merge_regions
-
-            speech_regions = merge_regions(
-                [(s.start, s.end) for s in transcription.segments],
-                audio_duration=source_audio.metadata.duration_seconds,
+            separated_audio, vocal_audio, background_audio = self._separate(
+                source_audio, transcription, 0.20, report_progress
             )
-            separated_audio = self._separator.separate_regions(source_audio, speech_regions)
-            self._maybe_unload("_separator")
-            vocal_audio = separated_audio.vocals
-            background_audio = separated_audio.background
-            if self.config.low_memory:
-                separated_audio = None
 
         report_progress("Extracting voice sample", 0.40)
         chosen_sample: Audio | None = None

--- a/src/videopython/ai/dubbing/separation.py
+++ b/src/videopython/ai/dubbing/separation.py
@@ -59,14 +59,9 @@ def merge_regions(
 class AudioSeparator(ManagedPredictor):
     """Separates audio into vocals and background components using Demucs."""
 
-    SUPPORTED_MODELS: list[str] = ["htdemucs", "htdemucs_ft", "htdemucs_6s", "mdx_extra"]
     STEM_NAMES = ["drums", "bass", "other", "vocals"]
-    STEM_NAMES_6S = ["drums", "bass", "other", "vocals", "guitar", "piano"]
 
     def __init__(self, model_name: str = "htdemucs", device: str | None = None):
-        if model_name not in self.SUPPORTED_MODELS:
-            raise ValueError(f"Model '{model_name}' not supported. Supported: {self.SUPPORTED_MODELS}")
-
         self.model_name = model_name
         self.device = device
         self._model: Any = None
@@ -129,7 +124,7 @@ class AudioSeparator(ManagedPredictor):
         sources_np = sources[0].cpu().numpy()
         del sources
 
-        stem_names = self.STEM_NAMES_6S if self.model_name == "htdemucs_6s" else self.STEM_NAMES
+        stem_names = self.STEM_NAMES
         vocals_idx = stem_names.index("vocals")
         non_vocal_indices = [i for i in range(len(stem_names)) if i != vocals_idx]
 

--- a/src/videopython/ai/understanding/classification.py
+++ b/src/videopython/ai/understanding/classification.py
@@ -23,7 +23,6 @@ class AudioClassifier(ManagedPredictor):
     """Audio event and sound classification using AST."""
 
     _model_attrs = ("_model", "_processor")
-    SUPPORTED_MODELS: list[str] = ["MIT/ast-finetuned-audioset-10-10-0.4593"]
     AST_SAMPLE_RATE: int = 16000
     AST_CHUNK_SECONDS: float = 10.0
     AST_HOP_SECONDS: float = 5.0
@@ -35,9 +34,6 @@ class AudioClassifier(ManagedPredictor):
         top_k: int = 10,
         device: str | None = None,
     ):
-        if model_name not in self.SUPPORTED_MODELS:
-            raise ValueError(f"Model '{model_name}' not supported. Supported: {self.SUPPORTED_MODELS}")
-
         self.model_name = model_name
         self.confidence_threshold = confidence_threshold
         self.top_k = top_k

--- a/uv.lock
+++ b/uv.lock
@@ -4675,7 +4675,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.52.0"
+version = "0.52.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
…g (0.52.1)

videopython.ai Tier-5 remainder (PR-3); completes the debt audit. No public API or behavior change.

- Dubbing pipeline: extract the Demucs source-separation block duplicated between process() and revoice() into a single behavior-preserving _separate() helper (the only difference between the two call sites was a progress fraction, now a parameter).

- Drop speculative config: AudioClassifier.SUPPORTED_MODELS + its single-model guard, and AudioSeparator.SUPPORTED_MODELS / STEM_NAMES_6S (the 6-stem branch was never selected). model_name is accepted as-is; an unknown model errors at load time (HuggingFace / Demucs) instead of a constructor ValueError.

Full AI suite passes; ruff + mypy clean.