### PR TITLE
Update generative models

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,40 @@
 # Release Notes
 
+## 0.54.0
+
+Replace the restricted-license media-generation defaults with permissively-licensed
+(Apache-2.0) alternatives. Follows 0.53.0 (detection + LLM swaps).
+
+### Breaking
+
+- **Text-to-image: SDXL (OpenRAIL++) -> Qwen-Image (`Qwen/Qwen-Image-2512`, Apache-2.0)**
+  via `diffusers` `QwenImagePipeline`. `TextToImage.generate_image` gains keyword args
+  (`negative_prompt`, `true_cfg_scale`, `num_inference_steps`, `width`/`height`,
+  `add_magic`, `seed`); it uses Qwen's `true_cfg_scale` (not `guidance_scale`) and appends
+  the model's recommended quality suffix by default. bf16 on CUDA with
+  `enable_model_cpu_offload()` + VAE tiling (~20B).
+- **Text-to-video: CogVideoX1.5-5B (custom license) -> Wan2.2-T2V-A14B (Apache-2.0)**
+  via `WanPipeline` + `AutoencoderKLWan`. Default `num_steps` 50->40, `guidance_scale` 6.0->4.0
+  (Wan2.2 A14B recommendations); MoE low-noise expert at `guidance_scale_2=3.0`.
+- **Image-to-video: CogVideoX1.5-5B-I2V -> Wan2.2-I2V-A14B (Apache-2.0)** via
+  `WanImageToVideoPipeline`. The input image is resized to Wan's area budget snapped to the
+  model grid. Default `num_steps` 50->40, `guidance_scale` 6.0->3.5.
+- **Generation now requires a CUDA GPU.** `TextToImage`/`TextToVideo`/`ImageToVideo` raise on
+  CPU/MPS instead of silently falling back — these ~20-28B models are impractical off-GPU.
+  (Detection/understanding models still run on CPU.)
+
+### Changed
+
+- `diffusers` floor raised `>=0.30.0` -> `>=0.35.0` (ships `QwenImagePipeline` + Wan2.2
+  support; tested on 0.37.1) in the `[ai]` extra and the uv override.
+- `_revisions.py`: removed the SDXL + two CogVideoX pins; added Qwen-Image-2512 + Wan2.2
+  T2V/I2V (the fp32 VAE loads from the same repo, so one pin covers both `from_pretrained`s).
+- Wan2.2 t2v/i2v text conditioning: re-tie the UMT5 encoder's `embed_tokens` to `shared` after
+  load (`transformers>=5.2` leaves it zero-initialized, which nulls out text conditioning so the
+  prompt is ignored), and add `ftfy>=6.1` (diffusers' Wan i2v pipeline imports it unconditionally
+  to clean prompts). Both found on the first real-GPU run.
+- Added mocked unit tests for `TextToImage`/`TextToVideo`/`ImageToVideo` (previously untested).
+
 ## 0.53.0
 
 Replace the AGPL-3.0 and restricted-license default models with permissively-licensed

--- a/docs/api/ai/generation.md
+++ b/docs/api/ai/generation.md
@@ -6,11 +6,11 @@ Generate videos, images, audio, and music from text prompts.
 
 | Class | Local Model Family |
 |-------|--------------------|
-| TextToVideo | CogVideoX1.5-5B |
-| ImageToVideo | CogVideoX1.5-5B-I2V |
+| TextToVideo | Wan2.2-T2V-A14B |
+| ImageToVideo | Wan2.2-I2V-A14B |
 | TextToSpeech | Chatterbox Multilingual |
 | TextToMusic | MusicGen |
-| TextToImage | SDXL |
+| TextToImage | Qwen-Image |
 
 ## TextToVideo
 

--- a/docs/examples/ai-video.md
+++ b/docs/examples/ai-video.md
@@ -75,14 +75,14 @@ create_ai_video("ai_generated.mp4")
 ### 1. Generate Images
 
 ```python
-image_gen = TextToImage()  # Uses local SDXL pipeline
+image_gen = TextToImage()  # Uses local Qwen-Image pipeline
 image = image_gen.generate_image("A serene mountain landscape at sunrise")
 ```
 
 ### 2. Animate to Video
 
 ```python
-video_gen = ImageToVideo()  # Uses local CogVideoX1.5-5B-I2V (outputs at 16 fps)
+video_gen = ImageToVideo()  # Uses local Wan2.2-I2V-A14B (outputs at 16 fps)
 video = video_gen.generate_video(image=image)
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -78,8 +78,11 @@ Protocol](https://modelcontextprotocol.io) server). See the
     your own `SpeechBackend` into `VideoDubber` (e.g. a remote synthesizer).
 
 !!! note "Hardware Requirements"
-    Local AI models (video generation, music generation) require a GPU.
-    CUDA (NVIDIA) or MPS (Apple Silicon) is supported. An NVIDIA A40 or better is recommended for video generation.
+    Image and video generation (`TextToImage`, `TextToVideo`, `ImageToVideo`) require an
+    **NVIDIA CUDA GPU** — these ~20–28B models raise on CPU/MPS rather than falling back. An
+    NVIDIA A40 or better is recommended for video generation. Music generation (`TextToMusic`)
+    runs on CUDA, Apple MPS, or CPU, and speech (`TextToSpeech`) on CUDA or CPU. Detection and
+    understanding models run on CPU (GPU optional).
 
 ## Local-Only AI Runtime
 
@@ -88,7 +91,8 @@ Protocol](https://modelcontextprotocol.io) server). See the
 Practical setup notes:
 
 - First AI run may download model weights.
-- Prefer GPU (`cuda` or `mps`) for generation-heavy workflows.
+- Image/video generation require a CUDA GPU; other AI models prefer a GPU (`cuda`, or `mps`
+  where supported) but run on CPU too.
 - Use the `device` argument where supported to force placement.
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ Expose the auto-edit pipeline as [Model Context Protocol](https://modelcontextpr
 
 ### AI Generation
 
-Generate images, video, speech, and music from text prompts. SDXL, CogVideoX, Chatterbox Multilingual TTS, MusicGen — all local, no API keys. [Learn more →](api/ai/generation.md)
+Generate images, video, speech, and music from text prompts. Qwen-Image, Wan2.2, Chatterbox Multilingual TTS, MusicGen — all local, no API keys. [Learn more →](api/ai/generation.md)
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.53.0"
+version = "0.54.0"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },
@@ -78,8 +78,13 @@ ai = [
     # Voice cloning TTS (generation/audio.py — Chatterbox); its strict pins drive
     # the [tool.uv].override-dependencies block below.
     "chatterbox-tts>=0.1.7",
-    # Local media generation: SDXL/CogVideoX + MusicGen (generation/*)
-    "diffusers>=0.30.0",
+    # Local media generation: Qwen-Image/Wan2.2 + MusicGen (generation/*).
+    # >=0.35 is the floor that ships QwenImagePipeline + Wan2.2 support (tested on 0.37.1).
+    "diffusers>=0.35.0",
+    # Wan2.2 i2v pipeline cleans prompts with ftfy via a hard import (diffusers'
+    # pipeline_wan_i2v); the t2v pipeline guards it with is_ftfy_available(), i2v
+    # does not, so it is a required dep for ImageToVideo.
+    "ftfy>=6.1",
     "accelerate>=0.29.2",
     # Dubbing loudness matching (dubbing/loudness.py)
     "pyloudnorm>=0.1.1",
@@ -136,7 +141,7 @@ ignore_missing_imports = true
 # These overrides let the combined [ai] resolve pick compatible versions; the
 # floors in [ai] are aligned with them so pip and uv resolve similar versions.
 override-dependencies = [
-    "torch>=2.8.0", "torchaudio>=2.8.0", "torchvision>=0.23.0,<0.24.0", "numpy>=2.0.0", "diffusers>=0.30.0",
+    "torch>=2.8.0", "torchaudio>=2.8.0", "torchvision>=0.23.0,<0.24.0", "numpy>=2.0.0", "diffusers>=0.35.0",
     # Some transitive deps pull opencv-python, which conflicts with our
     # opencv-python-headless (both provide cv2). Exclude opencv-python so
     # only the headless variant is installed.

--- a/src/tests/ai/test_generation_image.py
+++ b/src/tests/ai/test_generation_image.py
@@ -1,0 +1,78 @@
+"""Tests for TextToImage (Qwen-Image), with the diffusers pipeline mocked."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from videopython.ai.generation.image import TextToImage
+
+_QWEN_SHA = "25468b98e3276ca6700de15c6628e51b7de54a26"
+
+
+def _fake_diffusers(pipeline):
+    mod = MagicMock()
+    mod.QwenImagePipeline.from_pretrained.return_value = pipeline
+    return mod
+
+
+class TestInit:
+    @patch("videopython.ai.generation.image.select_device", return_value="cuda")
+    @patch("videopython.ai._optional.require")
+    def test_cuda_offloads_and_does_not_call_to(self, mock_require, _sd):
+        import torch
+
+        pipe = MagicMock()
+        fake = _fake_diffusers(pipe)
+        mock_require.return_value = fake
+
+        TextToImage(device="cuda")._init_local()
+
+        pipe.enable_model_cpu_offload.assert_called_once()
+        pipe.enable_vae_tiling.assert_called_once()
+        pipe.to.assert_not_called()
+
+        _, kwargs = fake.QwenImagePipeline.from_pretrained.call_args
+        assert kwargs["revision"] == _QWEN_SHA
+        assert kwargs["use_safetensors"] is True
+        assert kwargs["torch_dtype"] == torch.bfloat16
+        assert "variant" not in kwargs  # Qwen-Image has no fp16 variant
+
+    @patch("videopython.ai.generation.image.select_device", return_value="cpu")
+    def test_non_cuda_raises(self, _sd):
+        # Qwen-Image is CUDA-only; a non-CUDA device fails loudly (no CPU/MPS fallback).
+        with pytest.raises(RuntimeError, match="CUDA"):
+            TextToImage(device="cpu")._init_local()
+
+
+class TestGenerate:
+    def test_passes_qwen_params_and_appends_magic(self):
+        img = Image.new("RGB", (8, 8), (100, 110, 120))
+        pipe = MagicMock()
+        pipe.return_value.images = [img]
+
+        t = TextToImage()
+        t.device = "cpu"
+        t._pipeline = pipe
+
+        out = t.generate_image("a cat on a sofa")
+
+        assert out is img
+        _, kwargs = pipe.call_args
+        assert kwargs["true_cfg_scale"] == 4.0
+        assert kwargs["negative_prompt"] == " "
+        assert kwargs["width"] == 1328
+        assert kwargs["height"] == 1328
+        assert kwargs["prompt"].startswith("a cat on a sofa")
+        assert "Ultra HD" in kwargs["prompt"]  # magic suffix appended
+
+    def test_add_magic_false_keeps_prompt_verbatim(self):
+        pipe = MagicMock()
+        pipe.return_value.images = [Image.new("RGB", (4, 4))]
+
+        t = TextToImage()
+        t.device = "cpu"
+        t._pipeline = pipe
+
+        t.generate_image("plain prompt", add_magic=False)
+        assert pipe.call_args.kwargs["prompt"] == "plain prompt"

--- a/src/tests/ai/test_generation_video.py
+++ b/src/tests/ai/test_generation_video.py
@@ -1,0 +1,127 @@
+"""Tests for TextToVideo / ImageToVideo (Wan2.2), with the diffusers pipeline mocked."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from videopython.ai.generation.video import ImageToVideo, TextToVideo
+
+_T2V_SHA = "5be7df9619b54f4e2667b2755bc6a756675b5cd7"
+_I2V_SHA = "596658fd9ca6b7b71d5057529bbf319ecbc61d74"
+
+
+def _pil_frames(n, size=(16, 16), color=(120, 130, 140)):
+    return [Image.new("RGB", size, color) for _ in range(n)]
+
+
+class TestTextToVideo:
+    @patch("videopython.ai.generation.video.Video")
+    def test_frames_convert_to_uint8_rgb(self, mock_video):
+        # .frames[0] is a list of PIL images (output_type="pil"); guards against the
+        # output_type="np" float[0,1] path that uint8-casts to an all-black video.
+        pipe = MagicMock()
+        pipe.return_value.frames = [_pil_frames(3)]
+
+        t = TextToVideo()
+        t.device = "cpu"
+        t._pipeline = pipe
+
+        t.generate_video("a dog running", num_frames=3)
+
+        arr = mock_video.from_frames.call_args.args[0]
+        assert arr.dtype == np.uint8
+        assert arr.ndim == 4 and arr.shape[-1] == 3
+        assert arr.max() > 0  # not all-black
+        assert mock_video.from_frames.call_args.kwargs["fps"] == 16.0
+
+        kw = pipe.call_args.kwargs
+        assert kw["output_type"] == "pil"
+        assert kw["guidance_scale_2"] == 3.0
+        assert kw["height"] == 720 and kw["width"] == 1280
+        assert kw["negative_prompt"]  # non-empty canonical Wan negative prompt
+
+    @patch("videopython.ai.generation.video.select_device", return_value="cuda")
+    @patch("videopython.ai._optional.require")
+    def test_cuda_offloads_with_fp32_vae(self, mock_require, _sd):
+        import torch
+
+        diff = MagicMock()
+        pipe = MagicMock()
+        diff.WanPipeline.from_pretrained.return_value = pipe
+        mock_require.return_value = diff
+
+        TextToVideo(device="cuda")._init_local()
+
+        pipe.enable_model_cpu_offload.assert_called_once()
+        pipe.to.assert_not_called()
+        pipe.enable_vae_tiling.assert_not_called()  # Wan has no VAE tiling (Qwen-only)
+
+        # UMT5 embed re-tie: transformers>=5.2 leaves encoder.embed_tokens zero-initialized
+        # (checkpoint ships only shared.weight) -> dead text conditioning without this.
+        assert pipe.text_encoder.encoder.embed_tokens is pipe.text_encoder.shared
+
+        _, vae_kw = diff.AutoencoderKLWan.from_pretrained.call_args
+        assert vae_kw["subfolder"] == "vae"
+        assert vae_kw["torch_dtype"] == torch.float32
+        assert vae_kw["revision"] == _T2V_SHA
+
+        _, pipe_kw = diff.WanPipeline.from_pretrained.call_args
+        assert pipe_kw["revision"] == _T2V_SHA
+        assert pipe_kw["torch_dtype"] == torch.bfloat16
+
+    @patch("videopython.ai.generation.video.select_device", return_value="cpu")
+    def test_non_cuda_raises(self, _sd):
+        # Wan2.2 is CUDA-only; a non-CUDA device fails loudly (no CPU/MPS fallback).
+        with pytest.raises(RuntimeError, match="CUDA"):
+            TextToVideo(device="cpu")._init_local()
+
+
+class TestImageToVideo:
+    @patch("videopython.ai.generation.video.Video")
+    def test_resizes_to_grid_and_converts_frames(self, mock_video):
+        pipe = MagicMock()
+        pipe.vae_scale_factor_spatial = 8
+        pipe.transformer.config.patch_size = [1, 2, 2]  # real config is a 3-tuple; code reads [1] -> mod_value 16
+        pipe.return_value.frames = [_pil_frames(2, color=(50, 60, 70))]
+
+        t = ImageToVideo()
+        t.device = "cpu"
+        t._pipeline = pipe
+
+        t.generate_video(Image.new("RGB", (832, 480)), prompt="pan left")
+
+        kw = pipe.call_args.kwargs
+        assert kw["height"] % 16 == 0 and kw["width"] % 16 == 0
+        assert kw["image"].size == (kw["width"], kw["height"])  # image resized to requested dims
+        assert kw["output_type"] == "pil"
+
+        arr = mock_video.from_frames.call_args.args[0]
+        assert arr.dtype == np.uint8 and arr.max() > 0
+
+    @patch("videopython.ai.generation.video.select_device", return_value="cuda")
+    @patch("videopython.ai._optional.require")
+    def test_cuda_offloads_with_fp32_vae(self, mock_require, _sd):
+        import torch
+
+        diff = MagicMock()
+        pipe = MagicMock()
+        diff.WanImageToVideoPipeline.from_pretrained.return_value = pipe
+        mock_require.return_value = diff
+
+        ImageToVideo(device="cuda")._init_local()
+
+        pipe.enable_model_cpu_offload.assert_called_once()
+        pipe.to.assert_not_called()
+        pipe.enable_vae_tiling.assert_not_called()  # Wan has no VAE tiling (Qwen-only)
+
+        # UMT5 embed re-tie: transformers>=5.2 leaves encoder.embed_tokens zero-initialized
+        # (checkpoint ships only shared.weight) -> dead text conditioning without this.
+        assert pipe.text_encoder.encoder.embed_tokens is pipe.text_encoder.shared
+
+        _, vae_kw = diff.AutoencoderKLWan.from_pretrained.call_args
+        assert vae_kw["torch_dtype"] == torch.float32
+        assert vae_kw["revision"] == _I2V_SHA
+        _, pipe_kw = diff.WanImageToVideoPipeline.from_pretrained.call_args
+        assert pipe_kw["revision"] == _I2V_SHA

--- a/src/tests/test_packaging_extras.py
+++ b/src/tests/test_packaging_extras.py
@@ -130,6 +130,12 @@ def test_dependency_group_ai_matches_optional_ai(pyproject: Pyproject) -> None:
 #   accelerate   -> diffusers/transformers device-map plumbing (transitive)
 _TRANSITIVE_ONLY_DEPS = {"torchaudio", "torchvision", "accelerate"}
 
+# Deps we must declare for a *dependency's* runtime code path, never imported by our code:
+#   ftfy -> diffusers' Wan2.2 i2v pipeline (pipeline_wan_i2v) imports ftfy at runtime to
+#           clean prompts, but diffusers marks it optional and does not pull it in, so
+#           ImageToVideo crashes without it -> we pin it here.
+_RUNTIME_ONLY_DEPS = {"ftfy"}
+
 
 def test_every_declared_dep_is_imported_somewhere(pyproject: Pyproject) -> None:
     """Each dep declared in [ai] is actually imported under ai/ (lazily, anywhere)
@@ -152,7 +158,7 @@ def test_every_declared_dep_is_imported_somewhere(pyproject: Pyproject) -> None:
 
     missing: list[str] = []
     for dist in declared:
-        if dist in _TRANSITIVE_ONLY_DEPS:
+        if dist in _TRANSITIVE_ONLY_DEPS or dist in _RUNTIME_ONLY_DEPS:
             continue
         import_names = _DIST_TO_IMPORT_NAMES.get(dist, {dist.replace("-", "_")})
         if not any(_is_referenced(imp) for imp in import_names):

--- a/src/videopython/ai/_revisions.py
+++ b/src/videopython/ai/_revisions.py
@@ -71,11 +71,14 @@ MODEL_REVISIONS: dict[str, str] = {
     "opencv/face_detection_yunet": "3cc26e7f1014a5ee5d74a42acee58bafc9d0a310",
     # MusicGen (ai/generation/audio.py: TextToMusic)
     "facebook/musicgen-small": "4c8334b02c6ec4e8664a91979669a501ec497792",
-    # SDXL (ai/generation/image.py: TextToImage)
-    "stabilityai/stable-diffusion-xl-base-1.0": "462165984030d82259a11f4367a4eed129e94a7b",
-    # CogVideoX (ai/generation/video.py: TextToVideo / ImageToVideo)
-    "THUDM/CogVideoX1.5-5B": "fdc5267c90b5c06492985b966e43aae984e189e0",
-    "THUDM/CogVideoX1.5-5B-I2V": "46c90528707aebbe69066390b4fe7e7d24c9c2a4",
+    # Text-to-image — Qwen-Image (ai/generation/image.py: TextToImage), Apache-2.0;
+    # replaced the OpenRAIL++-licensed SDXL.
+    "Qwen/Qwen-Image-2512": "25468b98e3276ca6700de15c6628e51b7de54a26",
+    # Text/image-to-video — Wan2.2 (ai/generation/video.py: TextToVideo / ImageToVideo),
+    # Apache-2.0; replaced the custom-licensed CogVideoX. The fp32 VAE is loaded from the
+    # same repo (subfolder="vae"), so revision=pinned(repo) covers both from_pretrained calls.
+    "Wan-AI/Wan2.2-T2V-A14B-Diffusers": "5be7df9619b54f4e2667b2755bc6a756675b5cd7",
+    "Wan-AI/Wan2.2-I2V-A14B-Diffusers": "596658fd9ca6b7b71d5057529bbf319ecbc61d74",
 }
 
 

--- a/src/videopython/ai/generation/__init__.py
+++ b/src/videopython/ai/generation/__init__.py
@@ -2,7 +2,7 @@
 
 Each symbol's backing leaf module is imported only on first access, so
 ``from videopython.ai.generation import TextToImage`` does not pull in
-``audio`` (chatterbox/musicgen) or ``video`` (diffusers/CogVideoX). The
+``audio`` (chatterbox/musicgen) or ``video`` (diffusers/Wan2.2). The
 ``TYPE_CHECKING`` block keeps the symbols visible to mypy and IDEs.
 """
 

--- a/src/videopython/ai/generation/image.py
+++ b/src/videopython/ai/generation/image.py
@@ -1,4 +1,4 @@
-"""Image generation using local diffusion models."""
+"""Image generation using local diffusion models (Qwen-Image)."""
 
 from __future__ import annotations
 
@@ -10,9 +10,15 @@ from videopython.ai._device import log_device_initialization, select_device
 from videopython.ai._predictor import ManagedPredictor
 from videopython.ai._revisions import pinned
 
+_MODEL_NAME = "Qwen/Qwen-Image-2512"
+
+# Qwen-Image recommends appending a quality "magic" suffix to the prompt
+# (verbatim from the model card).
+_POSITIVE_MAGIC = ", Ultra HD, 4K, cinematic composition."
+
 
 class TextToImage(ManagedPredictor):
-    """Generates images from text descriptions using local models."""
+    """Generates images from text descriptions using local models (Qwen-Image, Apache-2.0)."""
 
     _model_attrs = ("_pipeline",)
 
@@ -21,27 +27,29 @@ class TextToImage(ManagedPredictor):
         self._pipeline: Any = None
 
     def _init_local(self) -> None:
-        """Initialize local diffusion pipeline."""
+        """Initialize the local Qwen-Image diffusion pipeline (CUDA-only)."""
         import torch
 
         from videopython.ai._optional import require
 
-        DiffusionPipeline = require("diffusers", feature="TextToImage").DiffusionPipeline
-
         requested_device = self.device
-        device = select_device(self.device, mps_allowed=True)
-        dtype = torch.float16 if device == "cuda" else torch.float32
-        variant = "fp16" if device == "cuda" else None
+        device = select_device(self.device, mps_allowed=False)
+        if device != "cuda":
+            raise RuntimeError("TextToImage requires a CUDA GPU; Qwen-Image (~20B) is impractical on CPU/MPS.")
 
-        model_name = "stabilityai/stable-diffusion-xl-base-1.0"
-        self._pipeline = DiffusionPipeline.from_pretrained(
-            model_name,
-            revision=pinned(model_name),
-            torch_dtype=dtype,
-            variant=variant,
+        QwenImagePipeline = require("diffusers", feature="TextToImage").QwenImagePipeline
+        self._pipeline = QwenImagePipeline.from_pretrained(
+            _MODEL_NAME,
+            revision=pinned(_MODEL_NAME),
+            torch_dtype=torch.bfloat16,
             use_safetensors=True,
         )
-        self._pipeline.to(device)
+        # ~20B params (Qwen2.5-VL text encoder + transformer + VAE). Offload submodules
+        # to the GPU on demand so it fits a single GPU; offload manages device placement,
+        # so we must NOT also call .to("cuda").
+        self._pipeline.enable_model_cpu_offload()
+        self._pipeline.enable_vae_tiling()
+
         self.device = device
         log_device_initialization(
             "TextToImage",
@@ -49,11 +57,37 @@ class TextToImage(ManagedPredictor):
             resolved_device=device,
         )
 
-        if device == "mps":
-            self._pipeline.enable_attention_slicing()
+    def generate_image(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str = " ",
+        true_cfg_scale: float = 4.0,
+        num_inference_steps: int = 50,
+        width: int = 1328,
+        height: int = 1328,
+        add_magic: bool = True,
+        seed: int = 42,
+    ) -> Image.Image:
+        """Generate an image from a text prompt.
 
-    def generate_image(self, prompt: str) -> Image.Image:
-        """Generate an image from a text prompt."""
+        Qwen-Image uses ``true_cfg_scale`` (not ``guidance_scale``) for
+        classifier-free guidance; a non-empty ``negative_prompt`` (default a single
+        space) is required to enable it. ``add_magic`` appends the model's
+        recommended quality suffix to ``prompt``.
+        """
+        import torch
+
         if self._pipeline is None:
             self._init_local()
-        return self._pipeline(prompt=prompt).images[0]
+
+        full_prompt = prompt + _POSITIVE_MAGIC if add_magic else prompt
+        return self._pipeline(
+            prompt=full_prompt,
+            negative_prompt=negative_prompt,
+            true_cfg_scale=true_cfg_scale,
+            num_inference_steps=num_inference_steps,
+            width=width,
+            height=height,
+            generator=torch.Generator(device=self.device).manual_seed(seed),
+        ).images[0]

--- a/src/videopython/ai/generation/video.py
+++ b/src/videopython/ai/generation/video.py
@@ -1,4 +1,4 @@
-"""Video generation using local diffusion models."""
+"""Video generation using local diffusion models (Wan2.2)."""
 
 from __future__ import annotations
 
@@ -14,19 +14,45 @@ from videopython.base.video import Video
 if TYPE_CHECKING:
     from PIL.Image import Image
 
+# Canonical Wan2.2 negative prompt (from the diffusers WanPipeline docstring example).
+_WAN_NEGATIVE_PROMPT = (
+    "Bright tones, overexposed, static, blurred details, subtitles, style, works, "
+    "paintings, images, static, overall gray, worst quality, low quality, JPEG "
+    "compression residue, ugly, incomplete, extra fingers, poorly drawn hands, "
+    "poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, "
+    "still picture, messy background, three legs, many people in the background, "
+    "walking backwards"
+)
 
-def _get_torch_device_and_dtype(device: str | None) -> tuple[str, Any]:
-    """Get the best available torch device and dtype for CogVideoX."""
-    import torch
 
+def _retie_umt5_embeddings(pipeline: Any) -> None:
+    """Restore Wan's text conditioning under transformers>=5.2.
+
+    Wan's checkpoint ships the UMT5 token embedding only as ``shared.weight``, but
+    transformers 5.2's ``UMT5EncoderModel`` has ``tie_word_embeddings=False`` and reads a
+    *separate* ``encoder.embed_tokens`` that the checkpoint never populates -- so it stays
+    zero-initialized. The encoder then emits an all-zero embedding for every prompt and
+    generation silently ignores the text (verified on GPU: prompt has no effect). Point the
+    embedding lookup back at the loaded ``shared`` weight to make conditioning live again.
+    """
+    text_encoder = pipeline.text_encoder
+    text_encoder.encoder.embed_tokens = text_encoder.shared
+
+
+def _require_cuda_device(device: str | None, component: str) -> str:
+    """Resolve to a CUDA device or raise.
+
+    Wan2.2-A14B (~28B MoE) is too large to run on CPU/MPS, so generation requires
+    a CUDA GPU rather than silently falling back to an unusable device.
+    """
     selected_device = select_device(device, mps_allowed=False)
-    if selected_device == "cuda":
-        return selected_device, torch.bfloat16
-    return selected_device, torch.float32
+    if selected_device != "cuda":
+        raise RuntimeError(f"{component} requires a CUDA GPU; Wan2.2-A14B (~28B) is impractical on CPU/MPS.")
+    return selected_device
 
 
 class TextToVideo(ManagedPredictor):
-    """Generates videos from text descriptions using local diffusion models."""
+    """Generates videos from text descriptions using Wan2.2-T2V (Apache-2.0)."""
 
     _model_attrs = ("_pipeline",)
 
@@ -35,16 +61,29 @@ class TextToVideo(ManagedPredictor):
         self._pipeline: Any = None
 
     def _init_local(self) -> None:
+        import torch
+
         from videopython.ai._optional import require
 
-        CogVideoXPipeline = require("diffusers", feature="TextToVideo").CogVideoXPipeline
+        diffusers = require("diffusers", feature="TextToVideo")
+        WanPipeline = diffusers.WanPipeline
+        AutoencoderKLWan = diffusers.AutoencoderKLWan
 
         requested_device = self.device
-        device, dtype = _get_torch_device_and_dtype(self.device)
+        device = _require_cuda_device(self.device, "TextToVideo")
 
-        model_name = "THUDM/CogVideoX1.5-5B"
-        self._pipeline = CogVideoXPipeline.from_pretrained(model_name, revision=pinned(model_name), torch_dtype=dtype)
-        self._pipeline.to(device)
+        model_name = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+        revision = pinned(model_name)
+        # VAE stays float32 for decode quality; the transformer/pipeline use bf16.
+        vae = AutoencoderKLWan.from_pretrained(
+            model_name, subfolder="vae", revision=revision, torch_dtype=torch.float32
+        )
+        self._pipeline = WanPipeline.from_pretrained(model_name, vae=vae, revision=revision, torch_dtype=torch.bfloat16)
+        _retie_umt5_embeddings(self._pipeline)
+        # A14B is a MoE (high+low-noise experts), too large for a single-GPU .to("cuda");
+        # offload submodules on demand (offload manages placement, so do NOT also call .to).
+        self._pipeline.enable_model_cpu_offload()
+
         self.device = device
         log_device_initialization(
             "TextToVideo",
@@ -55,9 +94,9 @@ class TextToVideo(ManagedPredictor):
     def generate_video(
         self,
         prompt: str,
-        num_steps: int = 50,
+        num_steps: int = 40,
         num_frames: int = 81,
-        guidance_scale: float = 6.0,
+        guidance_scale: float = 4.0,
     ) -> Video:
         """Generate video from text prompt."""
         import torch
@@ -65,11 +104,18 @@ class TextToVideo(ManagedPredictor):
         if self._pipeline is None:
             self._init_local()
 
+        # output_type="pil" is required: the "np" default returns float32 in [0, 1],
+        # which the uint8 cast below would floor to an all-black video.
         video_frames = self._pipeline(
             prompt=prompt,
-            num_inference_steps=num_steps,
+            negative_prompt=_WAN_NEGATIVE_PROMPT,
+            height=720,
+            width=1280,
             num_frames=num_frames,
+            num_inference_steps=num_steps,
             guidance_scale=guidance_scale,
+            guidance_scale_2=3.0,  # low-noise MoE expert; None would reuse guidance_scale
+            output_type="pil",
             generator=torch.Generator(device=self.device).manual_seed(42),
         ).frames[0]
         video_frames = np.asarray(video_frames, dtype=np.uint8)
@@ -77,7 +123,7 @@ class TextToVideo(ManagedPredictor):
 
 
 class ImageToVideo(ManagedPredictor):
-    """Generates videos from static images using local video diffusion."""
+    """Generates videos from static images using Wan2.2-I2V (Apache-2.0)."""
 
     _model_attrs = ("_pipeline",)
 
@@ -86,18 +132,29 @@ class ImageToVideo(ManagedPredictor):
         self._pipeline: Any = None
 
     def _init_local(self) -> None:
+        import torch
+
         from videopython.ai._optional import require
 
-        CogVideoXImageToVideoPipeline = require("diffusers", feature="ImageToVideo").CogVideoXImageToVideoPipeline
+        diffusers = require("diffusers", feature="ImageToVideo")
+        WanImageToVideoPipeline = diffusers.WanImageToVideoPipeline
+        AutoencoderKLWan = diffusers.AutoencoderKLWan
 
         requested_device = self.device
-        device, dtype = _get_torch_device_and_dtype(self.device)
+        device = _require_cuda_device(self.device, "ImageToVideo")
 
-        model_name = "THUDM/CogVideoX1.5-5B-I2V"
-        self._pipeline = CogVideoXImageToVideoPipeline.from_pretrained(
-            model_name, revision=pinned(model_name), torch_dtype=dtype
+        model_name = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+        revision = pinned(model_name)
+        vae = AutoencoderKLWan.from_pretrained(
+            model_name, subfolder="vae", revision=revision, torch_dtype=torch.float32
         )
-        self._pipeline.to(device)
+        self._pipeline = WanImageToVideoPipeline.from_pretrained(
+            model_name, vae=vae, revision=revision, torch_dtype=torch.bfloat16
+        )
+        _retie_umt5_embeddings(self._pipeline)
+        # A14B MoE is too large for a single-GPU .to("cuda"); offload submodules on demand.
+        self._pipeline.enable_model_cpu_offload()
+
         self.device = device
         log_device_initialization(
             "ImageToVideo",
@@ -105,13 +162,26 @@ class ImageToVideo(ManagedPredictor):
             resolved_device=device,
         )
 
+    def _resize_to_model_grid(self, image: Image) -> tuple[Image, int, int]:
+        """Resize ``image`` to Wan's area budget, snapped to the model's spatial grid.
+
+        Returns the resized image plus the ``(height, width)`` to request, derived
+        from the input aspect ratio against Wan's 480x832 area (per the model card).
+        """
+        max_area = 480 * 832
+        aspect_ratio = image.height / image.width
+        mod_value = self._pipeline.vae_scale_factor_spatial * self._pipeline.transformer.config.patch_size[1]
+        height = round(np.sqrt(max_area * aspect_ratio)) // mod_value * mod_value
+        width = round(np.sqrt(max_area / aspect_ratio)) // mod_value * mod_value
+        return image.resize((width, height)), height, width
+
     def generate_video(
         self,
         image: Image,
         prompt: str = "",
-        num_steps: int = 50,
+        num_steps: int = 40,
         num_frames: int = 81,
-        guidance_scale: float = 6.0,
+        guidance_scale: float = 3.5,
     ) -> Video:
         """Generate video animation from a static image."""
         import torch
@@ -119,12 +189,18 @@ class ImageToVideo(ManagedPredictor):
         if self._pipeline is None:
             self._init_local()
 
+        image, height, width = self._resize_to_model_grid(image)
         video_frames = self._pipeline(
-            prompt=prompt,
             image=image,
-            num_inference_steps=num_steps,
+            prompt=prompt,
+            negative_prompt=_WAN_NEGATIVE_PROMPT,
+            height=height,
+            width=width,
             num_frames=num_frames,
+            num_inference_steps=num_steps,
             guidance_scale=guidance_scale,
+            # No guidance_scale_2: the low-noise MoE expert reuses guidance_scale (its None default).
+            output_type="pil",
             generator=torch.Generator(device=self.device).manual_seed(42),
         ).frames[0]
         video_frames = np.asarray(video_frames, dtype=np.uint8)

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ constraints = [
     { name = "requests", specifier = ">=2.33.0" },
 ]
 overrides = [
-    { name = "diffusers", specifier = ">=0.30.0" },
+    { name = "diffusers", specifier = ">=0.35.0" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "opencv-python", marker = "sys_platform == '_'" },
     { name = "torch", specifier = ">=2.8.0" },
@@ -972,6 +972,18 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
 ]
 
 [[package]]
@@ -4605,7 +4617,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.53.0"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -4622,6 +4634,7 @@ ai = [
     { name = "chatterbox-tts" },
     { name = "demucs" },
     { name = "diffusers" },
+    { name = "ftfy" },
     { name = "imagehash" },
     { name = "ollama" },
     { name = "openai-whisper" },
@@ -4661,7 +4674,8 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'ai'", specifier = ">=0.29.2" },
     { name = "chatterbox-tts", marker = "extra == 'ai'", specifier = ">=0.1.7" },
     { name = "demucs", marker = "extra == 'ai'", specifier = ">=4.0.0" },
-    { name = "diffusers", marker = "extra == 'ai'", specifier = ">=0.30.0" },
+    { name = "diffusers", marker = "extra == 'ai'", specifier = ">=0.35.0" },
+    { name = "ftfy", marker = "extra == 'ai'", specifier = ">=6.1" },
     { name = "imagehash", marker = "extra == 'ai'", specifier = ">=4.3" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27,<2" },
     { name = "numpy", specifier = ">=1.25.2" },
@@ -4739,6 +4753,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the restricted-license generation defaults with Apache-2.0 alternatives:
- Text-to-image:  SDXL (OpenRAIL++)   -> Qwen-Image (QwenImagePipeline)
- Text-to-video:  CogVideoX1.5-5B     -> Wan2.2-T2V-A14B (WanPipeline)
- Image-to-video: CogVideoX1.5-5B-I2V -> Wan2.2-I2V-A14B (WanImageToVideoPipeline)

Generation now requires a CUDA GPU (these ~20-28B models are impractical on CPU/MPS): TextToImage/TextToVideo/ImageToVideo raise on non-CUDA devices and the SDXL/CogVideoX CPU/MPS fallbacks are dropped. Always bf16 transformer + enable_model_cpu_offload(); VAE stays fp32. Bump diffusers floor 0.30->0.35 and swap the SDXL/CogVideoX revision pins for Qwen-Image-2512 + Wan2.2 T2V/I2V.

Verified end-to-end on an RTX PRO 6000 (Blackwell, cu128), which surfaced two issues the mocked tests could not: Wan's UMT5 text encoder leaves encoder.embed_tokens zero-initialized on transformers>=5.2 (the checkpoint ships only shared.weight), nulling text conditioning -> re-tie embed_tokens to shared after load; and diffusers' Wan i2v pipeline imports ftfy unconditionally -> add ftfy>=6.1 to the [ai] extra. Image/t2v/i2v all follow the prompt.

BREAKING CHANGE: media generation requires a CUDA GPU. TextToImage uses Qwen's true_cfg_scale (not guidance_scale); TextToVideo/ImageToVideo default to Wan2.2 recommendations (num_steps 50->40, guidance_scale 6.0->4.0/3.5).