### PR TITLE
fix(ai): correct inference and diarization behavior

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 0.55.3
+
+- Scene captioning now sizes the Ollama context window for the number of images in
+  each request. If a model needs more visual tokens, the request retries with the
+  requirement reported by Ollama. Text-only requests keep the default, and an
+  explicit `num_ctx` still takes precedence.
+- Object detection filters now accept standard COCO names as well as D-FINE's
+  alternate spellings for `motorcycle`, `airplane`, `couch`, `potted plant`,
+  `dining table`, and `tv`. Matching ignores case and extra spaces, and unknown
+  names produce a warning after the model loads.
+- `AudioToText.diarize_transcription()` now preserves Whisper's per-segment
+  confidence metadata when it adds speakers to an existing transcription.
+
 ## 0.55.2
 
 `Audio.from_path` no longer holds several copies of the file while decoding, and takes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videopython"
-version = "0.55.2"
+version = "0.55.3"
 description = "Minimal video generation and processing library."
 authors = [
     { name = "Bartosz Wójtowicz", email = "bartoszwojtowicz@outlook.com" },

--- a/src/tests/ai/test_dubbing.py
+++ b/src/tests/ai/test_dubbing.py
@@ -1360,6 +1360,43 @@ class TestDiarizeTranscription:
         assert result.speakers == {"S0", "S1"}
         assert result.language == "en"
 
+    def test_keeps_per_segment_confidence(self, sample_audio, monkeypatch):
+        """Diarizing separately must not lose the confidence the combined path keeps.
+
+        Rebuilding from words regroups by speaker and drops the supplied
+        transcription's per-segment metadata, so it is re-attached by overlap --
+        the same treatment ``_transcribe_with_diarization`` already gives it.
+        """
+        from videopython.ai.understanding.audio import AudioToText
+        from videopython.base.transcription import TranscriptionWord
+
+        transcription = self._make_transcription_with_words()
+        for i, segment in enumerate(transcription.segments):
+            segment.avg_logprob = -0.1 * (i + 1)
+            segment.no_speech_prob = 0.01 * (i + 1)
+            segment.compression_ratio = 1.0 + i
+
+        def fake_init_diarization(self):
+            self._diarization_pipeline = lambda payload: "fake-diarization-result"
+
+        @staticmethod
+        def fake_assign_speakers(words, diarization_result):
+            # One speaker per original segment, so the rebuild lines up one-to-one
+            # with the sources and the expected values are unambiguous.
+            return [
+                TranscriptionWord(start=w.start, end=w.end, word=w.word, speaker="S0" if w.start < 1.5 else "S1")
+                for w in words
+            ]
+
+        monkeypatch.setattr(AudioToText, "_init_diarization", fake_init_diarization)
+        monkeypatch.setattr(AudioToText, "_assign_speakers_to_words", fake_assign_speakers)
+
+        result = AudioToText().diarize_transcription(sample_audio, transcription)
+
+        assert [s.avg_logprob for s in result.segments] == [-0.1, -0.2]
+        assert [s.no_speech_prob for s in result.segments] == [0.01, 0.02]
+        assert [s.compression_ratio for s in result.segments] == [1.0, 2.0]
+
 
 class TestPipelineSuppliedTranscriptionDiarization:
     """Tests for diarization-on-supplied-transcription plumbing in LocalDubbingPipeline."""

--- a/src/tests/ai/test_objects.py
+++ b/src/tests/ai/test_objects.py
@@ -113,3 +113,57 @@ class TestObjectDetector:
         det.detect(np.zeros((100, 200, 3), dtype=np.uint8))
         _, kwargs = det._processor.post_process_object_detection.call_args
         assert kwargs["threshold"] == 0.7
+
+
+class TestClassFilterSpellings:
+    """D-FINE emits VOC-style names for six COCO classes.
+
+    Passing the standard COCO spelling used to match nothing and draw nothing,
+    with no error to explain the silence -- and the class docstring claimed the
+    spellings were normalized when no normalization existed.
+    """
+
+    def test_standard_coco_spelling_matches_voc_label(self):
+        results = [_result(scores=[0.9], labels=[3], boxes=[[0.0, 0.0, 10.0, 10.0]])]
+        det = _detector_with(results, class_names={3: "motorbike"}, class_filter=("motorcycle",))
+        assert [o.label for o in det.detect(np.zeros((100, 200, 3), dtype=np.uint8))] == ["motorbike"]
+
+    def test_detector_own_spelling_still_matches(self):
+        results = [_result(scores=[0.9], labels=[3], boxes=[[0.0, 0.0, 10.0, 10.0]])]
+        det = _detector_with(results, class_names={3: "motorbike"}, class_filter=("motorbike",))
+        assert [o.label for o in det.detect(np.zeros((100, 200, 3), dtype=np.uint8))] == ["motorbike"]
+
+    @pytest.mark.parametrize(
+        ("given", "expected"),
+        [
+            ("motorcycle", "motorbike"),
+            ("airplane", "aeroplane"),
+            ("couch", "sofa"),
+            ("potted plant", "pottedplant"),
+            ("dining table", "diningtable"),
+            ("tv", "tvmonitor"),
+        ],
+    )
+    def test_every_diverging_class_is_aliased(self, given, expected):
+        assert ObjectDetector(class_filter=(given,)).class_filter == (expected,)
+
+    def test_case_and_spacing_are_normalized(self):
+        det = ObjectDetector(class_filter=("Potted  Plant", " TV "))
+        assert det.class_filter == ("pottedplant", "tvmonitor")
+
+    def test_unaliased_name_passes_through(self):
+        assert ObjectDetector(class_filter=("person",)).class_filter == ("person",)
+
+    def test_unknown_class_is_reported_once_the_model_is_known(self):
+        det = _detector_with([], class_names={0: "person"}, class_filter=("person", "sasquatch"))
+        assert det.unknown_filter_classes() == ("sasquatch",)
+
+    def test_no_unknown_classes_before_the_model_loads(self):
+        det = ObjectDetector(class_filter=("sasquatch",))
+        assert det.unknown_filter_classes() == ()
+
+    def test_unknown_class_warns_on_load(self, caplog):
+        det = _detector_with([], class_names={0: "person"}, class_filter=("sasquatch",))
+        with caplog.at_level("WARNING"):
+            det._warn_unknown_filter_classes()
+        assert "sasquatch" in caplog.text

--- a/src/tests/ai/test_ollama_backend.py
+++ b/src/tests/ai/test_ollama_backend.py
@@ -18,9 +18,15 @@ from videopython.ai.keyframe import KEYFRAME_MAX_DIM, downscale_keyframe, encode
 class _FakeClient:
     """Records chat() kwargs and returns a fixed ChatResponse-shaped object."""
 
-    def __init__(self, content: str, capabilities: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        content: str,
+        capabilities: list[str] | None = None,
+        errors: list[Exception] | None = None,
+    ) -> None:
         self.content = content
         self.capabilities = ["completion"] if capabilities is None else capabilities
+        self.errors = list(errors or [])
         self.calls: list[dict[str, Any]] = []
 
     def show(self, model: str) -> SimpleNamespace:
@@ -36,6 +42,8 @@ class _FakeClient:
         **kwargs: Any,
     ) -> SimpleNamespace:
         self.calls.append({"model": model, "messages": messages, "format": format, "options": options, **kwargs})
+        if self.errors:
+            raise self.errors.pop(0)
         return SimpleNamespace(message=SimpleNamespace(content=self.content))
 
 
@@ -128,3 +136,38 @@ def test_downscale_bounds_longest_side() -> None:
     assert shrunk.shape == (320, 768, 3)  # aspect preserved: 500 * 768 / 1200 == 320
     small = np.zeros((4, 6, 3), dtype=np.uint8)
     assert downscale_keyframe(small) is small  # never upscales
+
+
+def test_text_only_call_leaves_the_context_window_alone() -> None:
+    """Only image-bearing calls widen num_ctx.
+
+    Sizing every call up would preallocate a KV cache the text-only callers
+    (planner brief, translator) never need, so the widening is scoped to
+    requests that actually carry images.
+    """
+    backend = OllamaVisionLLM(model="m")
+    fake = _FakeClient('{"segments": []}')
+    _inject(backend, fake)
+
+    backend.generate_json(system="sys", text="brief", images=[], schema={"type": "object", "properties": {}})
+
+    assert "num_ctx" not in fake.calls[0]["options"]
+
+
+def test_image_call_retries_with_reported_context_requirement() -> None:
+    backend = OllamaVisionLLM(model="m")
+    fake = _FakeClient(
+        '{"segments": []}',
+        errors=[RuntimeError("request (9000 tokens) exceeds the available context size (4096 tokens)")],
+    )
+    _inject(backend, fake)
+
+    backend.generate_json(
+        system="sys",
+        text="brief",
+        images=[np.zeros((4, 4, 3), dtype=np.uint8)],
+        schema={"type": "object", "properties": {}},
+    )
+
+    assert len(fake.calls) == 2
+    assert fake.calls[1]["options"]["num_ctx"] == 16384

--- a/src/tests/ai/test_scene_vlm_parsing.py
+++ b/src/tests/ai/test_scene_vlm_parsing.py
@@ -75,3 +75,35 @@ def test_empty_images_raises() -> None:
     vlm, _ = _vlm_with("{}")
     with pytest.raises(ValueError, match="frame"):
         vlm.analyze_scene([])
+
+
+def test_context_window_is_sized_to_the_frame_count() -> None:
+    """Ollama fails an oversized request instead of truncating it.
+
+    A scene's frames go out as one multi-image call at roughly 1k tokens each, so
+    Ollama's own 4096 default only ever fits one or two frames. Regression guard:
+    before this was sized, a multi-cut clip died with exceed_context_size_error
+    while a single static shot passed, so the default looked fine in testing.
+    """
+    vlm, fake = _vlm_with(json.dumps({"caption": "c", "subjects": [], "shot_type": "wide"}))
+    vlm.analyze_scene([_frame() for _ in range(8)])
+
+    assert fake.calls[0]["options"]["num_ctx"] >= 8 * 1024
+
+
+def test_context_window_grows_with_more_frames() -> None:
+    vlm, fake = _vlm_with(json.dumps({"caption": "c", "subjects": [], "shot_type": "wide"}))
+    vlm.analyze_scene([_frame()])
+    vlm.analyze_scene([_frame() for _ in range(16)])
+
+    assert fake.calls[1]["options"]["num_ctx"] > fake.calls[0]["options"]["num_ctx"]
+
+
+def test_explicit_num_ctx_is_not_overridden() -> None:
+    """A caller batching an unusual frame count must be able to pin the window."""
+    vlm = SceneVLM(model="m", options={"num_ctx": 65536})
+    fake = _FakeClient(json.dumps({"caption": "c", "subjects": [], "shot_type": "wide"}))
+    vlm._client._client = fake
+    vlm.analyze_scene([_frame() for _ in range(4)])
+
+    assert fake.calls[0]["options"]["num_ctx"] == 65536

--- a/src/videopython/ai/_ollama.py
+++ b/src/videopython/ai/_ollama.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 import numpy as np
@@ -14,6 +15,45 @@ from videopython.ai.keyframe import encode_png_b64
 
 class OllamaError(AiError, RuntimeError):
     """Ollama returned unusable output (non-JSON or an unexpected shape)."""
+
+
+# Ollama's own default context window is 4096 tokens, and an oversized request
+# *fails* (``exceed_context_size_error``) instead of being truncated -- so a call
+# carrying images has to size the window before sending. A vision model spends
+# roughly this many tokens per image. Deliberately generous: underestimating
+# fails the request outright, overestimating only costs KV-cache memory.
+_TOKENS_PER_IMAGE = 1024
+# Headroom for the system prompt, the user text, and the generated answer.
+_TEXT_TOKEN_ALLOWANCE = 2048
+# Never ask for less than Ollama's own default.
+_MIN_NUM_CTX = 4096
+_CONTEXT_OVERFLOW_RE = re.compile(r"request \((\d+) tokens\) exceeds the available context size")
+
+
+def _round_num_ctx(token_count: int) -> int:
+    return max(_MIN_NUM_CTX, 1 << (token_count - 1).bit_length())
+
+
+def _num_ctx_for_images(image_count: int) -> int:
+    """Estimate the initial context window for ``image_count`` images.
+
+    Rounded up to a power of two so a run over scenes with differing frame counts
+    reuses a handful of window sizes instead of a new one per call -- ``num_ctx``
+    is a runner-level setting, so varying it every call risks reloading the model
+    between scenes.
+    """
+    needed = image_count * _TOKENS_PER_IMAGE + _TEXT_TOKEN_ALLOWANCE
+    return _round_num_ctx(needed)
+
+
+def _num_ctx_after_overflow(error: str, current: int) -> int | None:
+    """Return a larger context after Ollama reports a context overflow."""
+    match = _CONTEXT_OVERFLOW_RE.search(error)
+    if match:
+        return _round_num_ctx(int(match.group(1)) + _TEXT_TOKEN_ALLOWANCE)
+    if "exceed_context_size_error" in error:
+        return current * 2
+    return None
 
 
 class OllamaStructuredClient:
@@ -30,6 +70,10 @@ class OllamaStructuredClient:
     budget thinking, stops on ``length``, and returns empty content. None of these
     callers want the chain-of-thought, so thinking is disabled on models that
     support it.
+
+    Image requests start with a context estimate based on the image count. If a
+    model uses more visual tokens, the request retries once with the token count
+    reported by Ollama. An explicit ``num_ctx`` in ``options`` always wins.
     """
 
     def __init__(self, model: str, *, host: str | None = None, options: dict[str, Any] | None = None) -> None:
@@ -69,12 +113,23 @@ class OllamaStructuredClient:
         if images:
             user["images"] = [encode_png_b64(image) for image in images]
         messages = [{"role": "system", "content": system}, user]
+        options = self.options
+        image_count = len(images) if images else 0
+        auto_num_ctx = image_count > 0 and "num_ctx" not in options
+        if auto_num_ctx:
+            options = {**options, "num_ctx": _num_ctx_for_images(image_count)}
         kwargs: dict[str, Any] = {}
         if self._supports_thinking():
             kwargs["think"] = False
-        response = self._get_client().chat(
-            model=self.model, messages=messages, format=schema, options=self.options, **kwargs
-        )
+        client = self._get_client()
+        try:
+            response = client.chat(model=self.model, messages=messages, format=schema, options=options, **kwargs)
+        except Exception as exc:
+            retry_num_ctx = _num_ctx_after_overflow(str(exc), options["num_ctx"]) if auto_num_ctx else None
+            if retry_num_ctx is None:
+                raise
+            options = {**options, "num_ctx": retry_num_ctx}
+            response = client.chat(model=self.model, messages=messages, format=schema, options=options, **kwargs)
         content = response.message.content
         try:
             data = json.loads(content)

--- a/src/videopython/ai/effects.py
+++ b/src/videopython/ai/effects.py
@@ -43,7 +43,11 @@ class ObjectDetectionOverlay(Effect):
     confidence_threshold: float = Field(0.5, ge=0, le=1, description="Minimum detection confidence to draw a box, 0-1.")
     class_filter: list[str] | None = Field(
         None,
-        description='Only draw these COCO class names, e.g. ["person", "car", "dog"]. Null draws all classes.',
+        description=(
+            'Only draw these COCO class names, e.g. ["person", "car", "motorcycle"]. '
+            "Null draws all classes. Standard COCO names and D-FINE's alternate spellings "
+            "(motorbike, aeroplane, sofa, pottedplant, diningtable, tvmonitor) are accepted."
+        ),
     )
     show_confidence: bool = Field(True, description="Append the detection confidence as a percentage to each label.")
     box_color: tuple[int, int, int] | None = Field(

--- a/src/videopython/ai/understanding/audio.py
+++ b/src/videopython/ai/understanding/audio.py
@@ -333,7 +333,16 @@ class AudioToText(ManagedPredictor):
         )
 
         all_words = self._assign_speakers_to_words(all_words, diarization_result)
-        return Transcription(words=all_words, language=transcription.language)
+
+        # Rebuilding from words regroups by speaker and drops the per-segment
+        # confidence the supplied transcription carried, exactly as it does on the
+        # combined path -- so re-attach it the same way. Without this, splitting
+        # transcription and diarization into two calls silently loses confidence
+        # that running them as one keeps.
+        source_segments = transcription.segments
+        rebuilt = Transcription(words=all_words, language=transcription.language)
+        _attach_confidence_by_overlap(rebuilt.segments, source_segments)
+        return rebuilt
 
     def _run_vad(self, audio_mono: Audio) -> list[tuple[float, float]]:
         """Return voiced spans in seconds using Silero VAD.

--- a/src/videopython/ai/understanding/image.py
+++ b/src/videopython/ai/understanding/image.py
@@ -41,6 +41,11 @@ class SceneVLM(ManagedPredictor):
     The model must be vision-capable and support Ollama's structured-output
     ``format``; ``ollama pull <model>`` first. ``options`` are extra Ollama
     generation options merged over ``temperature=0``.
+
+    A scene's frames are sent as one multi-image request, so the context window
+    is sized to the frame count automatically -- Ollama's 4096-token default
+    fits only one or two frames and *fails* anything larger. Pass an explicit
+    ``num_ctx`` in ``options`` to override that sizing.
     """
 
     def __init__(

--- a/src/videopython/ai/understanding/objects.py
+++ b/src/videopython/ai/understanding/objects.py
@@ -10,14 +10,21 @@ two stay one mental model. Consumed by
 per-frame object analysis.
 
 D-FINE (Apache-2.0) replaced the AGPL-licensed Ultralytics YOLO weights. Its COCO
-labels use VOC-style spellings (``motorbike``, ``aeroplane``, ``sofa``, ``pottedplant``,
-``diningtable``, ``tvmonitor``) -- ``class_filter`` must use the model's exact names.
+labels use VOC-style spellings for six classes (``motorbike``, ``aeroplane``,
+``sofa``, ``pottedplant``, ``diningtable``, ``tvmonitor``) where the standard COCO
+names are ``motorcycle``, ``airplane``, ``couch``, ``potted plant``,
+``dining table`` and ``tv``. ``class_filter`` accepts either spelling: names are
+normalized through :data:`CLASS_ALIASES` before matching, and any name the model
+does not emit is logged once the class list is known.
 """
 
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 from videopython.ai._revisions import pinned
 from videopython.ai.understanding._detector import Backend, DetectorBase
@@ -28,7 +35,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ObjectDetector", "MODEL_SIZES"]
+__all__ = ["ObjectDetector", "MODEL_SIZES", "CLASS_ALIASES", "normalize_class_names"]
+
+# D-FINE emits VOC-style spellings for six COCO classes. Callers -- and LLMs asked
+# to name a class -- reach for the standard COCO spelling, which would match
+# nothing and draw nothing, with no error to explain the silence. Accept both.
+CLASS_ALIASES: dict[str, str] = {
+    "motorcycle": "motorbike",
+    "airplane": "aeroplane",
+    "couch": "sofa",
+    "potted plant": "pottedplant",
+    "dining table": "diningtable",
+    "tv": "tvmonitor",
+}
+
+
+def normalize_class_names(names: "Iterable[str]") -> tuple[str, ...]:
+    """Map COCO-standard class names onto the VOC-style spellings D-FINE emits.
+
+    Case and surrounding whitespace are normalized first, so ``"Potted Plant"``
+    and ``"potted  plant"`` both reach ``pottedplant``. A name with no alias is
+    passed through unchanged (lowercased) -- this translates spellings, it does
+    not validate them; see :meth:`ObjectDetector.unknown_filter_classes`.
+    """
+    return tuple(CLASS_ALIASES.get(key, key) for key in (" ".join(n.lower().split()) for n in names))
+
 
 # D-FINE COCO checkpoints (Apache-2.0), in ascending size/quality. ``model_size``
 # on ``ObjectDetectionOverlay`` maps onto these; pinned in ``_revisions.py``.
@@ -46,7 +77,9 @@ class ObjectDetector(DetectorBase[DetectedObject]):
     The D-FINE weights (default ``ustc-community/dfine-nano-coco``) download from
     HuggingFace on first real use; class names come from the model config.
     Detection is gated by ``confidence_threshold`` and optionally restricted to
-    ``class_filter`` (COCO class names; YOLO-style spellings are normalized).
+    ``class_filter``, which accepts either D-FINE's VOC-style spellings or the
+    standard COCO ones (``motorcycle``, ``airplane``, ``couch``, ``potted plant``,
+    ``dining table``, ``tv``) -- see :func:`normalize_class_names`.
     """
 
     DEFAULT_CONFIDENCE_THRESHOLD = 0.5
@@ -68,14 +101,18 @@ class ObjectDetector(DetectorBase[DetectedObject]):
                 ``ustc-community/dfine-nano-coco``, ``...-small-coco``,
                 ``...-medium-coco``, ``...-large-coco``). Downloaded on first use.
             confidence_threshold: Minimum detection confidence in ``[0, 1]``.
-            class_filter: If non-empty, only these COCO class names are kept
-                (D-FINE's VOC-style spelling, e.g. ``motorbike``/``tvmonitor``).
+            class_filter: If non-empty, only these COCO class names are kept.
+                Either spelling works -- ``motorcycle`` and ``motorbike`` both
+                match -- and names are normalized via
+                :func:`normalize_class_names`. A name the model never emits is
+                logged as a warning once the model loads, since it would
+                otherwise just silently match nothing.
             backend: Detection device - ``"cpu"``, ``"gpu"``, or ``"auto"``.
         """
         super().__init__(backend=backend)
         self.model_name = model_name
         self.confidence_threshold = confidence_threshold
-        self.class_filter = tuple(class_filter)
+        self.class_filter = normalize_class_names(class_filter)
         self._model: Any = None
         self._processor: Any = None
         self._class_names: dict[int, str] = {}
@@ -93,6 +130,26 @@ class ObjectDetector(DetectorBase[DetectedObject]):
             model = model.to("cuda")
         self._model = model
         self._class_names = {int(k): v for k, v in model.config.id2label.items()}
+        self._warn_unknown_filter_classes()
+
+    def unknown_filter_classes(self) -> tuple[str, ...]:
+        """``class_filter`` names this model never emits (empty until it loads)."""
+        if not self._class_names:
+            return ()
+        known = set(self._class_names.values())
+        return tuple(name for name in self.class_filter if name not in known)
+
+    def _warn_unknown_filter_classes(self) -> None:
+        """Log filter names that cannot match, which would otherwise draw nothing."""
+        unknown = self.unknown_filter_classes()
+        if unknown:
+            logger.warning(
+                "class_filter names not emitted by %s: %s. Nothing will be detected for them; "
+                "the model's classes are %s.",
+                self.model_name,
+                ", ".join(unknown),
+                ", ".join(sorted(set(self._class_names.values()))),
+            )
 
     def _infer(self, images: list[np.ndarray]) -> list[list[DetectedObject]]:
         import torch

--- a/uv.lock
+++ b/uv.lock
@@ -4509,7 +4509,7 @@ wheels = [
 
 [[package]]
 name = "videopython"
-version = "0.55.2"
+version = "0.55.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Size the Ollama context window for image calls, normalize standard COCO class names, and preserve per-segment confidence after separate diarization.