### PR TITLE
feat(ai)!: swap AGPL/restricted detection + LLM default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install "videopython[ai]"        # + ALL local AI features (GPU recommended)
 pip install "videopython[ai,mcp]"    # + MCP server for agent-driven editing
 ```
 
-Python `>=3.11, <3.14`. AI features run locally — no cloud API keys required, but model weights are downloaded on first use. LLM-driven editing and scene captioning use a local [Ollama](https://ollama.com) server (`ollama pull gemma3:27b`).
+Python `>=3.11, <3.14`. AI features run locally — no cloud API keys required, but model weights are downloaded on first use. LLM-driven editing and scene captioning use a local [Ollama](https://ollama.com) server (`ollama pull qwen3.6:27b`).
 
 ## Quick Start
 
@@ -55,7 +55,7 @@ Give `AutoEditor` your clips and a brief; a local Ollama vision model selects an
 ```python
 from videopython.ai import AutoEditor, OllamaVisionLLM
 
-editor = AutoEditor(planner=OllamaVisionLLM(model="gemma3:27b"))  # ollama pull gemma3:27b
+editor = AutoEditor(planner=OllamaVisionLLM(model="qwen3.6:27b"))  # ollama pull qwen3.6:27b
 edit = editor.edit(
     ["clip_a.mp4", "clip_b.mp4", "clip_c.mp4"],
     brief="A punchy 15-second teaser; lead with the most dynamic shot.",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## 0.53.0
+
+Replace the AGPL-3.0 and restricted-license default models with permissively-licensed
+(Apache-2.0 / MIT) alternatives, removing the AGPL dependency from the `[ai]` extra.
+
+### Breaking
+
+- **Object detection: Ultralytics YOLOv8 (AGPL-3.0) -> D-FINE (Apache-2.0)** via
+  `transformers`. `ObjectDetector(model_name=...)` now takes a D-FINE HuggingFace repo id
+  (default `ustc-community/dfine-nano-coco`), not `yolov8*.pt`. `class_filter` must use
+  D-FINE's VOC-style COCO names (e.g. `motorbike`, `tvmonitor`) — there is no YOLO-spelling
+  alias. `ObjectDetectionOverlay.model_size` (n/s/m) maps to D-FINE nano/small/medium.
+  Higher accuracy (~42.8 vs ~37 nano mAP); somewhat slower on CPU, comparable on GPU.
+- **Face detection: YOLOv8-Face (AGPL-3.0) -> OpenCV YuNet (MIT)**, CPU-only via OpenCV
+  DNN. The face detector/trackers (`FaceSmoothingTracker`, `FaceShotTracker`) and the
+  `face_crop` op no longer accept a `backend` param, and the dead GPU `sample_rate` /
+  interpolation path was removed from `FaceSmoothingTracker.track_video`.
+- **Default local LLM: `gemma3:27b` (Gemma Terms) -> `qwen3.6:27b` (Apache-2.0)** for
+  translation, scene description, and auto-edit planning. Confirm a custom model supports
+  Ollama's structured-output `format` locally; `qwen3.6:35b` is a higher-quality option.
+
+### Changed
+
+- Removed `ultralytics` from the `[ai]` extra, `uv.lock`, and mypy config. Added
+  `torchvision` (BSD, `<0.24` to match torch 2.8) — it backs the `transformers` fast image
+  processor used by D-FINE.
+- Renamed the internal shared detector base `understanding/_yolo.py:YoloDetector` to
+  `understanding/_detector.py:DetectorBase` (backend-agnostic; D-FINE and YuNet share it).
+- Added HuggingFace revision pins for the D-FINE COCO repos and the YuNet ONNX checkpoint;
+  removed the `arnabdhar/YOLOv8-Face-Detection` pin.
+
 ## 0.52.1
 
 `videopython.ai` internal cleanup (PR-3): the two Tier-5 items deferred from 0.52.0.

--- a/docs/api/ai/auto_edit.md
+++ b/docs/api/ai/auto_edit.md
@@ -10,7 +10,7 @@ and the [MCP server](../../guides/mcp.md) for the agent-driven variant.
 ```python
 from videopython.ai import AutoEditor, OllamaVisionLLM
 
-editor = AutoEditor(planner=OllamaVisionLLM(model="gemma3:27b"))
+editor = AutoEditor(planner=OllamaVisionLLM(model="qwen3.6:27b"))
 edit = editor.edit(["a.mp4", "b.mp4"], brief="A 15s teaser, most dynamic shot first.")
 edit.run_to_file("teaser.mp4")
 ```

--- a/docs/api/ai/dubbing.md
+++ b/docs/api/ai/dubbing.md
@@ -192,8 +192,8 @@ context window, with one parse-retry on any segments the first pass misses.
 
 ```python
 # Translation always uses the local Ollama model. Pick the Ollama model + server
-# (pull it first: `ollama pull gemma3:27b`).
-dubber = VideoDubber(translator_model="gemma3:27b", translator_host="http://localhost:11434")
+# (pull it first: `ollama pull qwen3.6:27b`).
+dubber = VideoDubber(translator_model="qwen3.6:27b", translator_host="http://localhost:11434")
 ```
 
 Segments the model never returns (after the retry) are surfaced on
@@ -402,7 +402,7 @@ config = DubbingConfig(
     device="cuda",
     low_memory=True,
     whisper_model="large",
-    translator_model="gemma3:27b",
+    translator_model="qwen3.6:27b",
     vocabulary=["Klarna", "Allegro"],
 )
 dubber = VideoDubber(config=config)

--- a/docs/api/ai/effects.md
+++ b/docs/api/ai/effects.md
@@ -6,7 +6,7 @@ core editing layer keeps no AI dependency.
 
 ## ObjectDetectionOverlay
 
-Detects objects in every frame with a YOLOv8-COCO model and composites tidy,
+Detects objects in every frame with a D-FINE COCO model and composites tidy,
 colour-coded bounding boxes with class labels (and optional confidence). The
 detector ([`ObjectDetector`](understanding.md#objectdetector)) is constructed
 internally; the box/label drawing is done by the AI-free renderer
@@ -48,7 +48,7 @@ In a JSON editing plan (it is exposed in the LLM-facing schema):
 ### Performance
 
 `object_detection_overlay` is **streamable** — memory stays bounded on long
-clips — but detection is **compute**-bound: a YOLO forward pass runs per
+clips — but detection is **compute**-bound: a D-FINE forward pass runs per
 sampled frame. To cap cost:
 
 - **`window`** — restrict the overlay (and therefore detection) to a time range.

--- a/docs/api/ai/understanding.md
+++ b/docs/api/ai/understanding.md
@@ -12,8 +12,8 @@ For a single aggregate, serializable analysis object across multiple analyzers, 
 | AudioToText | Whisper |
 | AudioClassifier | AST |
 | SemanticSceneDetector | TransNetV2 |
-| FaceShotTracker / FaceSmoothingTracker | YOLOv8-face |
-| ObjectDetector | YOLOv8-COCO |
+| FaceShotTracker / FaceSmoothingTracker | OpenCV YuNet |
+| ObjectDetector | D-FINE (COCO) |
 
 ## AudioToText
 
@@ -132,7 +132,7 @@ for event in result.events:
 ## SceneVLM
 
 `SceneVLM` describes scenes with a local Ollama vision model (`model` kwarg, an
-Ollama tag you have pulled; default `gemma3:27b`). It needs a running Ollama
+Ollama tag you have pulled; default `qwen3.6:27b`). It needs a running Ollama
 server and a vision-capable model that supports structured output.
 
 `analyze_scene()` and `analyze_frame()` return a structured
@@ -173,7 +173,7 @@ for scene in scenes:
 
 ## Face Tracking
 
-Two YOLOv8-face trackers share one detector, one per use case:
+Two YuNet-based face trackers share one detector, one per use case:
 
 - `FaceShotTracker.track_shot(frames, frame_indices)` returns a list of
   [`FaceTrack`](#facetrack) objects with stable ids within a shot, via IoU
@@ -186,7 +186,7 @@ Two YOLOv8-face trackers share one detector, one per use case:
 ```python
 from videopython.ai import FaceShotTracker
 
-tracker = FaceShotTracker(backend="auto")
+tracker = FaceShotTracker()
 tracks = tracker.track_shot(frames)
 
 for track in tracks:
@@ -200,14 +200,15 @@ for track in tracks:
 
 ## ObjectDetector
 
-`ObjectDetector` runs a YOLOv8-COCO model and returns a list of
+`ObjectDetector` runs a D-FINE COCO model and returns a list of
 [`DetectedObject`](#detectedobject) per frame, with normalized bounding boxes
 sorted by confidence. It is the object-detection counterpart to the face
 trackers and powers [`ObjectDetectionOverlay`](effects.md#objectdetectionoverlay).
 
-The Ultralytics weights auto-download on first use; class names come from the
-loaded model. Detection is gated by `confidence_threshold` and optionally
-restricted to `class_filter`.
+The D-FINE weights (Apache-2.0) download from HuggingFace on first use; class
+names come from the model config. Detection is gated by `confidence_threshold`
+and optionally restricted to `class_filter`. D-FINE uses VOC-style COCO names, so
+`class_filter` must use the model's exact spellings (e.g. `motorbike`, `tvmonitor`).
 
 ```python
 from videopython.ai import ObjectDetector
@@ -215,7 +216,7 @@ from videopython.base import Video
 
 video = Video.from_path("street.mp4")
 
-detector = ObjectDetector(model_name="yolov8n.pt", class_filter=("person", "car"))
+detector = ObjectDetector(model_name="ustc-community/dfine-nano-coco", class_filter=("person", "car"))
 for obj in detector.detect(video.frames[0]):
     print(f"{obj.label} {obj.confidence:.2f} @ {obj.bounding_box}")
 

--- a/docs/api/ai/video_analysis.md
+++ b/docs/api/ai/video_analysis.md
@@ -58,7 +58,7 @@ config = VideoAnalysisConfig(
         "face_tracker",
     },
     analyzer_params={
-        "scene_vlm": {"model": "gemma3:27b"},  # any vision tag you've pulled
+        "scene_vlm": {"model": "qwen3.6:27b"},  # any vision tag you've pulled
         "audio_to_text": {
             "model_name": "large",
             "vocabulary": ["Klarna", "Allegro", "InPost"],  # brand-name biasing

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -235,7 +235,7 @@ and the default LLM-facing schema because they need a server-resolved
 | ID | Class | Category | Streamable |
 |---|---|---|---|
 | `face_crop` | `FaceTrackingCrop` | transform | yes — compile-time detection pass drives a per-frame crop track |
-| `object_detection_overlay` | `ObjectDetectionOverlay` | effect | yes — per-frame box overlay; YOLOv8 detection on a `detection_interval` cadence; bounded memory, not bounded compute |
+| `object_detection_overlay` | `ObjectDetectionOverlay` | effect | yes — per-frame box overlay; D-FINE detection on a `detection_interval` cadence; bounded memory, not bounded compute |
 
 ## API Reference
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -61,15 +61,15 @@ Protocol](https://modelcontextprotocol.io) server). See the
     Scene captioning (`SceneVLM`, used by `VideoAnalyzer`), dubbing translation,
     and the `AutoEditor` / MCP planner run against a local
     [Ollama](https://ollama.com) server — there is no in-process fallback. Install
-    Ollama, then pull the verified default model:
+    Ollama, then pull the default model:
 
     ```bash
     ollama serve            # start the local daemon
-    ollama pull gemma3:27b  # the default vision/translation model
+    ollama pull qwen3.6:27b  # the default vision/translation model
     ```
 
-    The model must support Ollama's structured-output `format`; `gemma3:27b` is
-    verified. Generation (image/video/speech/music), transcription, detection, and
+    The model must support Ollama's structured-output `format`. The default
+    `qwen3.6:27b` is an Apache-2.0 vision model. Generation (image/video/speech/music), transcription, detection, and
     audio classification do **not** need Ollama.
 
 !!! note "Dubbing TTS"

--- a/docs/guides/auto-editing.md
+++ b/docs/guides/auto-editing.md
@@ -7,8 +7,8 @@ editorial selection. No cloud API keys, no timestamps to hand-author.
 ```python
 from videopython.ai import AutoEditor, OllamaVisionLLM
 
-# The planner is a local Ollama vision model. Pull it first: `ollama pull gemma3:27b`.
-editor = AutoEditor(planner=OllamaVisionLLM(model="gemma3:27b"))
+# The planner is a local Ollama vision model. Pull it first: `ollama pull qwen3.6:27b`.
+editor = AutoEditor(planner=OllamaVisionLLM(model="qwen3.6:27b"))
 
 edit = editor.edit(
     ["clip_a.mp4", "clip_b.mp4", "clip_c.mp4"],
@@ -50,7 +50,7 @@ budget it raises `AutoEditError`.
 
 ```python
 editor = AutoEditor(
-    planner=OllamaVisionLLM(model="gemma3:27b"),
+    planner=OllamaVisionLLM(model="qwen3.6:27b"),
     max_rounds=3,
     normalize_target="largest",   # unify segment dimensions to the largest source
 )
@@ -71,8 +71,8 @@ edit = editor.edit_from_analyses(analyses, brief="A calm, scenic 20s intro.")
 ## Choosing a planner model
 
 The planner must be **vision-capable** (it is sent keyframes) **and** support
-Ollama's structured-output `format` (schema-conditioned decoding). `gemma3:27b`
-is the verified default. Some builds — e.g. certain MLX vision models — accept
+Ollama's structured-output `format` (schema-conditioned decoding). `qwen3.6:27b`
+is the default (Apache-2.0). Some builds — e.g. certain MLX vision models — accept
 images but ignore `format`, and planning fails; if a model returns prose instead
 of JSON, pick another tag. `OllamaVisionLLM` is model-agnostic via `model=`, and
 `StructuredVisionLLM` is the seam if you want to back the planner with something

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -9,7 +9,7 @@ drives the edit with **its own model as the planner** (no in-process LLM).
 ```bash
 pip install "videopython[ai,mcp]"
 ollama serve         # scene captioning uses a local Ollama vision model
-ollama pull gemma3:27b   # the default scene-VLM model
+ollama pull qwen3.6:27b   # the default scene-VLM model
 videopython-mcp      # stdio server
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.52.1"
+version = "0.53.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },
@@ -68,8 +68,8 @@ ai = [
     "openai-whisper>=20240930",
     "pyannote-audio>=4.0.0",
     "silero-vad>=5.1",
-    # Visual understanding: detection, scene/temporal, VLM (understanding/*, video_analysis)
-    "ultralytics>=8.0.0",
+    # Visual understanding: detection (D-FINE/YuNet via transformers + opencv core
+    # dep), scene/temporal, VLM (understanding/*, video_analysis)
     "transnetv2-pytorch>=1.0.5",
     "transformers>=5.2.0",
     "imagehash>=4.3",
@@ -85,9 +85,13 @@ ai = [
     "pyloudnorm>=0.1.1",
     # LLM-authored editing planner (auto_edit/local.py OllamaVisionLLM)
     "ollama>=0.5.0",
-    # Shared torch stack
+    # Shared torch stack. torchvision backs the transformers "fast" image
+    # processor used by the D-FINE object detector (understanding/objects.py).
     "torch>=2.8.0",
     "torchaudio>=2.8.0",
+    # Capped to the torch-2.8-compatible line; torchvision<->torch are ABI-coupled
+    # and uv does not know it (0.23.x pairs with torch 2.8.x).
+    "torchvision>=0.23.0,<0.24.0",
 ]
 # MCP server (videopython/mcp/). Pin <2 — v2 is pre-release/breaking.
 mcp = ["mcp>=1.27,<2"]
@@ -112,7 +116,6 @@ module = [
     "torch", "torch.*",
     "diffusers", "diffusers.*",
     "ollama", "ollama.*",
-    "ultralytics", "ultralytics.*",
     "transformers", "transformers.*",
     "transnetv2_pytorch", "transnetv2_pytorch.*",
     "chatterbox", "chatterbox.*",
@@ -133,8 +136,8 @@ ignore_missing_imports = true
 # These overrides let the combined [ai] resolve pick compatible versions; the
 # floors in [ai] are aligned with them so pip and uv resolve similar versions.
 override-dependencies = [
-    "torch>=2.8.0", "torchaudio>=2.8.0", "numpy>=2.0.0", "diffusers>=0.30.0",
-    # ultralytics depends on opencv-python which conflicts with our
+    "torch>=2.8.0", "torchaudio>=2.8.0", "torchvision>=0.23.0,<0.24.0", "numpy>=2.0.0", "diffusers>=0.30.0",
+    # Some transitive deps pull opencv-python, which conflicts with our
     # opencv-python-headless (both provide cv2). Exclude opencv-python so
     # only the headless variant is installed.
     "opencv-python ; sys_platform == '_'",

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -2678,10 +2678,10 @@ class TestDubberTranslatorKwarg:
     def test_dubber_propagates_translator_model_kwarg(self):
         from videopython.ai.dubbing import VideoDubber
 
-        dubber = VideoDubber(translator_model="gemma3:27b")
+        dubber = VideoDubber(translator_model="qwen3.6:27b")
         dubber._init_local_pipeline()
 
-        assert dubber._local_pipeline.config.translator_model == "gemma3:27b"
+        assert dubber._local_pipeline.config.translator_model == "qwen3.6:27b"
 
     def test_dubber_default_translator_model_is_none(self):
         from videopython.ai.dubbing import VideoDubber

--- a/src/tests/ai/test_effects.py
+++ b/src/tests/ai/test_effects.py
@@ -109,7 +109,7 @@ class TestStreamingDraw:
 
         _, kwargs = mock_cls.call_args
         assert kwargs["class_filter"] == ("person", "car")
-        assert kwargs["model_name"] == "yolov8n.pt"
+        assert kwargs["model_name"] == "ustc-community/dfine-nano-coco"
 
     @patch("videopython.ai.effects.ObjectDetector")
     def test_model_size_maps_to_weights(self, mock_cls):
@@ -118,7 +118,7 @@ class TestStreamingDraw:
 
         _stream(ObjectDetectionOverlay(model_size="m"), frames)
         _, kwargs = mock_cls.call_args
-        assert kwargs["model_name"] == "yolov8m.pt"
+        assert kwargs["model_name"] == "ustc-community/dfine-medium-coco"
 
 
 class TestStreamingContract:

--- a/src/tests/ai/test_objects.py
+++ b/src/tests/ai/test_objects.py
@@ -1,4 +1,4 @@
-"""Tests for the ObjectDetector understanding primitive (mocked YOLO)."""
+"""Tests for the ObjectDetector understanding primitive (mocked D-FINE)."""
 
 from unittest.mock import MagicMock
 
@@ -8,40 +8,39 @@ import pytest
 from videopython.ai.understanding.objects import ObjectDetector
 
 
-class FakeBoxes:
-    """Minimal stand-in for an Ultralytics Results.boxes object."""
+def _result(scores, labels, boxes):
+    """A post_process_object_detection result dict (one per image).
 
-    def __init__(self, xyxy, conf, cls):
-        self.xyxy = [np.array(b, dtype=float) for b in xyxy]
-        self.conf = list(conf)
-        self.cls = list(cls)
-
-    def __len__(self):
-        return len(self.xyxy)
-
-
-class FakeResult:
-    def __init__(self, boxes, orig_shape):
-        self.boxes = boxes
-        self.orig_shape = orig_shape
+    ``.tolist()`` is all ObjectDetector reads, so numpy arrays stand in for the
+    torch tensors transformers returns.
+    """
+    return {
+        "scores": np.array(scores, dtype=float),
+        "labels": np.array(labels, dtype=int),
+        "boxes": np.array(boxes, dtype=float).reshape(-1, 4),
+    }
 
 
 def _detector_with(results, class_names=None, **kwargs):
-    """Build an ObjectDetector whose model is a mock returning ``results``."""
+    """Build an ObjectDetector whose processor/model are mocked.
+
+    ``results`` is the list (one dict per image) that the mocked
+    ``post_process_object_detection`` returns. The real ``_infer`` body (torch
+    no_grad, target_sizes) still runs; only the model + processor are faked.
+    """
     det = ObjectDetector(**kwargs)
     det._class_names = class_names or {0: "person", 2: "car"}
-    det._yolo_model = MagicMock(return_value=results)
+    processor = MagicMock()
+    processor.return_value = {"pixel_values": np.zeros((len(results), 3, 8, 8), dtype=np.float32)}
+    processor.post_process_object_detection.return_value = results
+    det._processor = processor
+    det._model = MagicMock(return_value=MagicMock())
     return det
 
 
 def _two_object_result():
     # person (conf 0.9) and car (conf 0.8) in a 100h x 200w image.
-    boxes = FakeBoxes(
-        xyxy=[[20.0, 10.0, 120.0, 60.0], [0.0, 0.0, 100.0, 50.0]],
-        conf=[0.9, 0.8],
-        cls=[0, 2],
-    )
-    return [FakeResult(boxes, orig_shape=(100, 200))]
+    return [_result(scores=[0.9, 0.8], labels=[0, 2], boxes=[[20.0, 10.0, 120.0, 60.0], [0.0, 0.0, 100.0, 50.0]])]
 
 
 class TestObjectDetector:
@@ -62,14 +61,22 @@ class TestObjectDetector:
 
     def test_results_sorted_by_confidence(self):
         # Provide lower-confidence first; detector should sort descending.
-        boxes = FakeBoxes(
-            xyxy=[[0, 0, 10, 10], [0, 0, 20, 20]],
-            conf=[0.4, 0.95],
-            cls=[2, 0],
-        )
-        det = _detector_with([FakeResult(boxes, (100, 100))])
+        results = [_result(scores=[0.4, 0.95], labels=[2, 0], boxes=[[0, 0, 10, 10], [0, 0, 20, 20]])]
+        det = _detector_with(results)
         objs = det.detect(np.zeros((100, 100, 3), dtype=np.uint8))
         assert [o.confidence for o in objs] == [0.95, 0.4]
+
+    def test_boxes_out_of_bounds_are_clamped(self):
+        # D-FINE can emit boxes slightly outside the frame; they must clamp to 0..1.
+        results = [_result(scores=[0.9], labels=[0], boxes=[[-5.0, -2.0, 220.0, 110.0]])]
+        det = _detector_with(results)
+        obj = det.detect(np.zeros((100, 200, 3), dtype=np.uint8))[0]
+        bb = obj.bounding_box
+        assert bb is not None
+        assert bb.x == pytest.approx(0.0)
+        assert bb.y == pytest.approx(0.0)
+        assert bb.x + bb.width == pytest.approx(1.0)
+        assert bb.y + bb.height == pytest.approx(1.0)
 
     def test_class_filter_drops_other_labels(self):
         det = _detector_with(_two_object_result(), class_filter=("person",))
@@ -77,7 +84,7 @@ class TestObjectDetector:
         assert [o.label for o in objs] == ["person"]
 
     def test_detect_handles_empty_results(self):
-        det = _detector_with([])
+        det = _detector_with([_result(scores=[], labels=[], boxes=[])])
         assert det.detect(np.zeros((10, 10, 3), dtype=np.uint8)) == []
 
     def test_detect_batch_list(self):
@@ -101,8 +108,8 @@ class TestObjectDetector:
         det = ObjectDetector(backend="cpu")
         assert det.execution_device() == "cpu"
 
-    def test_confidence_threshold_passed_to_model(self):
+    def test_confidence_threshold_passed_to_post_process(self):
         det = _detector_with(_two_object_result(), confidence_threshold=0.7)
         det.detect(np.zeros((100, 200, 3), dtype=np.uint8))
-        _, kwargs = det._yolo_model.call_args
-        assert kwargs["conf"] == 0.7
+        _, kwargs = det._processor.post_process_object_detection.call_args
+        assert kwargs["threshold"] == 0.7

--- a/src/tests/ai/test_transforms.py
+++ b/src/tests/ai/test_transforms.py
@@ -358,69 +358,17 @@ class TestFaceTrackingCropFraming:
         assert positions == [(657, 0)] * 10
 
 
-class TestGPUFaceTracking:
-    """Tests for GPU-accelerated face tracking features."""
+class TestTrackVideo:
+    """Tests for FaceSmoothingTracker.track_video (every-frame CPU detection)."""
 
-    def test_face_tracker_gpu_params(self):
-        """Test FaceSmoothingTracker accepts GPU parameters."""
-        tracker = FaceSmoothingTracker(
-            backend="gpu",
-            sample_rate=5,
-            batch_size=8,
-        )
-        assert tracker.backend == "gpu"
-        assert tracker.sample_rate == 5
+    def test_batch_size_is_stored(self):
+        tracker = FaceSmoothingTracker(batch_size=8)
         assert tracker.batch_size == 8
-
-    def test_face_tracker_default_backend_is_auto(self):
-        """Test FaceSmoothingTracker defaults to auto backend."""
-        tracker = FaceSmoothingTracker()
-        assert tracker.backend == "auto"
-
-    def test_face_tracking_crop_gpu_params(self):
-        """Test FaceTrackingCrop accepts and stores GPU parameters."""
-        crop = FaceTrackingCrop(
-            backend="gpu",
-            sample_rate=5,
-        )
-        assert crop.backend == "gpu"
-        assert crop.sample_rate == 5
-
-    def test_interpolate_bbox(self):
-        """Test bounding box interpolation."""
-        bbox1 = (0.0, 0.0, 0.1, 0.1)
-        bbox2 = (1.0, 1.0, 0.2, 0.2)
-
-        # t=0 should return bbox1
-        result = FaceSmoothingTracker._interpolate_bbox(bbox1, bbox2, 0.0)
-        assert result == bbox1
-
-        # t=1 should return bbox2
-        result = FaceSmoothingTracker._interpolate_bbox(bbox1, bbox2, 1.0)
-        assert result == bbox2
-
-        # t=0.5 should return midpoint
-        result = FaceSmoothingTracker._interpolate_bbox(bbox1, bbox2, 0.5)
-        assert result[0] == pytest.approx(0.5)
-        assert result[1] == pytest.approx(0.5)
-        assert result[2] == pytest.approx(0.15)
-        assert result[3] == pytest.approx(0.15)
-
-    def test_interpolate_bbox_quarter(self):
-        """Test bounding box interpolation at t=0.25."""
-        bbox1 = (0.2, 0.2, 0.1, 0.1)
-        bbox2 = (0.6, 0.6, 0.2, 0.2)
-
-        result = FaceSmoothingTracker._interpolate_bbox(bbox1, bbox2, 0.25)
-        assert result[0] == pytest.approx(0.3)  # 0.2 + 0.25 * 0.4
-        assert result[1] == pytest.approx(0.3)
-        assert result[2] == pytest.approx(0.125)  # 0.1 + 0.25 * 0.1
-        assert result[3] == pytest.approx(0.125)
 
     @patch("videopython.ai.transforms.FaceSmoothingTracker._init_detector")
     def test_track_video_with_mock(self, mock_init):
         """Test track_video with mocked detector."""
-        tracker = FaceSmoothingTracker(smoothing=0.0, sample_rate=1, backend="cpu")
+        tracker = FaceSmoothingTracker(smoothing=0.0)
 
         mock_detector = MagicMock()
         # Return faces for batched detection
@@ -440,32 +388,6 @@ class TestGPUFaceTracking:
         mock_detector.detect_batch.assert_called_once()
 
     @patch("videopython.ai.transforms.FaceSmoothingTracker._init_detector")
-    def test_track_video_with_sampling(self, mock_init):
-        """Test track_video with frame sampling and interpolation."""
-        tracker = FaceSmoothingTracker(smoothing=0.0, sample_rate=3, backend="gpu")
-
-        mock_detector = MagicMock()
-        # Return faces only for sampled frames (frames 0, 3, 6, 9)
-        # For 10 frames with sample_rate=3: indices 0, 3, 6, 9
-        mock_detector.detect_batch.return_value = [
-            [MockDetectedFace((0.3, 0.3), 0.1, 0.1)],  # frame 0
-            [MockDetectedFace((0.5, 0.5), 0.1, 0.1)],  # frame 3
-            [MockDetectedFace((0.7, 0.7), 0.1, 0.1)],  # frame 6
-            [MockDetectedFace((0.7, 0.7), 0.1, 0.1)],  # frame 9
-        ]
-        tracker._detector = mock_detector
-
-        frames = np.zeros((10, 1080, 1920, 3), dtype=np.uint8)
-        results = tracker.track_video(frames)
-
-        assert len(results) == 10
-        # Sampled frames should have exact values
-        assert results[0][0] == pytest.approx(0.3, abs=0.01)
-        # Interpolated frames should be between sampled values
-        # Frame 1 should be interpolated between frame 0 and 3
-        assert 0.3 < results[1][0] < 0.5
-
-    @patch("videopython.ai.transforms.FaceSmoothingTracker._init_detector")
     def test_track_video_empty_frames(self, mock_init):
         """Test track_video with empty frame list."""
         tracker = FaceSmoothingTracker()
@@ -476,46 +398,17 @@ class TestGPUFaceTracking:
         assert results == []
 
     @patch("videopython.ai.understanding.faces._FaceDetector")
-    def test_face_tracker_passes_gpu_params_to_detector(self, mock_detector_class):
-        """Test FaceSmoothingTracker passes GPU params to internal detector backend."""
+    def test_track_video_builds_detector_with_min_face_size(self, mock_detector_class):
+        """track_video lazily builds the YuNet detector with the configured params."""
         mock_detector = MagicMock()
         mock_detector.detect_batch.return_value = [[]]
         mock_detector_class.return_value = mock_detector
 
-        tracker = FaceSmoothingTracker(
-            backend="gpu",
-            min_face_size=50,
-        )
-
-        # Initialize detector by calling track_video
+        tracker = FaceSmoothingTracker(min_face_size=50)
         frames = np.zeros((1, 100, 100, 3), dtype=np.uint8)
         tracker.track_video(frames)
 
-        # Verify detector backend was created with correct params
-        mock_detector_class.assert_called_once_with(
-            min_face_size=50,
-            backend="gpu",
-        )
-
-    @patch("videopython.ai.transforms.FaceSmoothingTracker")
-    def test_face_tracking_crop_passes_params_to_tracker(self, mock_tracker_class):
-        """Test FaceTrackingCrop passes GPU params to FaceSmoothingTracker."""
-        mock_tracker = MagicMock()
-        mock_tracker.detect_and_track.return_value = (0.5, 0.5, 0.1, 0.1)
-        mock_tracker_class.return_value = mock_tracker
-
-        frames = [np.zeros((480, 640, 3), dtype=np.uint8)] * 5
-
-        crop = FaceTrackingCrop(
-            backend="gpu",
-            sample_rate=5,
-        )
-        crop._track_crop_positions(frames, 640, 480)
-
-        # Verify FaceSmoothingTracker was created with GPU params
-        call_kwargs = mock_tracker_class.call_args[1]
-        assert call_kwargs["backend"] == "gpu"
-        assert call_kwargs["sample_rate"] == 5
+        mock_detector_class.assert_called_once_with(min_face_size=50)
 
 
 class TestFaceCropSubtitleValidateGap:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -6,7 +6,7 @@ Test structure:
 
 AI test markers:
 - @pytest.mark.requires_model_download - Tests that download models 100MB+
-  (e.g., YOLOv8-face, Qwen3.5, PANNs). These are skipped in CI.
+  (e.g., D-FINE, YuNet, Whisper). These are skipped in CI.
 
 CI runs: uv run pytest src/tests/ai -m "not requires_model_download"
 Local runs: uv run pytest src/tests/ai -v (all tests including model downloads)
@@ -68,8 +68,7 @@ def pytest_configure(config):
     """Register custom pytest markers."""
     config.addinivalue_line(
         "markers",
-        "requires_model_download: marks tests that download heavy AI models "
-        "(YOLOv8-face, Qwen3.5, PANNs, Whisper) - skipped in CI",
+        "requires_model_download: marks tests that download heavy AI models (D-FINE, YuNet, Whisper) - skipped in CI",
     )
 
 

--- a/src/tests/test_packaging_extras.py
+++ b/src/tests/test_packaging_extras.py
@@ -53,7 +53,6 @@ _HEAVY_IMPORT_NAMES: set[str] = {
     "whisper",
     "pyannote",
     "silero_vad",
-    "ultralytics",
     "transnetv2_pytorch",
     "chatterbox",
     "demucs",
@@ -126,9 +125,10 @@ def test_dependency_group_ai_matches_optional_ai(pyproject: Pyproject) -> None:
 
 # Deps that are declared as resolver co-pins/floors but have NO direct import
 # under ai/ — they're pulled transitively by a sibling dep that we DO import:
-#   torchaudio  -> co-pin for the torch stack (whisper/chatterbox/demucs)
-#   accelerate  -> diffusers/transformers device-map plumbing (transitive)
-_TRANSITIVE_ONLY_DEPS = {"torchaudio", "accelerate"}
+#   torchaudio   -> co-pin for the torch stack (whisper/chatterbox/demucs)
+#   torchvision  -> backs the transformers "fast" image processor used by D-FINE
+#   accelerate   -> diffusers/transformers device-map plumbing (transitive)
+_TRANSITIVE_ONLY_DEPS = {"torchaudio", "torchvision", "accelerate"}
 
 
 def test_every_declared_dep_is_imported_somewhere(pyproject: Pyproject) -> None:

--- a/src/videopython/ai/__init__.py
+++ b/src/videopython/ai/__init__.py
@@ -5,7 +5,7 @@ Every public symbol is re-exported lazily via PEP 562 ``__getattr__`` so that
 leaf module backing the requested symbol — not every sibling. All AI capabilities
 ship in the single ``[ai]`` extra; the laziness keeps ``import videopython`` (and
 importing one leaf class) light by deferring the heavy ML imports (torch /
-transformers / diffusers / ultralytics) until a symbol is actually used. When
+transformers / diffusers / chatterbox) until a symbol is actually used. When
 ``[ai]`` is not installed, touching a symbol raises a clear
 ``pip install 'videopython[ai]'``-pointing ``ImportError`` at attribute access
 instead of failing the whole package import.

--- a/src/videopython/ai/_optional.py
+++ b/src/videopython/ai/_optional.py
@@ -52,7 +52,7 @@ def lazy_exports(package: str, exports: dict[str, str]) -> tuple[Callable[[str],
     imported only on first attribute access, so importing the package does not
     pull in any sibling leaf module. This keeps ``import videopython`` (and
     importing a single leaf class) light by deferring the heavy ML imports
-    (torch / transformers / diffusers / ultralytics) until a symbol is used.
+    (torch / transformers / diffusers / chatterbox) until a symbol is used.
 
     Args:
         package: The ``__name__`` of the package defining the re-exports. Used

--- a/src/videopython/ai/_predictor.py
+++ b/src/videopython/ai/_predictor.py
@@ -19,9 +19,9 @@ Subclasses with non-default model fields just declare ``_model_attrs``; those
 whose teardown isn't "null the fields + release" (e.g. delegating to a client's
 own ``unload()``) override ``unload()`` instead.
 
-The base imports no torch / transformers / ultralytics (``release_device_memory``
-defers its torch import), so it stays safe to mix into any predictor regardless
-of how it is constructed.
+The base imports no torch / transformers (``release_device_memory`` defers its
+torch import), so it stays safe to mix into any predictor regardless of how it is
+constructed.
 """
 
 from __future__ import annotations

--- a/src/videopython/ai/_revisions.py
+++ b/src/videopython/ai/_revisions.py
@@ -33,14 +33,6 @@ Usage:
 # documented here rather than registered above. ``pinned()`` returns None for
 # them, which leaves the caller on its current (unpinned) behavior.
 #
-#   * ultralytics YOLO asset -- ai/understanding/objects.py loads
-#     ``YOLO(self.model_name)`` (e.g. "yolov8n.pt"). Ultralytics resolves and
-#     downloads this from its own GitHub release assets, not from a HF repo,
-#     so there is no HF revision to pin. (The face detector in
-#     ai/understanding/faces.py is different: it pulls a YOLOv8 *checkpoint*
-#     from the HF repo ``arnabdhar/YOLOv8-Face-Detection`` via
-#     hf_hub_download, and that one IS pinned below.)
-#
 #   * Chatterbox internal load -- ai/generation/audio.py calls
 #     ``ChatterboxMultilingualTTS.from_pretrained(device=...)`` with no repo
 #     argument. The repo id + revision are resolved internally by the
@@ -67,8 +59,16 @@ MODEL_REVISIONS: dict[str, str] = {
     "pyannote/speaker-diarization-community-1": "3533c8cf8e369892e6b79ff1bf80f7b0286a54ee",
     # Audio event classifier (ai/understanding/classification.py: AudioClassifier)
     "MIT/ast-finetuned-audioset-10-10-0.4593": "f826b80d28226b62986cc218e5cec390b1096902",
-    # Face detection checkpoint (ai/understanding/faces.py: hf_hub_download)
-    "arnabdhar/YOLOv8-Face-Detection": "52fa54977207fa4f021de949b515fb19dcab4488",
+    # Object detection — D-FINE COCO (ai/understanding/objects.py: ObjectDetector).
+    # Apache-2.0; replaced the AGPL Ultralytics YOLO weights. Loaded by AutoImageProcessor
+    # AND DFineForObjectDetection.from_pretrained, both keyed on the full repo id.
+    "ustc-community/dfine-nano-coco": "066438d3d8f0da137a37b38fdf3368fd4afceced",
+    "ustc-community/dfine-small-coco": "f79e65b5fbb33ceb9d3ebba042955d7410c608f8",
+    "ustc-community/dfine-medium-coco": "4ab9f5e466432f4fcf9a9a023da6aa5ecc9c9829",
+    "ustc-community/dfine-large-coco": "aa8f8211545e4cff5adf52ea512f9ac74a9824ec",
+    # Face detection checkpoint — OpenCV YuNet ONNX, MIT (ai/understanding/faces.py:
+    # hf_hub_download). Replaced the AGPL arnabdhar/YOLOv8-Face-Detection weights.
+    "opencv/face_detection_yunet": "3cc26e7f1014a5ee5d74a42acee58bafc9d0a310",
     # MusicGen (ai/generation/audio.py: TextToMusic)
     "facebook/musicgen-small": "4c8334b02c6ec4e8664a91979669a501ec497792",
     # SDXL (ai/generation/image.py: TextToImage)

--- a/src/videopython/ai/auto_edit/local.py
+++ b/src/videopython/ai/auto_edit/local.py
@@ -11,16 +11,17 @@ from .backend import PlannerError
 if TYPE_CHECKING:
     import numpy as np
 
-DEFAULT_OLLAMA_MODEL = "gemma3:27b"
+DEFAULT_OLLAMA_MODEL = "qwen3.6:27b"
 
 
 class OllamaVisionLLM:
     """A StructuredVisionLLM backed by a local Ollama server.
 
     The model must be vision-capable (it is sent keyframes) AND support Ollama's
-    structured-output ``format`` (the EditPlan schema constrains the decode). Not
-    every model supports schema conditioning -- ``gemma3:27b`` is verified working;
-    some builds (e.g. certain MLX ones) fail it. ``ollama pull <model>`` first;
+    structured-output ``format`` (the EditPlan schema constrains the decode). The
+    default ``qwen3.6:27b`` is an Apache-2.0 vision model; not every model supports
+    schema conditioning (some builds, e.g. certain MLX ones, fail it), so confirm
+    ``format`` works for a custom model locally. ``ollama pull <model>`` first;
     ``options`` are extra generation options merged over ``temperature=0``.
 
     Thin wrapper over the shared :class:`OllamaStructuredClient`: its only job is

--- a/src/videopython/ai/dubbing/translation.py
+++ b/src/videopython/ai/dubbing/translation.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # Default Ollama text model for translation; override via the `model` arg (and
 # `ollama pull` it first). Any instruct model that supports structured output works.
-DEFAULT_TRANSLATION_MODEL = "gemma3:27b"
+DEFAULT_TRANSLATION_MODEL = "qwen3.6:27b"
 
 
 def _is_translatable_text(text: str) -> bool:

--- a/src/videopython/ai/effects.py
+++ b/src/videopython/ai/effects.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 import numpy as np
 from pydantic import Field, PrivateAttr
 
-from videopython.ai.understanding.objects import ObjectDetector
+from videopython.ai.understanding.objects import MODEL_SIZES, ObjectDetector
 from videopython.base.description import DetectedObject
 from videopython.base.draw_detections import DetectionStyle, draw_detections
 from videopython.editing.operation import Effect
@@ -25,7 +25,7 @@ __all__ = ["ObjectDetectionOverlay"]
 class ObjectDetectionOverlay(Effect):
     """Detect objects per frame and overlay labelled bounding boxes.
 
-    Runs a YOLOv8-COCO detector and composites tidy, colour-coded boxes with
+    Runs a D-FINE COCO detector and composites tidy, colour-coded boxes with
     class labels (and optional confidence) onto every frame in the window.
 
     Detection runs on a ``detection_interval`` cadence in the streaming path and
@@ -70,7 +70,7 @@ class ObjectDetectionOverlay(Effect):
     model_size: Literal["n", "s", "m"] = Field(
         "n",
         description=(
-            "YOLOv8 model size: 'n' (nano, fastest), 's' (small), 'm' (medium, most accurate). "
+            "D-FINE detector size: 'n' (nano, fastest), 's' (small), 'm' (medium, most accurate). "
             "Larger detects better but is slower."
         ),
     )
@@ -96,7 +96,7 @@ class ObjectDetectionOverlay(Effect):
         """Build the detector lazily. Single patch point for tests."""
         if self._detector is None:
             self._detector = ObjectDetector(
-                model_name=f"yolov8{self.model_size}.pt",
+                model_name=MODEL_SIZES[self.model_size],
                 confidence_threshold=self.confidence_threshold,
                 class_filter=tuple(self.class_filter or ()),
                 backend=self.backend,

--- a/src/videopython/ai/transforms.py
+++ b/src/videopython/ai/transforms.py
@@ -74,8 +74,6 @@ class FaceTrackingCrop(Operation):
         ),
     )
     detection_interval: int = Field(3, ge=1, description="Frames between face detections.")
-    backend: Literal["cpu", "gpu", "auto"] = Field("auto", description='Detection backend - "cpu", "gpu", or "auto".')
-    sample_rate: int = Field(1, ge=1, description="For GPU backend, detect every Nth frame and interpolate.")
 
     def _apply_framing_offset(self, face_cx: float, face_cy: float, face_h: float) -> tuple[float, float]:
         if self.framing_rule == "offset":
@@ -139,8 +137,6 @@ class FaceTrackingCrop(Operation):
             face_index=self.face_index,
             smoothing=self.smoothing,
             detection_interval=self.detection_interval,
-            backend=self.backend,
-            sample_rate=self.sample_rate,
         )
         default = ((frame_w - out_w) // 2, (frame_h - out_h) // 2)
         last = default

--- a/src/videopython/ai/understanding/_detector.py
+++ b/src/videopython/ai/understanding/_detector.py
@@ -1,21 +1,21 @@
-"""Shared lazy YOLOv8 detector wrapper for the understanding layer.
+"""Shared lazy detector base for the understanding layer.
 
-``ObjectDetector`` (COCO objects) and ``_FaceDetector`` (faces) were nearly
-identical YOLO wrappers: same ``cpu``/``gpu``/``auto`` device resolution, same
-lazy load + ``.to("cuda")``, same ``detect`` / ``detect_batch`` shape, differing
-only in how the model is loaded and how a result is parsed into detections.
-:class:`YoloDetector` holds all the shared machinery; subclasses supply just
-``_load_model`` (build ``self._yolo_model``), ``_parse`` (one result -> list of
-detections), and ``_conf`` (the confidence passed to YOLO).
+``ObjectDetector`` (COCO objects, D-FINE via transformers) and ``_FaceDetector``
+(faces, OpenCV YuNet) share the same machinery: ``cpu``/``gpu``/``auto`` device
+resolution, lazy load, the ``detect`` / ``detect_batch`` shape, and ``unload``.
+:class:`DetectorBase` holds that machinery; subclasses supply just ``_load_model``
+(populate the ``_model_attrs`` fields) and ``_infer`` (map a batch of frames to a
+list of per-frame detections).
 
-The heavy ``ultralytics`` import is deferred to :meth:`_build_yolo` (guarded by
-``require``), so constructing a detector pulls in no torch until it actually runs.
+The two backends are completely different (transformers vs OpenCV DNN), so the
+base imports no model library itself; each subclass defers its heavy import into
+``_load_model`` (guarded by ``require`` where the dep lives in the ``[ai]`` extra).
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Generic, Literal, TypeVar
+from typing import Generic, Literal, TypeVar
 
 import numpy as np
 
@@ -28,26 +28,25 @@ T = TypeVar("T")
 Backend = Literal["cpu", "gpu", "auto"]
 
 
-class YoloDetector(ManagedPredictor, Generic[T]):
-    """Lazy YOLOv8 wrapper: device resolution, lazy load, detect/detect_batch, unload.
+class DetectorBase(ManagedPredictor, Generic[T]):
+    """Lazy detector base: device resolution, lazy load, detect/detect_batch, unload.
 
     Context-managed via :class:`ManagedPredictor`; ``unload()`` drops the model
-    and frees the resolved device. Subclass contract:
+    reference(s) named in ``_model_attrs`` and frees the resolved device. Subclass
+    contract:
       * ``_FEATURE`` -- name surfaced in the ``[ai]``-extra ``ImportError``.
-      * ``_load_model()`` -- set ``self._yolo_model`` (call :meth:`_build_yolo`)
-        plus any label state.
-      * ``_parse(result)`` -- map one ultralytics result to a list of detections.
-      * ``_conf()`` -- the ``conf`` threshold passed to the model.
+      * ``_model_attrs`` -- attribute(s) holding loaded model state; the first one
+        doubles as the "is loaded" sentinel.
+      * ``_load_model()`` -- populate the ``_model_attrs`` fields plus any label state.
+      * ``_infer(images)`` -- map a list of frames to a list of per-frame detections.
     """
 
-    _FEATURE = "YoloDetector"
-    _model_attrs = ("_yolo_model",)
+    _FEATURE = "detector"
     _device_attr = "_resolved_device"
 
     def __init__(self, *, backend: Backend = "auto") -> None:
         self.backend: Backend = backend
         self._resolved_device: Literal["cpu", "cuda"] | None = None
-        self._yolo_model: Any = None
 
     def _resolve_device(self) -> Literal["cpu", "cuda"]:
         if self._resolved_device is not None:
@@ -67,37 +66,23 @@ class YoloDetector(ManagedPredictor, Generic[T]):
         """Resolved execution device for this detector."""
         return self._resolve_device()
 
-    def _build_yolo(self, model_path: str) -> None:
-        """Construct ``self._yolo_model`` from a model id/path and move it to the device."""
-        from videopython.ai._optional import require
-
-        YOLO = require("ultralytics", feature=self._FEATURE).YOLO
-        self._yolo_model = YOLO(model_path)
-        if self._resolve_device() == "cuda":
-            self._yolo_model.to("cuda")
-
     # --- subclass hooks -----------------------------------------------------
     def _load_model(self) -> None:
         raise NotImplementedError
 
-    def _conf(self) -> float:
-        raise NotImplementedError
-
-    def _parse(self, result: Any) -> list[T]:
+    def _infer(self, images: list[np.ndarray]) -> list[list[T]]:
         raise NotImplementedError
 
     # --- public API ---------------------------------------------------------
     def _ensure_loaded(self) -> None:
-        if self._yolo_model is None:
+        if getattr(self, self._model_attrs[0], None) is None:
             self._load_model()
 
     def detect(self, image: np.ndarray) -> list[T]:
         """Detect in a single ``(H, W, 3)`` frame."""
         self._ensure_loaded()
-        results = self._yolo_model(image, conf=self._conf(), verbose=False)
-        if not results:
-            return []
-        return self._parse(results[0])
+        results = self._infer([image])
+        return results[0] if results else []
 
     def detect_batch(self, images: list[np.ndarray] | np.ndarray) -> list[list[T]]:
         """Detect in a batch of frames (list or stacked ``(N, H, W, 3)``)."""
@@ -107,5 +92,4 @@ class YoloDetector(ManagedPredictor, Generic[T]):
             return []
 
         self._ensure_loaded()
-        results = self._yolo_model(images, conf=self._conf(), verbose=False)
-        return [self._parse(result) for result in results]
+        return self._infer(images)

--- a/src/videopython/ai/understanding/faces.py
+++ b/src/videopython/ai/understanding/faces.py
@@ -14,14 +14,19 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
+import cv2
 import numpy as np
 
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
-from videopython.ai.understanding._yolo import Backend, YoloDetector
+from videopython.ai.understanding._detector import DetectorBase
 from videopython.base.description import BoundingBox, DetectedFace, FaceTrack
 
 logger = logging.getLogger(__name__)
+
+# OpenCV YuNet face detector (MIT). Pinned in ``_revisions.py``.
+_YUNET_REPO = "opencv/face_detection_yunet"
+_YUNET_FILENAME = "face_detection_yunet_2023mar.onnx"
 
 
 # Hamming/IoU tunables. Module-level constants — same convention as the
@@ -31,59 +36,81 @@ DEFAULT_IOU_MATCH_THRESHOLD = 0.3
 DEFAULT_MAX_MISSED_FRAMES = 3
 
 
-class _FaceDetector(YoloDetector[DetectedFace]):
-    """Internal YOLOv8-face detector over the shared :class:`YoloDetector` base.
+class _FaceDetector(DetectorBase[DetectedFace]):
+    """Internal OpenCV YuNet face detector over the shared :class:`DetectorBase`.
 
-    Pulls the pinned ``arnabdhar/YOLOv8-Face-Detection`` checkpoint and filters
-    detections below ``min_face_size`` pixels. Producers in ``transforms.py``
-    reach for this class via the lifted module path.
+    Pulls the pinned ``opencv/face_detection_yunet`` ONNX checkpoint (MIT) and
+    filters detections below ``min_face_size`` pixels. Runs on CPU via OpenCV DNN.
+    Producers in ``transforms.py`` reach for this class via the lifted module path.
     """
 
     CONFIDENCE_THRESHOLD = 0.5
+    NMS_THRESHOLD = 0.3
+    TOP_K = 5000
     _FEATURE = "face tracking"
+    _model_attrs = ("_yunet",)
 
-    def __init__(
-        self,
-        min_face_size: int = 30,
-        backend: Backend = "auto",
-    ):
-        super().__init__(backend=backend)
+    def __init__(self, min_face_size: int = 30):
+        super().__init__(backend="cpu")  # YuNet runs on CPU via OpenCV DNN
         self.min_face_size = min_face_size
+        self._yunet: Any = None
+        self._input_size: tuple[int, int] | None = None  # (w, h) currently set on the model
 
-    def _conf(self) -> float:
-        return self.CONFIDENCE_THRESHOLD
+    def execution_device(self) -> Literal["cpu", "cuda"]:
+        """YuNet runs on CPU via OpenCV DNN."""
+        return "cpu"
 
     def _load_model(self) -> None:
         from huggingface_hub import hf_hub_download
 
         model_path = hf_hub_download(
-            repo_id="arnabdhar/YOLOv8-Face-Detection",
-            filename="model.pt",
-            revision=pinned("arnabdhar/YOLOv8-Face-Detection"),
+            repo_id=_YUNET_REPO,
+            filename=_YUNET_FILENAME,
+            revision=pinned(_YUNET_REPO),
         )
-        self._build_yolo(model_path)
+        # input_size is a placeholder; setInputSize() per frame overrides it.
+        self._yunet = cv2.FaceDetectorYN.create(  # type: ignore[attr-defined]
+            model_path,
+            "",
+            (320, 320),
+            self.CONFIDENCE_THRESHOLD,
+            self.NMS_THRESHOLD,
+            self.TOP_K,
+        )
+        self._input_size = (320, 320)
 
-    def _parse(self, result: Any) -> list[DetectedFace]:
+    def _infer(self, images: list[np.ndarray]) -> list[list[DetectedFace]]:
+        # YuNet has no batch API; detect one frame at a time.
+        return [self._detect_one(image) for image in images]
+
+    def _detect_one(self, frame: np.ndarray) -> list[DetectedFace]:
+        img_h, img_w = frame.shape[:2]
+        size = (img_w, img_h)
+        if self._input_size != size:
+            self._yunet.setInputSize(size)
+            self._input_size = size
+        # videopython frames are RGB; OpenCV DNN expects BGR.
+        bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        _, faces = self._yunet.detect(bgr)
+        return self._parse(faces, img_w, img_h)
+
+    def _parse(self, faces: np.ndarray | None, img_w: int, img_h: int) -> list[DetectedFace]:
         detected_faces: list[DetectedFace] = []
-        boxes = result.boxes
-        if boxes is None:
+        if faces is None or len(faces) == 0:
             return detected_faces
 
-        img_h, img_w = result.orig_shape
-        for i in range(len(boxes)):
-            x1, y1, x2, y2 = boxes.xyxy[i].tolist()
-            conf = float(boxes.conf[i])
-
-            face_w = x2 - x1
-            face_h = y2 - y1
+        # YuNet rows: [x, y, w, h, 5x(lx, ly) landmarks, score]; coords are pixels.
+        for row in faces:
+            x, y, face_w, face_h = float(row[0]), float(row[1]), float(row[2]), float(row[3])
+            conf = float(row[14])
             if face_w < self.min_face_size or face_h < self.min_face_size:
                 continue
 
             detected_faces.append(
                 DetectedFace(
                     bounding_box=BoundingBox(
-                        x=x1 / img_w,
-                        y=y1 / img_h,
+                        x=x / img_w,
+                        y=y / img_h,
                         width=face_w / img_w,
                         height=face_h / img_h,
                     ),
@@ -122,14 +149,13 @@ class _FaceTrackerBase(ManagedPredictor):
     the :class:`ManagedPredictor` context-manager contract.
     """
 
-    def __init__(self, *, min_face_size: int, backend: Backend) -> None:
+    def __init__(self, *, min_face_size: int) -> None:
         self.min_face_size = min_face_size
-        self.backend: Backend = backend
         self._detector: _FaceDetector | None = None
 
     def _init_detector(self) -> None:
         """Initialize the face detector lazily."""
-        self._detector = _FaceDetector(min_face_size=self.min_face_size, backend=self.backend)
+        self._detector = _FaceDetector(min_face_size=self.min_face_size)
 
     def _ensure_detector(self) -> _FaceDetector:
         if self._detector is None:
@@ -159,8 +185,6 @@ class FaceSmoothingTracker(_FaceTrackerBase):
         smoothing: float = 0.8,
         detection_interval: int = 3,
         min_face_size: int = 30,
-        backend: Backend = "auto",
-        sample_rate: int = 1,
         batch_size: int = 16,
     ):
         """Initialize the smoothing tracker.
@@ -172,23 +196,19 @@ class FaceSmoothingTracker(_FaceTrackerBase):
             smoothing: Exponential moving average factor (0-1). Higher = smoother.
             detection_interval: Run detection every N frames, hold position between.
             min_face_size: Minimum face size in pixels for detection.
-            backend: Detection backend - "cpu", "gpu", or "auto".
-            sample_rate: For GPU backend, detect every Nth frame and interpolate.
-                Only used by track_video(). Default 1 (every frame).
-            batch_size: Batch size for GPU detection. Default 16.
+            batch_size: Frames per detection batch in ``track_video``. Default 16.
         """
-        super().__init__(min_face_size=min_face_size, backend=backend)
+        super().__init__(min_face_size=min_face_size)
         self.selection_strategy = selection_strategy
         self.face_index = face_index
         self.smoothing = smoothing
         self.detection_interval = detection_interval
-        self.sample_rate = sample_rate
         self.batch_size = batch_size
         self._last_position: tuple[float, float] | None = None
         self._last_size: tuple[float, float] | None = None
         self._smoothed_position: tuple[float, float] | None = None
         self._smoothed_size: tuple[float, float] | None = None
-        logger.info("FaceSmoothingTracker initialized with backend=%s", self.backend)
+        logger.info("FaceSmoothingTracker initialized (detection_interval=%s)", self.detection_interval)
 
     def _select_face(
         self,
@@ -297,35 +317,21 @@ class FaceSmoothingTracker(_FaceTrackerBase):
         self._smoothed_position = None
         self._smoothed_size = None
 
-    @staticmethod
-    def _interpolate_bbox(
-        bbox1: tuple[float, float, float, float],
-        bbox2: tuple[float, float, float, float],
-        t: float,
-    ) -> tuple[float, float, float, float]:
-        """Linearly interpolate between two bounding boxes."""
-        return (
-            bbox1[0] + (bbox2[0] - bbox1[0]) * t,
-            bbox1[1] + (bbox2[1] - bbox1[1]) * t,
-            bbox1[2] + (bbox2[2] - bbox1[2]) * t,
-            bbox1[3] + (bbox2[3] - bbox1[3]) * t,
-        )
-
     def track_video(
         self,
         frames: np.ndarray,
     ) -> list[tuple[float, float, float, float] | None]:
-        """Track face through entire video using optimized batch detection.
+        """Track the face through a whole clip via batched per-frame detection.
 
-        Optimized for GPU backends with frame sampling and interpolation
-        for smooth tracking with reduced computation.
+        Detection runs on every frame (the YuNet detector is CPU-only), then each
+        frame's selected face is EMA-smoothed.
 
         Args:
             frames: Video frames array of shape (N, H, W, 3).
 
         Returns:
-            List of face positions (cx, cy, w, h) for each frame, or None if
-            no face detected and no fallback available.
+            List of face positions (cx, cy, w, h) for each frame, or None where
+            no face was detected and no fallback was available.
         """
         if self._detector is None:
             self._init_detector()
@@ -337,69 +343,14 @@ class FaceSmoothingTracker(_FaceTrackerBase):
 
         h, w = frames[0].shape[:2]
 
-        execution_device_getter = getattr(self._detector, "execution_device", None)
-        if callable(execution_device_getter):
-            resolved = execution_device_getter()
-            backend_execution_device = resolved if resolved in {"cpu", "cuda"} else None
-        else:
-            backend_execution_device = None
-        if backend_execution_device is None:
-            backend_execution_device = "cuda" if self.backend == "gpu" else "cpu"
+        detections: list[list[DetectedFace]] = []
+        for batch_start in range(0, n_frames, self.batch_size):
+            batch = [frames[i] for i in range(batch_start, min(batch_start + self.batch_size, n_frames))]
+            detections.extend(self._detector.detect_batch(batch))
 
-        use_sampled_interpolation = self.sample_rate > 1 and backend_execution_device == "cuda"
-
-        if use_sampled_interpolation:
-            sample_indices = list(range(0, n_frames, self.sample_rate))
-            if sample_indices[-1] != n_frames - 1:
-                sample_indices.append(n_frames - 1)
-        else:
-            sample_indices = list(range(n_frames))
-
-        sampled_frames = [frames[i] for i in sample_indices]
-
-        sampled_detections: list[list[DetectedFace]] = []
-        for batch_start in range(0, len(sampled_frames), self.batch_size):
-            batch_end = min(batch_start + self.batch_size, len(sampled_frames))
-            batch = sampled_frames[batch_start:batch_end]
-            batch_results = self._detector.detect_batch(batch)
-            sampled_detections.extend(batch_results)
-
-        sampled_faces: list[tuple[float, float, float, float] | None] = []
-        for faces in sampled_detections:
-            face_info = self._select_face(faces, w, h)
-            sampled_faces.append(face_info)
-
-        if not use_sampled_interpolation:
-            self.reset()
-            return [self._smooth(face_info) for face_info in sampled_faces]
-
-        all_positions: list[tuple[float, float, float, float] | None] = [None] * n_frames
-
-        for idx, sample_idx in enumerate(sample_indices):
-            all_positions[sample_idx] = sampled_faces[idx]
-
-        for i in range(len(sample_indices) - 1):
-            start_idx = sample_indices[i]
-            end_idx = sample_indices[i + 1]
-            start_face = sampled_faces[i]
-            end_face = sampled_faces[i + 1]
-
-            if start_face is None and end_face is None:
-                continue
-            elif start_face is None:
-                for j in range(start_idx, end_idx):
-                    all_positions[j] = end_face
-            elif end_face is None:
-                for j in range(start_idx + 1, end_idx + 1):
-                    all_positions[j] = start_face
-            else:
-                gap = end_idx - start_idx
-                for j in range(start_idx + 1, end_idx):
-                    t = (j - start_idx) / gap
-                    all_positions[j] = self._interpolate_bbox(start_face, end_face, t)
-
+        faces = [self._select_face(frame_faces, w, h) for frame_faces in detections]
         self.reset()
-        return [self._smooth(face_info) for face_info in all_positions]
+        return [self._smooth(face_info) for face_info in faces]
 
 
 class FaceShotTracker(_FaceTrackerBase):
@@ -414,7 +365,6 @@ class FaceShotTracker(_FaceTrackerBase):
     def __init__(
         self,
         min_face_size: int = 30,
-        backend: Backend = "auto",
         batch_size: int = 16,
         iou_match_threshold: float = DEFAULT_IOU_MATCH_THRESHOLD,
         max_missed_frames: int = DEFAULT_MAX_MISSED_FRAMES,
@@ -423,18 +373,17 @@ class FaceShotTracker(_FaceTrackerBase):
 
         Args:
             min_face_size: Minimum face size in pixels for detection.
-            backend: Detection backend - "cpu", "gpu", or "auto".
             batch_size: Batch size for detection. Default 16.
             iou_match_threshold: Minimum IoU between consecutive detections to
                 continue an existing track.
             max_missed_frames: Consecutive frames a track may go without a
                 detection before it is closed.
         """
-        super().__init__(min_face_size=min_face_size, backend=backend)
+        super().__init__(min_face_size=min_face_size)
         self.batch_size = batch_size
         self.iou_match_threshold = iou_match_threshold
         self.max_missed_frames = max_missed_frames
-        logger.info("FaceShotTracker initialized with backend=%s", self.backend)
+        logger.info("FaceShotTracker initialized (min_face_size=%s)", self.min_face_size)
 
     def track_shot(
         self,

--- a/src/videopython/ai/understanding/image.py
+++ b/src/videopython/ai/understanding/image.py
@@ -11,7 +11,7 @@ from videopython.ai._ollama import OllamaStructuredClient
 from videopython.ai._predictor import ManagedPredictor
 from videopython.base.description import SceneDescription
 
-DEFAULT_SCENE_VLM_MODEL = "gemma3:27b"
+DEFAULT_SCENE_VLM_MODEL = "qwen3.6:27b"
 
 _SHOT_TYPES = ("wide", "medium", "close-up", "extreme close-up", "establishing", "other")
 

--- a/src/videopython/ai/understanding/objects.py
+++ b/src/videopython/ai/understanding/objects.py
@@ -1,42 +1,62 @@
 """General object detection for the understanding layer.
 
 ``ObjectDetector`` is the object-detection counterpart to the face detector in
-``faces.py``: a lazy YOLOv8-COCO wrapper returning
+``faces.py``: a lazy D-FINE COCO detector (transformers) returning
 :class:`~videopython.base.description.DetectedObject` with normalized bounding
-boxes. Both share :class:`~videopython.ai.understanding._yolo.YoloDetector`
+boxes. Both share :class:`~videopython.ai.understanding._detector.DetectorBase`
 (lazy init, device selection, ``detect`` / ``detect_batch`` / ``unload``), so the
 two stay one mental model. Consumed by
 ``videopython.ai.effects.ObjectDetectionOverlay``; usable directly for any
 per-frame object analysis.
+
+D-FINE (Apache-2.0) replaced the AGPL-licensed Ultralytics YOLO weights. Its COCO
+labels use VOC-style spellings (``motorbike``, ``aeroplane``, ``sofa``, ``pottedplant``,
+``diningtable``, ``tvmonitor``) -- ``class_filter`` must use the model's exact names.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from videopython.ai.understanding._yolo import Backend, YoloDetector
+from videopython.ai._revisions import pinned
+from videopython.ai.understanding._detector import Backend, DetectorBase
 from videopython.base.description import BoundingBox, DetectedObject
+
+if TYPE_CHECKING:
+    import numpy as np
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ObjectDetector"]
+__all__ = ["ObjectDetector", "MODEL_SIZES"]
+
+# D-FINE COCO checkpoints (Apache-2.0), in ascending size/quality. ``model_size``
+# on ``ObjectDetectionOverlay`` maps onto these; pinned in ``_revisions.py``.
+MODEL_SIZES: dict[str, str] = {
+    "n": "ustc-community/dfine-nano-coco",
+    "s": "ustc-community/dfine-small-coco",
+    "m": "ustc-community/dfine-medium-coco",
+}
+DEFAULT_MODEL = MODEL_SIZES["n"]
 
 
-class ObjectDetector(YoloDetector[DetectedObject]):
-    """Lazy YOLOv8-COCO object detector returning normalized detections.
+class ObjectDetector(DetectorBase[DetectedObject]):
+    """Lazy D-FINE COCO object detector returning normalized detections.
 
-    The Ultralytics weights (default ``yolov8n.pt``) auto-download on first
-    real use; class names come from the loaded model. Detection is gated by
-    ``confidence_threshold`` and optionally restricted to ``class_filter``.
+    The D-FINE weights (default ``ustc-community/dfine-nano-coco``) download from
+    HuggingFace on first real use; class names come from the model config.
+    Detection is gated by ``confidence_threshold`` and optionally restricted to
+    ``class_filter`` (COCO class names; YOLO-style spellings are normalized).
     """
 
     DEFAULT_CONFIDENCE_THRESHOLD = 0.5
     _FEATURE = "ObjectDetector"
+    # Override the base sentinel/unload set: hold the model AND the processor.
+    _model_attrs = ("_model", "_processor")
 
     def __init__(
         self,
-        model_name: str = "yolov8n.pt",
+        model_name: str = DEFAULT_MODEL,
         confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
         class_filter: tuple[str, ...] = (),
         backend: Backend = "auto",
@@ -44,46 +64,71 @@ class ObjectDetector(YoloDetector[DetectedObject]):
         """Initialize the detector.
 
         Args:
-            model_name: Ultralytics COCO model id or path (e.g. ``yolov8n.pt``,
-                ``yolov8s.pt``, ``yolov8m.pt``). Downloaded on first use.
+            model_name: D-FINE COCO HuggingFace repo id (e.g.
+                ``ustc-community/dfine-nano-coco``, ``...-small-coco``,
+                ``...-medium-coco``, ``...-large-coco``). Downloaded on first use.
             confidence_threshold: Minimum detection confidence in ``[0, 1]``.
-            class_filter: If non-empty, only these COCO class names are kept.
+            class_filter: If non-empty, only these COCO class names are kept
+                (D-FINE's VOC-style spelling, e.g. ``motorbike``/``tvmonitor``).
             backend: Detection device - ``"cpu"``, ``"gpu"``, or ``"auto"``.
         """
         super().__init__(backend=backend)
         self.model_name = model_name
         self.confidence_threshold = confidence_threshold
-        self.class_filter = class_filter
+        self.class_filter = tuple(class_filter)
+        self._model: Any = None
+        self._processor: Any = None
         self._class_names: dict[int, str] = {}
         logger.info("ObjectDetector initialized with model=%s backend=%s", model_name, backend)
 
-    def _conf(self) -> float:
-        return self.confidence_threshold
-
     def _load_model(self) -> None:
-        # No revision pin: ultralytics resolves/downloads this asset from its own
-        # GitHub release assets, not a HF repo, and YOLO() takes no revision arg
-        # (see videopython.ai._revisions module docstring).
-        self._build_yolo(self.model_name)
-        self._class_names = dict(self._yolo_model.names)
+        from videopython.ai._optional import require
 
-    def _parse(self, result: Any) -> list[DetectedObject]:
+        tf = require("transformers", feature=self._FEATURE)
+        revision = pinned(self.model_name)
+        self._processor = tf.AutoImageProcessor.from_pretrained(self.model_name, revision=revision, use_fast=True)
+        model = tf.DFineForObjectDetection.from_pretrained(self.model_name, revision=revision)
+        model.eval()
+        if self._resolve_device() == "cuda":
+            model = model.to("cuda")
+        self._model = model
+        self._class_names = {int(k): v for k, v in model.config.id2label.items()}
+
+    def _infer(self, images: list[np.ndarray]) -> list[list[DetectedObject]]:
+        import torch
+
+        device = self._resolve_device()
+        inputs = self._processor(images=images, return_tensors="pt")
+        if device == "cuda":
+            inputs = inputs.to("cuda")
+        with torch.no_grad():
+            outputs = self._model(**inputs)
+        # target_sizes is (height, width) per image; D-FINE letterboxes internally
+        # so post-processing needs the original sizes to de-letterbox the boxes.
+        target_sizes = torch.tensor([[img.shape[0], img.shape[1]] for img in images], device=device)
+        results = self._processor.post_process_object_detection(
+            outputs, target_sizes=target_sizes, threshold=self.confidence_threshold
+        )
+        return [self._parse(result, img.shape[1], img.shape[0]) for result, img in zip(results, images)]
+
+    def _parse(self, result: dict[str, Any], img_w: int, img_h: int) -> list[DetectedObject]:
         detected: list[DetectedObject] = []
-        boxes = result.boxes
-        if boxes is None:
-            return detected
-
-        img_h, img_w = result.orig_shape
-        for i in range(len(boxes)):
-            label = self._class_names.get(int(boxes.cls[i]), str(int(boxes.cls[i])))
+        scores = result["scores"].tolist()
+        labels = result["labels"].tolist()
+        boxes = result["boxes"].tolist()
+        for score, label_id, (x1, y1, x2, y2) in zip(scores, labels, boxes):
+            label = self._class_names.get(int(label_id), str(int(label_id)))
             if self.class_filter and label not in self.class_filter:
                 continue
-
-            x1, y1, x2, y2 = boxes.xyxy[i].tolist()
+            # D-FINE boxes can sit slightly outside the frame; clamp before normalizing.
+            x1 = min(max(x1, 0.0), img_w)
+            x2 = min(max(x2, 0.0), img_w)
+            y1 = min(max(y1, 0.0), img_h)
+            y2 = min(max(y2, 0.0), img_h)
             detected.append(
                 DetectedObject(
                     label=label,
-                    confidence=float(boxes.conf[i]),
+                    confidence=float(score),
                     bounding_box=BoundingBox(
                         x=x1 / img_w,
                         y=y1 / img_h,

--- a/src/videopython/ai/video_analysis/models.py
+++ b/src/videopython/ai/video_analysis/models.py
@@ -146,7 +146,7 @@ class VideoAnalysisConfig(BaseModel):
         VideoAnalysisConfig(
             analyzer_params={
                 "audio_to_text": {"model_name": "large"},
-                "scene_vlm": {"model": "gemma3:27b"},
+                "scene_vlm": {"model": "qwen3.6:27b"},
             }
         )
     """

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ overrides = [
     { name = "opencv-python", marker = "sys_platform == '_'" },
     { name = "torch", specifier = ">=2.8.0" },
     { name = "torchaudio", specifier = ">=2.8.0" },
+    { name = "torchvision", specifier = ">=0.23.0,<0.24.0" },
 ]
 
 [[package]]
@@ -2392,15 +2393,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
 
 [[package]]
-name = "opencv-python"
-version = "4.11.0.86"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
-
-[[package]]
 name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
@@ -2762,32 +2754,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "polars"
-version = "1.36.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "polars-runtime-32" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/dc/56f2a90c79a2cb13f9e956eab6385effe54216ae7a2068b3a6406bae4345/polars-1.36.1.tar.gz", hash = "sha256:12c7616a2305559144711ab73eaa18814f7aa898c522e7645014b68f1432d54c", size = 711993, upload-time = "2025-12-10T01:14:53.033Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/c6/36a1b874036b49893ecae0ac44a2f63d1a76e6212631a5b2f50a86e0e8af/polars-1.36.1-py3-none-any.whl", hash = "sha256:853c1bbb237add6a5f6d133c15094a9b727d66dd6a4eb91dbb07cdb056b2b8ef", size = 802429, upload-time = "2025-12-10T01:13:53.838Z" },
-]
-
-[[package]]
-name = "polars-runtime-32"
-version = "1.36.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/df/597c0ef5eb8d761a16d72327846599b57c5d40d7f9e74306fc154aba8c37/polars_runtime_32-1.36.1.tar.gz", hash = "sha256:201c2cfd80ceb5d5cd7b63085b5fd08d6ae6554f922bcb941035e39638528a09", size = 2788751, upload-time = "2025-12-10T01:14:54.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/ea/871129a2d296966c0925b078a9a93c6c5e7facb1c5eebfcd3d5811aeddc1/polars_runtime_32-1.36.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:327b621ca82594f277751f7e23d4b939ebd1be18d54b4cdf7a2f8406cecc18b2", size = 43494311, upload-time = "2025-12-10T01:13:56.096Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/76/0038210ad1e526ce5bb2933b13760d6b986b3045eccc1338e661bd656f77/polars_runtime_32-1.36.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ab0d1f23084afee2b97de8c37aa3e02ec3569749ae39571bd89e7a8b11ae9e83", size = 39300602, upload-time = "2025-12-10T01:13:59.366Z" },
-    { url = "https://files.pythonhosted.org/packages/54/1e/2707bee75a780a953a77a2c59829ee90ef55708f02fc4add761c579bf76e/polars_runtime_32-1.36.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:899b9ad2e47ceb31eb157f27a09dbc2047efbf4969a923a6b1ba7f0412c3e64c", size = 44511780, upload-time = "2025-12-10T01:14:02.285Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b2/3fede95feee441be64b4bcb32444679a8fbb7a453a10251583053f6efe52/polars_runtime_32-1.36.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d9d077bb9df711bc635a86540df48242bb91975b353e53ef261c6fae6cb0948f", size = 40688448, upload-time = "2025-12-10T01:14:05.131Z" },
-    { url = "https://files.pythonhosted.org/packages/05/0f/e629713a72999939b7b4bfdbf030a32794db588b04fdf3dc977dd8ea6c53/polars_runtime_32-1.36.1-cp39-abi3-win_amd64.whl", hash = "sha256:cc17101f28c9a169ff8b5b8d4977a3683cd403621841623825525f440b564cf0", size = 44464898, upload-time = "2025-12-10T01:14:08.296Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/d8/a12e6aa14f63784cead437083319ec7cece0d5bb9a5bfe7678cc6578b52a/polars_runtime_32-1.36.1-cp39-abi3-win_arm64.whl", hash = "sha256:809e73857be71250141225ddd5d2b30c97e6340aeaa0d445f930e01bef6888dc", size = 39798896, upload-time = "2025-12-10T01:14:11.568Z" },
 ]
 
 [[package]]
@@ -4616,42 +4582,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ultralytics"
-version = "8.3.249"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "opencv-python", marker = "sys_platform == '_'" },
-    { name = "pillow" },
-    { name = "polars" },
-    { name = "psutil" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "scipy" },
-    { name = "torch" },
-    { name = "torchvision" },
-    { name = "ultralytics-thop" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/94/082b7a6466d475a9ddbc163a5d25858bd6a6c1d6743c8d6c51d68525bb24/ultralytics-8.3.249.tar.gz", hash = "sha256:9686be83d5ada2fbe9cedeaba1e59a24d87a2a97c653bb5b13741ac274308630", size = 989824, upload-time = "2026-01-07T11:56:02.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/16/6fa0c192328a22b9b3fe338918df7130a716a990977cef87a38e7e4411ff/ultralytics-8.3.249-py3-none-any.whl", hash = "sha256:a3667697a5158cb78695b6b74e310650828ac231665f00840587baa14d9c2b39", size = 1153305, upload-time = "2026-01-07T11:55:58.92Z" },
-]
-
-[[package]]
-name = "ultralytics-thop"
-version = "2.0.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "torch" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/63/21a32e1facfeee245dbdfb7b4669faf7a36ff7c00b50987932bdab126f4b/ultralytics_thop-2.0.18.tar.gz", hash = "sha256:21103bcd39cc9928477dc3d9374561749b66a1781b35f46256c8d8c4ac01d9cf", size = 34557, upload-time = "2025-10-29T16:58:13.526Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c7/fb42228bb05473d248c110218ffb8b1ad2f76728ed8699856e5af21112ad/ultralytics_thop-2.0.18-py3-none-any.whl", hash = "sha256:2bb44851ad224b116c3995b02dd5e474a5ccf00acf237fe0edb9e1506ede04ec", size = 28941, upload-time = "2025-10-29T16:58:12.093Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4675,7 +4605,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.52.1"
+version = "0.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -4700,9 +4630,9 @@ ai = [
     { name = "silero-vad" },
     { name = "torch" },
     { name = "torchaudio" },
+    { name = "torchvision" },
     { name = "transformers" },
     { name = "transnetv2-pytorch" },
-    { name = "ultralytics" },
 ]
 mcp = [
     { name = "mcp" },
@@ -4746,10 +4676,10 @@ requires-dist = [
     { name = "silero-vad", marker = "extra == 'ai'", specifier = ">=5.1" },
     { name = "torch", marker = "extra == 'ai'", specifier = ">=2.8.0" },
     { name = "torchaudio", marker = "extra == 'ai'", specifier = ">=2.8.0" },
+    { name = "torchvision", marker = "extra == 'ai'", specifier = ">=0.23.0,<0.24.0" },
     { name = "tqdm", specifier = ">=4.66.3" },
     { name = "transformers", marker = "extra == 'ai'", specifier = ">=5.2.0" },
     { name = "transnetv2-pytorch", marker = "extra == 'ai'", specifier = ">=1.0.5" },
-    { name = "ultralytics", marker = "extra == 'ai'", specifier = ">=8.0.0" },
 ]
 provides-extras = ["ai", "mcp"]
 


### PR DESCRIPTION
Drop the AGPL-3.0 Ultralytics YOLO stack and restricted-license default models in favor of Apache-2.0/MIT alternatives:
- Object detection: Ultralytics YOLOv8 (AGPL) -> D-FINE (Apache-2.0) via transformers
- Face detection: YOLOv8-Face (AGPL) -> OpenCV YuNet (MIT)
- Default local LLM: gemma3:27b (Gemma Terms) -> qwen3.6:27b (Apache-2.0)

Remove ultralytics from the [ai] extra + uv.lock + mypy; add torchvision (BSD, <0.24 for torch 2.8) for the transformers fast image processor. Generalize the shared YOLO base into a backend-agnostic DetectorBase.

BREAKING CHANGE: ObjectDetector class_filter requires D-FINE's VOC-style COCO names (no YOLO alias) and model_name takes D-FINE HF repo ids; face tracking is CPU-only (removed backend + GPU sample_rate/interpolation from the trackers and the face_crop op); default Ollama LLM is now qwen3.6:27b.