### PR TITLE
Make sure pip install gets resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Run pre-commit hooks
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
+  pip_resolve:
+    # The consumer-install guard. Lives in its own workflow so it can also run on
+    # a schedule without dragging the whole matrix along; see pip-resolve.yml.
+    name: Wheel resolves with pip
+    uses: ./.github/workflows/pip-resolve.yml
+
   docs:
     name: Documentation build
     runs-on: ubuntu-latest

--- a/.github/workflows/pip-resolve.yml
+++ b/.github/workflows/pip-resolve.yml
@@ -1,0 +1,44 @@
+name: Wheel resolves with pip
+
+# Guards the bug class that shipped in 0.54.0: `[ai]` was unsatisfiable for every
+# consumer while CI stayed green, because `[tool.uv].override-dependencies`
+# reconciled the conflict in-repo and overrides do NOT ship in the built wheel.
+# Nothing else in CI installs the wheel the way a consumer does, so nothing else
+# can see that class of breakage.
+#
+# Scheduled as well as called from ci.yml on push: these failures arrive from
+# UPSTREAM releases tightening their pins, not from our commits, so a push-only
+# check would not notice until someone happened to push.
+on:
+  workflow_call:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC
+
+jobs:
+  pip_resolve:
+    name: Resolve built wheel with pip (no uv overrides)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extras: ["ai", "ai,mcp"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        run: uv python install 312
+      - name: Build the wheel
+        run: uv build --wheel
+      - name: Resolve [${{ matrix.extras }}] in a clean environment
+        run: |
+          set -euo pipefail
+          wheel=$(ls dist/*.whl)
+          python -m venv /tmp/resolve
+          /tmp/resolve/bin/pip install --upgrade pip
+          # --dry-run resolves the whole graph without installing ~10 GB of CUDA
+          # wheels. pip exits non-zero on ResolutionImpossible, which is the
+          # signal we want; verified against 0.54.0, which fails here with
+          # "chatterbox-tts 0.1.7 depends on torch==2.6.0".
+          /tmp/resolve/bin/pip install --dry-run "${wheel}[${{ matrix.extras }}]"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,6 +70,42 @@ uv run mkdocs serve   # live preview at http://127.0.0.1:8000
 uv run mkdocs build   # render the static site to ./site
 ```
 
+## Dependencies
+
+### The consumer-install invariant
+
+`[ai]` must resolve for someone running plain `pip install "videopython[ai]"`.
+
+`[tool.uv]` tables (`override-dependencies`, `constraint-dependencies`) are a uv
+*workspace* feature — they do not ship in the built wheel. Anything reconciled only
+there is invisible to consumers, so it makes CI green while every downstream install
+fails. That is exactly what happened in 0.54.0.
+
+There are deliberately no overrides today. If a dependency ships metadata that cannot
+be satisfied, fix the metadata rather than patching it locally:
+
+* upstream a fix, or
+* fork the package and publish corrected metadata (what 0.54.1 did), or
+* drop the dependency.
+
+The `pip_resolve` CI job (`.github/workflows/pip-resolve.yml`) builds the wheel and
+resolves `[ai]` and `[ai,mcp]` with pip in a clean venv, on every push and weekly on
+a schedule. The schedule matters because these breakages arrive from upstream
+releases tightening their pins, not from our own commits.
+
+### `videopython-chatterbox`
+
+`[ai]` depends on
+[`videopython-chatterbox`](https://github.com/BartWojtowicz/videopython-chatterbox),
+our fork of `chatterbox-tts`, published to PyPI. It is upstream's source with
+corrected dependency metadata — upstream pins `torch==2.6.0`, `diffusers==0.29.0`
+and `transformers==5.2.0` with `==`, which cannot be satisfied alongside the rest of
+`[ai]` (`pyannote-audio` alone needs `torch>=2.8`). The import name is still
+`chatterbox`, so no application code changes.
+
+Resync when upstream ships a release we want. Both distributions install a top-level
+`chatterbox` package, so they must never be installed together.
+
 ## Releasing
 
 To release a new version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,21 +57,15 @@ dev = [
 # `[ai]` extra so dev installs every AI capability (single source of truth).
 ai = ["videopython[ai]"]
 
-# pip install "videopython[ai]" - pip uses optional-dependencies, not dependency-groups.
-#
-# A single [ai] extra installs every AI capability. The heavy ML deps still load
-# lazily at first use (no top-level imports under ai/), so importing videopython
-# stays light even with [ai] installed.
+# One [ai] extra for every AI capability. Heavy ML deps load lazily at first use
+# (no top-level imports under ai/), so importing videopython stays light.
 [project.optional-dependencies]
 ai = [
     # Speech recognition / diarization (understanding/audio.py)
     "openai-whisper>=20240930",
-    # whisper imports numba (timing.py), and numba is version-coupled to numpy:
-    # each release declares a `numpy<X` cap that moves forward (0.62 -> <2.4,
-    # 0.66 -> <2.5). Without a floor a resolver can satisfy a newer numpy by
-    # backtracking numba to an ancient release instead, which then fails at
-    # `import whisper`. Floor it so numba's own cap does the work; 0.62 is the
-    # oldest release covering our full Python range (3.11-3.13).
+    # Floored, not capped: numba declares the numpy cap, and without a floor a
+    # resolver satisfies a newer numpy by backtracking numba instead, breaking
+    # `import whisper`. 0.62 is the oldest release covering Python 3.11-3.13.
     "numba>=0.62",
     "pyannote-audio>=4.0.0",
     "silero-vad>=5.1",
@@ -82,20 +76,14 @@ ai = [
     "imagehash>=4.3",
     # Audio source separation (understanding/separation.py)
     "demucs>=4.0.0",
-    # Voice cloning TTS (generation/audio.py — Chatterbox). Upstream chatterbox-tts
-    # 0.1.7 pins diffusers==0.29.0 / torch==2.6.0 / transformers==5.2.0 with `==`,
-    # which is unsatisfiable against pyannote-audio (torch>=2.8) and our
-    # diffusers>=0.35 — it made `pip install "videopython[ai]"` impossible for
-    # consumers. videopython-chatterbox is upstream's source with corrected
-    # metadata (identical apart from its self-version lookup); the import name is
-    # still `chatterbox`. See https://github.com/BartWojtowicz/videopython-chatterbox
+    # Voice cloning TTS (generation/audio.py). Our fork of chatterbox-tts with
+    # corrected metadata; import name is still `chatterbox`. Not upstream — its
+    # `==` pins make [ai] unsatisfiable. See DEVELOPMENT.md "Dependencies".
     "videopython-chatterbox>=0.1.7.post1",
-    # Local media generation: Qwen-Image/Wan2.2 + MusicGen (generation/*).
-    # >=0.35 is the floor that ships QwenImagePipeline + Wan2.2 support (tested on 0.37.1).
+    # Local media generation (generation/*). >=0.35 ships QwenImagePipeline + Wan2.2.
     "diffusers>=0.35.0",
-    # Wan2.2 i2v pipeline cleans prompts with ftfy via a hard import (diffusers'
-    # pipeline_wan_i2v); the t2v pipeline guards it with is_ftfy_available(), i2v
-    # does not, so it is a required dep for ImageToVideo.
+    # Required, despite looking like diffusers' problem: the Wan2.2 i2v pipeline
+    # imports ftfy unguarded (the t2v one guards it with is_ftfy_available()).
     "ftfy>=6.1",
     "accelerate>=0.29.2",
     # Dubbing loudness matching (dubbing/loudness.py)
@@ -106,16 +94,13 @@ ai = [
     # processor used by the D-FINE object detector (understanding/objects.py).
     "torch>=2.8.0",
     "torchaudio>=2.8.0",
-    # No upper bound: each torchvision release declares an exact `torch==X.Y.Z`
-    # pin, so resolvers co-select a valid pair unaided. Capping torchvision alone
-    # is actively harmful — it transitively pinned torch to 2.8 (cu12) while
-    # torchaudio floated to 2.11 (cu13), resolving cleanly and then dying at
-    # import with `OSError: libcudart.so.13`. Cap every member or none.
+    # Do NOT add an upper bound. torchvision pins an exact torch, so capping it
+    # alone pinned torch to 2.8 (cu12) while torchaudio floated to 2.11 (cu13) —
+    # resolved cleanly, then died at import with `OSError: libcudart.so.13`.
+    # Cap every member of the torch stack or none.
     "torchvision>=0.23.0",
-    # torchaudio 2.11 routes save()/load() through torchcodec, and torchcodec is a
-    # native extension linked against libtorch that declares no torch requirement
-    # of its own. It arrives transitively via pyannote-audio; declare it so it is
-    # visible rather than incidental.
+    # Transitive via pyannote-audio, declared because torchaudio 2.11+ routes
+    # save()/load() through it and it is ABI-coupled to torch.
     "torchcodec>=0.7.0",
 ]
 # MCP server (videopython/mcp/). Pin <2 — v2 is pre-release/breaking.
@@ -156,36 +141,10 @@ module = [
 ignore_missing_imports = true
 
 [tool.uv]
-# NOTE: overrides are a uv workspace feature — they do NOT ship in the built
-# wheel. Anything reconciled only here is invisible to `pip install videopython`,
-# so [ai] must be resolvable without this block. Keep it minimal.
-#
-# The torch/torchaudio/torchvision/diffusers overrides that used to live here
-# existed solely to paper over chatterbox-tts's `==` pins. They masked the
-# breakage from CI while every downstream consumer hit it, and an override
-# replaces a requirement *everywhere* — including torchvision's own exact
-# `torch==2.8.0` pin, which would have produced an ABI-invalid pair on the next
-# `uv lock --upgrade`. [ai] now depends on videopython-chatterbox, whose metadata
-# is correct, so none of them are needed.
-# The numpy>=2.0.0 override is gone for the same reason: it existed to counter
-# chatterbox-tts's `numpy<2.0.0` pin, and it also replaced numba's `numpy<2.5`
-# cap, resolving numpy 2.5 into an environment where `import whisper` dies with
-# "Numba needs NumPy 2.4 or less". numba IS version-coupled to numpy.
-#
-# The opencv-python exclusion is gone too. It was added for ultralytics, whose
-# opencv-python requirement clashed with our opencv-python-headless (both
-# provide `cv2`, so whichever installs last wins). ultralytics was dropped in
-# 0.51.0 and nothing in the graph has required opencv-python since -- verified
-# by re-resolving without it. It was also false protection: being uv-only it
-# never reached the pip users it claimed to shield. The invariant is now guarded
-# somewhere that ships, by test_no_conflicting_opencv_distribution.
-#
-# There are deliberately no overrides. If you are about to add one, the
-# requirement it patches is invisible to consumers -- fix the dependency
-# metadata instead, as 0.54.1 did by forking chatterbox-tts.
-# Pin minimum versions for transitive deps with known vulnerabilities.
-# Pygments 2.20.0 has a security fix but breaks mkdocs (passes None to html.escape).
-# Keep pygments<2.20.0 until a compatible release is available.
+# No overrides, deliberately: they are a uv workspace feature and do not ship in
+# the wheel, so anything patched here is invisible to `pip install`. Fix the
+# dependency's metadata instead — see DEVELOPMENT.md "Dependencies".
+# requests: CVE floor. pygments <2.20.0: 2.20.0 breaks mkdocs (passes None to html.escape).
 constraint-dependencies = ["requests>=2.33.0", "pygments>=2.19.2,<2.20.0"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,12 +171,18 @@ ignore_missing_imports = true
 # chatterbox-tts's `numpy<2.0.0` pin, and it also replaced numba's `numpy<2.5`
 # cap, resolving numpy 2.5 into an environment where `import whisper` dies with
 # "Numba needs NumPy 2.4 or less". numba IS version-coupled to numpy.
-override-dependencies = [
-    # Some transitive deps pull opencv-python, which conflicts with our
-    # opencv-python-headless (both provide cv2). Exclude opencv-python so
-    # only the headless variant is installed.
-    "opencv-python ; sys_platform == '_'",
-]
+#
+# The opencv-python exclusion is gone too. It was added for ultralytics, whose
+# opencv-python requirement clashed with our opencv-python-headless (both
+# provide `cv2`, so whichever installs last wins). ultralytics was dropped in
+# 0.51.0 and nothing in the graph has required opencv-python since -- verified
+# by re-resolving without it. It was also false protection: being uv-only it
+# never reached the pip users it claimed to shield. The invariant is now guarded
+# somewhere that ships, by test_no_conflicting_opencv_distribution.
+#
+# There are deliberately no overrides. If you are about to add one, the
+# requirement it patches is invisible to consumers -- fix the dependency
+# metadata instead, as 0.54.1 did by forking chatterbox-tts.
 # Pin minimum versions for transitive deps with known vulnerabilities.
 # Pygments 2.20.0 has a security fix but breaks mkdocs (passes None to html.escape).
 # Keep pygments<2.20.0 until a compatible release is available.

--- a/src/tests/test_packaging_extras.py
+++ b/src/tests/test_packaging_extras.py
@@ -124,6 +124,30 @@ def test_dependency_group_ai_matches_optional_ai(pyproject: Pyproject) -> None:
     )
 
 
+def test_no_conflicting_opencv_distribution() -> None:
+    """Nothing may pull ``opencv-python`` alongside our ``opencv-python-headless``.
+
+    Both distributions install a top-level ``cv2`` package, so having both in the
+    graph means whichever pip unpacks last wins -- and the headless variant is the
+    one that matters for server deploys (the GUI build drags in libGL and friends).
+
+    This used to be enforced by a ``[tool.uv].override-dependencies`` entry added
+    for ultralytics. That was false protection: overrides are a uv workspace
+    feature and do not ship in the wheel, so it shielded our own CI and nobody
+    else. ultralytics was dropped in 0.51.0 and nothing has required
+    opencv-python since, so the override is gone and this guard replaces it --
+    reading the resolved lock, where a *transitive* reintroduction would show up.
+    """
+    lock = (_REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
+    assert 'name = "opencv-python-headless"' in lock, "headless opencv vanished from the resolved graph"
+    assert 'name = "opencv-python"\n' not in lock, (
+        "opencv-python re-entered the dependency graph; it conflicts with "
+        "opencv-python-headless (both provide `cv2`). Find the dep that pulls it and "
+        "constrain that dep -- do NOT add a [tool.uv] override, which would hide the "
+        "problem from every consumer installing with pip."
+    )
+
+
 # Deps that are declared as resolver co-pins/floors but have NO direct import
 # under ai/ — they're pulled transitively by a sibling dep that we DO import:
 #   torchaudio   -> co-pin for the torch stack (whisper/chatterbox/demucs)

--- a/src/videopython/editing/effects.py
+++ b/src/videopython/editing/effects.py
@@ -311,9 +311,8 @@ class ColorGrading(Effect):
         if self.brightness != 0 or self.contrast != 1.0:
             out = cv2.LUT(out, self._lut_tone)
         if self.saturation != 1.0:
-            # Saturation as a blend toward the luma-weighted greyscale of the
-            # frame. Replaces an RGB->HSV->RGB float32 round trip that cost more
-            # than every other stage of the grade combined (~42 of 56 ms/frame).
+            # Blend toward luma-weighted greyscale. Not an HSV round trip: that
+            # costs more than every other stage of the grade combined.
             grey = cv2.cvtColor(out, cv2.COLOR_RGB2GRAY)
             out = cv2.addWeighted(
                 out, self.saturation, cv2.cvtColor(grey, cv2.COLOR_GRAY2RGB), 1.0 - self.saturation, 0
@@ -364,17 +363,13 @@ class Vignette(Effect):
     def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
         """Bake the gain mask into a 3-channel uint8 lookup, once per stream.
 
-        The mask is static, so the only per-frame work should be one multiply.
-        Storing it as uint8 replicated across channels lets ``cv2.multiply`` run
-        the whole frame in a single SIMD pass with no float conversion --
-        ~10x faster than promoting every frame to float32, and the mask itself
-        is *smaller* than the float32 original (6.2 MB vs 8.3 MB at 1080p).
+        The mask is static, so per-frame work is one ``cv2.multiply`` SIMD pass
+        with no float conversion.
 
-        The clip to [0, 1] also fixes a real defect: ``_create_mask`` goes
-        NEGATIVE once ``strength`` is high enough (down to -1.0 at
-        ``strength=1.0``), and ``(frame * -1.0).astype(np.uint8)`` wraps around,
-        so the darkest corners rendered as mid-grey (200 -> 56) and the vignette
-        got *brighter* past the zero crossing instead of saturating to black.
+        Clipping to [0, 1] is load-bearing, not tidying: ``_create_mask`` goes
+        negative once ``strength`` is high enough (-1.0 at ``strength=1.0``), and
+        ``(frame * -1.0).astype(np.uint8)`` wraps, which renders the darkest
+        corners mid-grey and makes the vignette brighten past the zero crossing.
         """
         if self._mask is None or self._mask.shape != (height, width):
             self._mask = self._create_mask(height, width)
@@ -1429,18 +1424,14 @@ class FilmGrain(Effect):
     _geometry: tuple[int, int] = PrivateAttr(default=(0, 0))
 
     def streaming_init(self, total_frames: int, fps: float, width: int, height: int, **_context: Any) -> None:
-        """Draw one oversized noise plane up front; each frame reads a random window of it.
+        """Draw one oversized noise plane up front; each frame reads a random window.
 
-        Generating fresh Gaussian noise per frame meant ~2M ``standard_normal``
-        samples every frame, which dominated the effect (~31 ms/frame, more than
-        twice the encoder's whole per-frame budget). Sampling a
-        ``GRAIN_POOL_PAD``-padded plane once and taking a randomly offset window
-        per frame gives grain that still changes every frame -- offsets jump
-        rather than drift, so it scintillates like film rather than sliding --
-        for one saturating integer add.
+        Sampling Gaussian noise per frame costs ~2M draws a frame and dominates
+        the effect; one padded plane plus a per-frame offset reduces that to a
+        saturating integer add.
 
-        Reproducibility is unchanged in contract (same ``seed`` -> same grain),
-        though the pattern itself differs from the per-frame-RNG version.
+        Offsets jump rather than advance, so the grain scintillates like film
+        instead of sliding. Same ``seed`` still gives the same grain.
         """
         amp = self.intensity * 255.0
         pad = GRAIN_POOL_PAD

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,6 @@ constraints = [
     { name = "pygments", specifier = ">=2.19.2,<2.20.0" },
     { name = "requests", specifier = ">=2.33.0" },
 ]
-overrides = [{ name = "opencv-python", marker = "sys_platform == '_'" }]
 
 [[package]]
 name = "accelerate"
@@ -659,7 +658,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -688,43 +687,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2189,7 +2188,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2228,7 +2227,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2240,7 +2239,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2270,9 +2269,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2284,7 +2283,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4488,8 +4487,8 @@ name = "uvicorn"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
 wheels = [


### PR DESCRIPTION
0.54.1 fixed `pip install "videopython[ai]"` being unsatisfiable, but nothing stopped it recurring. The bug class was precisely "CI resolved fine while pip, uv and Poetry all hit a hard failure": [tool.uv].override-dependencies reconciled the conflict in-repo, and overrides do not ship in the built wheel. test_packaging_extras only checks pyproject self-consistency, so no test installed the artifact a consumer installs.

Adds a pip_resolve workflow that builds the wheel and resolves [ai] and [ai,mcp] with pip in a clean venv. --dry-run resolves the full graph without pulling ~10 GB of CUDA wheels, and pip exits non-zero on ResolutionImpossible. Verified both directions locally: the current wheel resolves (exit 0, ~50s) and 0.54.0 fails with the historical root cause, "chatterbox-tts 0.1.7 depends on torch==2.6.0" against our torch>=2.8.0.

It lives in its own workflow, called from ci.yml on push and also run weekly. The schedule is the point: these failures arrive from upstream releases tightening their pins, not from our commits, so a push-only check would not notice until someone happened to push.

Also removes the last override. It excluded opencv-python, which conflicts with opencv-python-headless (both provide `cv2`, last writer wins), and was added in dd316b2 for ultralytics -- the comment at the time named it explicitly, before being genericized to "some transitive deps". ultralytics was dropped in 0.51.0, and re-resolving without the override confirms nothing has required opencv-python since. It was false protection anyway: being uv-only it never reached the pip users it claimed to shield.
test_no_conflicting_opencv_distribution now guards the invariant by reading the resolved lock, where a transitive reintroduction would actually show up.

No release: [tool.uv] tables are not part of the wheel, so the published artifact is unchanged. uv.lock carries marker refinements from the re-resolve.